### PR TITLE
Add 'ignore_failure' option to the rightscale.server_array.Execute actor (issue #81)

### DIFF
--- a/docs/actors/rightscale.server_array.Execute.md
+++ b/docs/actors/rightscale.server_array.Execute.md
@@ -18,6 +18,8 @@ execution of those tasks from start to finish and returns the results.
   * `array`    - The name of the ServerArray to operate on
   * `script`   - The name of the RightScript or Recipe to execute
   * `inputs`   - Dictionary of Key/Value pairs to use as inputs for the script
+  * `ignore_failure` - True/False, whether or not to ignore the script
+                       execution result.
 
 Examples
 
@@ -25,6 +27,7 @@ Examples
     # input named ELB_NAME.
     { 'array': 'my-array',
       'script': 'connect to elb',
+      'ignore_failure': True,
       'inputs': { 'ELB_NAME': 'text:my-elb' } }
 
 **Dry Mode**

--- a/kingpin/actors/rightscale/test/integration_server_array.py
+++ b/kingpin/actors/rightscale/test/integration_server_array.py
@@ -200,6 +200,7 @@ class IntegrationServerArray(testing.AsyncTestCase):
             'Execute %s' % self.clone_name,
             {'array': self.clone_name,
              'script': self.template_script,
+             'ignore_failure': False,
              'inputs': {'SLEEP': 'text:15'}},
             dry=True)
         ret = yield actor.execute()
@@ -212,6 +213,7 @@ class IntegrationServerArray(testing.AsyncTestCase):
             'Execute %s' % self.clone_name,
             {'array': self.clone_name,
              'script': self.template_script,
+             'ignore_failure': False,
              'inputs': {'SLEEP': 'text:15'}})
         ret = yield actor.execute()
         self.assertEquals(True, ret)
@@ -223,6 +225,7 @@ class IntegrationServerArray(testing.AsyncTestCase):
             'Execute %s' % self.clone_name,
             {'array': self.clone_name,
              'script': 'bogus script',
+             'ignore_failure': False,
              'inputs': {'SLEEP': 'text:15'}})
         res = yield actor.execute()
         self.assertEquals(res, False)
@@ -234,6 +237,7 @@ class IntegrationServerArray(testing.AsyncTestCase):
             'Execute %s' % self.clone_name,
             {'array': self.clone_name,
              'script': self.template_script,
+             'ignore_failure': False,
              'inputs': {'SLEEP': 'bogus field'}})
         res = yield actor.execute()
         self.assertEquals(res, False)
@@ -245,6 +249,7 @@ class IntegrationServerArray(testing.AsyncTestCase):
             'Execute missing::recipe',
             {'array': self.clone_name,
              'script': 'missing::recipe',
+             'ignore_failure': False,
              'inputs': {}},
             dry=True)
         res = yield actor.execute()
@@ -257,9 +262,34 @@ class IntegrationServerArray(testing.AsyncTestCase):
             'Execute missing::recipe',
             {'array': self.clone_name,
              'script': 'missing::recipe',
+             'ignore_failure': False,
              'inputs': {}})
         res = yield actor.execute()
         self.assertEquals(res, False)
+
+    @attr('integration')
+    @testing.gen_test(timeout=120)
+    def integration_06e_execute_script_fails_to_run(self):
+        actor = server_array.Execute(
+            'Execute %s' % self.clone_name,
+            {'array': self.clone_name,
+             'script': self.template_script,
+             'ignore_failure': False,
+             'inputs': {'SLEEP': 'text:invalid_input'}})
+        res = yield actor.execute()
+        self.assertEquals(res, False)
+
+    @attr('integration')
+    @testing.gen_test(timeout=120)
+    def integration_06e_execute_script_fails_to_run_but_ignored(self):
+        actor = server_array.Execute(
+            'Execute %s' % self.clone_name,
+            {'array': self.clone_name,
+             'script': self.template_script,
+             'ignore_failure': True,
+             'inputs': {'SLEEP': 'text:invalid_input'}})
+        res = yield actor.execute()
+        self.assertEquals(res, True)
 
     @attr('integration', 'dry')
     @testing.gen_test(timeout=120)


### PR DESCRIPTION
This patch adds a required parameter 'ignore_failure' to the Execute script actor. Setting it to False ensures the current behavior, where the result of the script (success/failure) matter. Setting it to True means that the actor will return True regardless of the script execution result.

Note: I think we should hold off on merging this until we handle issue #60. If we merge this now, it will break existing scripts for people because they will have to add this option to the JSON. If #60 is not addressed in v0.1.1, then this should be held until v0.2.0.
