### PR TITLE
Only raise exceptions during total failure

### DIFF
--- a/kingpin/actors/aws/sqs.py
+++ b/kingpin/actors/aws/sqs.py
@@ -203,7 +203,7 @@ class Delete(SQSBaseActor):
         return ok
 
     @gen.coroutine
-    @utils.retry(SQSQueueNotFoundException, delay=aws_settings.SQS_RETRY_DELAY)
+    @utils.retry(delay=aws_settings.SQS_RETRY_DELAY)
     def _execute(self):
         """Executes an actor and yields the results when its finished.
 
@@ -217,8 +217,8 @@ class Delete(SQSBaseActor):
                                not self.option('idempotent'))
 
         if not_found_condition:
-            raise SQSQueueNotFoundException(
-                'No queues with pattern "%s" found.' % pattern)
+            self.log.critical('No queues with pattern "%s" found.' % pattern)
+            raise gen.Return(False)
 
         self.log.info('Deleting SQS Queues: %s' % matched_queues)
 

--- a/kingpin/actors/aws/test/test_sqs.py
+++ b/kingpin/actors/aws/test/test_sqs.py
@@ -153,6 +153,13 @@ class TestDeleteSQSQueueActor(SQSTestCase):
         self.assertTrue(self.conn().get_all_queues.called)
         self.assertFalse(self.conn().delete_queue.called)
 
+    @testing.gen_test
+    def test_execute_not_found_dry(self):
+        actor = sqs.Delete('Unit Test Action',
+                           {'name': 'unit-test-queue',
+                            'region': 'us-west-2'},
+                           dry=True)
+
         self.conn().get_all_queues = mock.Mock(return_value=[])
         # Should fail even in dry run, if idempotent flag is not there.
         settings.SQS_RETRY_DELAY = 0

--- a/kingpin/actors/rightscale/api.py
+++ b/kingpin/actors/rightscale/api.py
@@ -514,7 +514,8 @@ class RightScale(object):
         try:
             ret = yield tasks
         except requests.exceptions.HTTPError as e:
-            raise ServerArrayException('Script Execution Error: %s' % e)
+            log.critical('Script Execution Error: %s' % e)
+            raise gen.Return(False)
 
         raise gen.Return(ret)
 

--- a/kingpin/actors/rightscale/test/test_api.py
+++ b/kingpin/actors/rightscale/test/test_api.py
@@ -364,9 +364,9 @@ class TestRightScale(testing.AsyncTestCase):
 
         # Test with invalid inputs raising a 422 error
         self.client.make_generic_request = fake_web_request
-        with self.assertRaises(api.ServerArrayException):
-            yield self.client.run_executable_on_instances(
-                'my::recipe', {}, [mock_instance])
+        res = yield self.client.run_executable_on_instances(
+            'my::recipe', {}, [mock_instance])
+        self.assertFalse(res)
 
     @testing.gen_test
     def test_make_generic_request(self):

--- a/kingpin/actors/rightscale/test/test_server_array.py
+++ b/kingpin/actors/rightscale/test/test_server_array.py
@@ -131,7 +131,14 @@ class TestCloneActor(testing.AsyncTestCase):
 
         source_array = mock.MagicMock(name='unittestarray')
         source_array.self.path = '/fo/bar/123'
-        self.actor._find_server_arrays = mock_tornado(source_array)
+
+        return_values = [[], source_array]
+
+        @gen.coroutine
+        def fsa(*args, **kwargs):
+            raise gen.Return(return_values.pop())
+
+        self.actor._find_server_arrays = fsa
 
         new_array = mock.MagicMock(name='unittestarray v1')
         new_array.self.path = '/foo/bar/124'
@@ -148,7 +155,14 @@ class TestCloneActor(testing.AsyncTestCase):
 
         source_array = mock.MagicMock(name='unittestarray')
         source_array.self.path = '/fo/bar/123'
-        self.actor._find_server_arrays = mock_tornado(source_array)
+
+        return_values = [[], source_array]
+
+        @gen.coroutine
+        def fsa(*args, **kwargs):
+            raise gen.Return(return_values.pop())
+
+        self.actor._find_server_arrays = fsa
 
         self.client_mock.update_server_array = mock_tornado()
 

--- a/kingpin/actors/test/test_hipchat.py
+++ b/kingpin/actors/test/test_hipchat.py
@@ -175,8 +175,8 @@ class TestHipchatMessage(testing.AsyncTestCase):
             m.return_value = FakeExceptionRaisingHTTPClientClass()
             m.return_value.response_value = http_response
 
-            with self.assertRaises(httpclient.HTTPError):
-                yield actor._execute()
+            res = yield actor._execute()
+            self.assertFalse(res)
 
     @testing.gen_test
     def test_execute_with_unknown_exception(self):


### PR DESCRIPTION
- This reworks every Actor to return False on during normal failures
  -- This means the actor tries its job and fails.
- Exceptions are raised only for unmanageble conditions (when the actor
  can't attempt its job, or does not understand what you want from it).
