### PR TITLE
Catch and retry wait_for_task() methods on ProtocolError exceptions.

### DIFF
--- a/kingpin/actors/rightscale/api.py
+++ b/kingpin/actors/rightscale/api.py
@@ -349,7 +349,8 @@ class RightScale(object):
         raise gen.Return()
 
     @gen.coroutine
-    @utils.retry(excs=requests.packages.urllib3.exceptions.HTTPError, retries=3)
+    @utils.retry(excs=requests.packages.urllib3.exceptions.HTTPError,
+                 retries=3)
     def wait_for_task(self, task, sleep=5):
         """Monitors a RightScale task for completion.
 


### PR DESCRIPTION
Fix for issue #28 
