### PR TITLE
Fix threadpool testing errors

### DIFF
--- a/kingpin/actors/aws/test/test_elb.py
+++ b/kingpin/actors/aws/test/test_elb.py
@@ -147,7 +147,7 @@ class TestELBActor(testing.AsyncTestCase):
             mock.Mock(state='InService'),
             mock.Mock(state='OutOfService'),
             mock.Mock(state='OutOfService'),
-            ]
+        ]
         val = yield actor._is_healthy(elb, 3)
 
         self.assertTrue(val)

--- a/kingpin/utils.py
+++ b/kingpin/utils.py
@@ -157,8 +157,8 @@ def thread_coroutine(func, *args, **kwargs):
             # second time, we allow it to be raised.
             #
             # This should be patched in the python-rightscale library so it
-            # auto-retries, but until then we have a patch here to at least allow
-            # one automatic retry.
+            # auto-retries, but until then we have a patch here to at least
+            # allow one automatic retry.
             log.debug('Fetch failed. Will retry one time: %s' % e)
             ret = yield tp.submit(func, *args, **kwargs)
 


### PR DESCRIPTION
Potential fix for #11 

https://docs.python.org/3.2/library/concurrent.futures.html#concurrent.futures.Executor.shutdown
