### PR TITLE
Add 'warn_on_failure' option to BaseActor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,14 +109,16 @@ execute them in a predictable order.
 
 ##### Schema Description
 
-The JSON schema is simple. We take a single JSON object that has 3 fields:
-`actor`, `desc` and `options`.
+The JSON schema is simple. We take a single JSON object that has a few fields:
 
   * `actor` - A text-string describing the name of the Actor package and class.
     For example, `kingpin.actors.rightscale.server_array.Clone`, or
     `misc.Sleep`.
   * `desc` - A text-string describing the name of the stage or action. Meant to
     ensure that the logs are very human readable.
+  * `warn_on_fail` - True/False whether or not to ignore an Actors failure and
+    return True anyways. Defaults to `False`, but if `True` a `warning` message
+    is logged.
   * `options` - A dictionary of key/value pairs that are required for the
     specific `actor` that you're instantiating. See individual Actor
     documentation below for these options.
@@ -125,6 +127,7 @@ The simples JSON file could look like this:
 
     { "desc": "Hipchat: Notify Oncall Room",
       "actor": "hipchat.Message",
+      "warn_on_failure": true,
       "options": {
         "message": "Beginning release %RELEASE%", "room": "Oncall"
       }

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -122,6 +122,14 @@ RightScale ServerTemplate.
         |
         +-- actors.aws
         |   | Amazon Web Services Actor
+        |   |
+        |   +-- elb
+        |   |   +-- WaitUntilHealthy
+        |   |
+        |   +-- sqs
+        |       +-- Create
+        |       +-- Delete
+        |       +-- WaitUntilEmpty
         |
         +-- actors.email
         |   | Email Actor
@@ -133,6 +141,8 @@ RightScale ServerTemplate.
         |
         +-- actors.librato
             | Librato Metric Actor
+            |
+            +-- Annotation
 
 ### Setup
 

--- a/kingpin/actors/base.py
+++ b/kingpin/actors/base.py
@@ -76,7 +76,7 @@ class BaseActor(object):
     # }
     all_options = {}
 
-    def __init__(self, desc, options, dry=False):
+    def __init__(self, desc, options, dry=False, warn_on_failure=False):
         """Initializes the Actor.
 
         Args:
@@ -84,11 +84,14 @@ class BaseActor(object):
             options: (Dict) Key/Value pairs that have the options
                      for this action. Values should be primitives.
             dry: (Bool) or not this Actor will actually make changes.
+            warn_on_failure: (Bool) Whether this actor ignores its return
+                             value and always returns True (but warns).
         """
         self._type = '%s.%s' % (self.__module__, self.__class__.__name__)
         self._desc = desc
         self._options = options
         self._dry = dry
+        self._warn_on_failure = warn_on_failure
 
         self._setup_log()
         self._setup_defaults()
@@ -195,10 +198,21 @@ class BaseActor(object):
             self.log.exception(e)
             raise gen.Return(False)
 
+        # Log the result. If theres a failure, throw up a warning. Depending on
+        # how _warn_on_failure is set, we may actually return this failed
+        # result ... or we may swallow it up and return True anyways.
         if result:
             self.log.debug('Finished successfully.')
         else:
             self.log.warning('Finished with errors.')
+
+        # If we are ignoring the result of the actor, then we return True no
+        # matter what.
+        if self._warn_on_failure:
+            self.log.warning(
+                'Returning True even though a failure was '
+                'detected (warn_on_failure=%s)' % self._warn_on_failure)
+            result = True
 
         raise gen.Return(result)
 

--- a/kingpin/actors/test/test_base.py
+++ b/kingpin/actors/test/test_base.py
@@ -33,11 +33,14 @@ class FakeHTTPClientClass(object):
 class TestBaseActor(testing.AsyncTestCase):
 
     @gen.coroutine
-    def sleep(self):
-        # Basically a fake action that should take a few seconds to run for the
-        # sake of the unit tests.
-        yield utils.tornado_sleep(0.1)
+    def true(self):
+        yield utils.tornado_sleep(0.01)
         raise gen.Return(True)
+
+    @gen.coroutine
+    def false(self):
+        yield utils.tornado_sleep(0.01)
+        raise gen.Return(False)
 
     def setUp(self):
         super(TestBaseActor, self).setUp()
@@ -47,7 +50,7 @@ class TestBaseActor(testing.AsyncTestCase):
 
         # Mock out the actors ._execute() method so that we have something to
         # test
-        self.actor._execute = self.sleep
+        self.actor._execute = self.true
 
     @testing.gen_test
     def test_httplib_debugging(self):
@@ -109,10 +112,20 @@ class TestBaseActor(testing.AsyncTestCase):
 
     @testing.gen_test
     def test_execute(self):
-        # Call the executor and test it out
         res = yield self.actor.execute()
+        self.assertEquals(res, True)
 
-        # Make sure we fired off an alert.
+    @testing.gen_test
+    def test_execute_fail(self):
+        self.actor._execute = self.false
+        res = yield self.actor.execute()
+        self.assertEquals(res, False)
+
+    @testing.gen_test
+    def test_execute_fail_with_warn_on_failure(self):
+        self.actor._execute = self.false
+        self.actor._warn_on_failure = True
+        res = yield self.actor.execute()
         self.assertEquals(res, True)
 
     @testing.gen_test

--- a/kingpin/actors/utils.py
+++ b/kingpin/actors/utils.py
@@ -34,8 +34,11 @@ def get_actor(config, dry):
 
                 {'actor': <string name of actor>
                  'options': <dict of options to pass to actor>
-                 'desc': <string description of actor>}
+                 'desc': <string description of actor>,
+                 'warn_on_failure': <bool>}
+
         dry: Boolean whether or not in Dry mode
+        warn_on_failure: Boolean
 
     Returns:
         <actor object>

--- a/kingpin/schema.py
+++ b/kingpin/schema.py
@@ -49,6 +49,9 @@ SCHEMA_1_0 = {
                 },
             },
         },
+
+        # Not required. In code, will default to False.
+        'warn_on_failure': {'type': 'boolean'},
     }
 }
 


### PR DESCRIPTION
This new 'warn_on_fail' option changes the behavior of the BaseActor and
allow for actors to fail, but Kingpin scripts to continue to operate. It
works by returning True regardless of the execution status of the Actors
`_execute()` method.

The option defaults to False (same as previous behavior), and is sanity
checked by the JSON schema file.
