### PR TITLE
Bugfix: Destroying a non existent server array should return False.

### DIFF
--- a/kingpin/actors/rightscale/test/integration_server_array.py
+++ b/kingpin/actors/rightscale/test/integration_server_array.py
@@ -279,3 +279,13 @@ class IntegrationServerArray(testing.AsyncTestCase):
             {'array': self.clone_name})
         ret = yield actor.execute()
         self.assertEquals(True, ret)
+
+    @attr('integration')
+    @testing.gen_test(timeout=600)
+    def integration_07b_destroy_missing_array(self):
+        # Re-run the same destroy.. this time it should fail
+        actor = server_array.Destroy(
+            'Destroy %s (should fail)' % self.template_array,
+            {'array': self.clone_name})
+        ret = yield actor.execute()
+        self.assertEquals(ret, False)

--- a/kingpin/actors/rightscale/test/test_server_array.py
+++ b/kingpin/actors/rightscale/test/test_server_array.py
@@ -401,14 +401,23 @@ class TestDestroyActor(TestServerArrayBaseActor):
             'Destroy',
             {'array': 'unittestarray'})
         with mock.patch.object(server_array, 'Terminate') as t:
-            t()._execute = mock_tornado()
+            t()._execute = mock_tornado(mock.MagicMock())
             obj = yield actor._terminate()
             self.assertEquals(t()._execute._call_count, 1)
             self.assertEquals(obj, t())
 
     @testing.gen_test
-    def test_execute(self):
+    def test_terminate_missing_array(self):
+        actor = server_array.Destroy(
+            'Destroy',
+            {'array': 'unittestarray'})
+        with mock.patch.object(server_array, 'Terminate') as t:
+            t()._execute = mock_tornado(False)
+            ret = yield actor._terminate()
+            self.assertEquals(ret, False)
 
+    @testing.gen_test
+    def test_execute(self):
         actor = server_array.Destroy(
             'Destroy',
             {'array': 'unittestarray'})
@@ -423,6 +432,15 @@ class TestDestroyActor(TestServerArrayBaseActor):
         self.assertEquals(actor._terminate._call_count, 1)
         self.assertEquals(actor._destroy_array._call_count, 1)
         self.assertTrue(ret)
+
+    @testing.gen_test
+    def test_execute_terminate_fails(self):
+        actor = server_array.Destroy(
+            'Destroy',
+            {'array': 'unittestarray'})
+        actor._terminate = mock_tornado(False)
+        ret = yield actor._execute()
+        self.assertEquals(ret, False)
 
     @testing.gen_test
     def test_destroy_array(self):


### PR DESCRIPTION
There were two bugs here...
1. Logging string problem (unmatched %s).
2. The Destroy actor needs to pay attention to whether the Terminate
   actor succeeded. If it does not, it should raise an exception and get
   out of there.
