### PR TITLE
Issue #88: Rollbar Deployment Actor

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,20 @@ cause/effect analysis.
 
   * [librato.Annotation](docs/actors/librato.Annotation.md)
 
+#### Rollbar
+
+The Rollbar Actor allows you to post Deploy messages to Rollbar when you
+execute a code deployment.
+
+**Required Environment Variables**
+
+  * `ROLLBAR_TOKEN` - Rollbar API Token
+
+**Actor-specific Documentation**
+
+  * [rollbar.Deploy](docs/actors/rollbar.Deploy.md)
+
+
 #### RightScale
 
 The RightScale Actors allow you to interact with resources inside your

--- a/docs/actors/rollbar.Deploy.md
+++ b/docs/actors/rollbar.Deploy.md
@@ -1,0 +1,36 @@
+##### rollbar.Deploy
+
+Posts a Deploy message to Rollbar.
+
+[Rollbar Deploy Integration](https://rollbar.com/docs/deploys_other/)
+
+**API Token**
+
+You must use an API token created in your *Project Access Tokens* account
+settings section. This token should have *post_server_item* permissions for the
+actual deploy, and *read* permissions for the Dry run.
+
+**Options**
+
+  * `environment` - The environment to deploy to
+  * `revision` - The deployment revision
+  * `local_username` - The user who initiated the deploy
+  * `rollbar_username` - *(Optional)* The Rollbar Username to assign the deploy to
+  * `comment` - *(Optional)* Comment describing the deploy
+
+Examples
+
+    { "actor": "rollbar.Deploy",
+      "desc": "update rollbar deploy",
+      "options": {
+        "environment": "Prod",
+        "revision": "%DEPLOY%",
+        "local_username": "Kingpin",
+        "rollbar_username": "Kingpin",
+        "comment": "some comment %DEPLOY%"
+      }
+    }
+
+**Dry Mode**
+
+Accesses the Rollbar API and validates that the token can access your project.

--- a/kingpin/actors/rollbar.py
+++ b/kingpin/actors/rollbar.py
@@ -1,0 +1,185 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2014 Nextdoor.com, Inc
+
+"""Rollbar Actor objects"""
+
+import logging
+import os
+import urllib
+
+from tornado import gen
+from tornado import httpclient
+
+from kingpin import utils
+from kingpin.actors import base
+from kingpin.actors import exceptions
+
+log = logging.getLogger(__name__)
+
+__author__ = 'Matt Wise <matt@nextdoor.com>'
+
+
+API_CONTENT_TYPE = 'application/json'
+API_URL = 'https://api.rollbar.com/api/1'
+API_DEPLOY_PATH = '%s/deploy/' % API_URL
+API_PROJECT_PATH = '%s/project/' % API_URL
+
+TOKEN = os.getenv('ROLLBAR_TOKEN', None)
+
+
+class RollbarBase(base.HTTPBaseActor):
+
+    """Simple Rollbar Base Abstract Actor"""
+
+    def __init__(self, *args, **kwargs):
+        """Check required environment variables."""
+        super(RollbarBase, self).__init__(*args, **kwargs)
+
+        if not TOKEN:
+            raise exceptions.InvalidCredentials(
+                'Missing the "ROLLBAR_TOKEN" environment variable.')
+
+        self._token = TOKEN
+
+    def _build_potential_args(self, potential_args):
+        """Builds a full set of arguments to pass to Rollbar.
+
+        Appends the authentication token and a few other bits to the
+        arguments supplied.
+
+        Args:
+            potential_Args: A hash of potential arguments.
+
+        Returns:
+            A larger hash of arguments.
+        """
+        potential_args['access_token'] = self._token
+        return potential_args
+
+    @gen.coroutine
+    @utils.retry(excs=(httpclient.HTTPError), retries=3)
+    def _fetch_wrapper(self, *args, **kwargs):
+        """Wrap the superclass _fetch method to catch known Rollbar errors.
+
+        https://rollbar.com/docs/api_overview/
+        """
+        try:
+            res = yield self._fetch(*args, **kwargs)
+        except httpclient.HTTPError as e:
+            # These are HTTPErrors that we know about, and can log specific
+            # error messages for.
+
+            if e.code == 403:
+                raise exceptions.InvalidCredentials(
+                    'The "ROLLBAR_TOKEN" is invalid')
+            elif e.code == 422:
+                raise exceptions.RecoverableActorFailure(
+                    'Unprocessable Entity - the request was parseable (i.e. '
+                    'valid JSON), but some parameters were missing or '
+                    'otherwise invalid.')
+            elif e.code == 429:
+                raise exceptions.RecoverableActorFailure(
+                    'Too Many Requests - If rate limiting is enabled for '
+                    'your access token, this return code signifies that the '
+                    'rate limit has been reached and the item was not '
+                    'processed.')
+            else:
+                # We ran into a problem we can't handle. Also, keep in mind
+                # that @utils.retry() was used, so this error happened several
+                # times before getting here. Raise it.
+                raise exceptions.RecoverableActorFailure(
+                    'Unexpected error from Rollbar API: %s' % e)
+
+        raise gen.Return(res)
+
+    @gen.coroutine
+    def _project(self):
+        """Get a project description back from Rollbar.
+
+        This method is used as a simple test that the API keys work. It access
+        the list of projects from Rollbar and raises the appropriate exceptions
+        if it cannot.
+
+        https://rollbar.com/docs/api/projects/#list-your-projects
+
+        Raises:
+            gen.Return(<Dictionary of the response from Rollbar>)
+        """
+
+        args = self._build_potential_args({})
+        url = self._generate_escaped_url(API_PROJECT_PATH, args)
+        res = yield self._fetch_wrapper(url)
+        raise gen.Return(res)
+
+
+class Deploy(RollbarBase):
+
+    """Simple Rollbar Deploy Actor."
+
+    https://rollbar.com/docs/deploys_other/
+
+    """
+    all_options = {
+        'environment': (str, None, 'Name of the environment being deployed'),
+        'revision': (str, None, 'Revision number/sha being deployed'),
+        'local_username': (str, 'Kingpin', 'User who deployed'),
+        'rollbar_username': (str, '', 'Rollbar username'),
+        'comment': (str, '', 'Deploy comment')
+    }
+
+    @gen.coroutine
+    def _deploy(self):
+        """Posts a Deploy to rollbar.
+
+        https://rollbar.com/docs/deploys_other/
+
+        Raises:
+            gen.Return(<Dictionary of the response from Rollbar>)
+        """
+
+        rollbar_username = self.option('rollbar_username')
+        if rollbar_username == '':
+            rollbar_username = None
+
+        args = self._build_potential_args({
+            'environment': self.option('environment'),
+            'revision': self.option('revision'),
+            'local_username': self.option('local_username'),
+            'rollbar_username': rollbar_username,
+            'comment': self.option('comment')
+        })
+
+        escaped_post = urllib.urlencode(args)
+        res = yield self._fetch_wrapper(API_DEPLOY_PATH, post=escaped_post)
+        raise gen.Return(res)
+
+    @gen.coroutine
+    def _execute(self):
+        """Executes an actor and yields the results when its finished.
+
+        raises: gen.Return()
+        """
+        rollbar_string = (
+            'Rollbar Deploy Notification %s/%s' %
+            (self.option('environment'), self.option('revision')))
+
+        if self._dry:
+            self.log.info('Would have sent %s, but instead just validating '
+                          'API key.' % rollbar_string)
+            yield self._project()
+            raise gen.Return()
+
+        self.log.info('Sending %s' % rollbar_string)
+        yield self._deploy()
+        raise gen.Return()

--- a/kingpin/actors/test/integration_rollbar.py
+++ b/kingpin/actors/test/integration_rollbar.py
@@ -1,0 +1,88 @@
+"""Tests for the actors.rollbar package"""
+
+from tornado import testing
+
+from kingpin import version
+from kingpin.actors import rollbar
+from kingpin.actors import exceptions
+
+
+__author__ = 'Matt Wise <matt@nextdoor.com>'
+
+
+class IntegrationRollbarDeploy(testing.AsyncTestCase):
+
+    """Simple high level integration tests agains the Rollbar API.
+
+    These tests actually hit the Rollbar API and test that the code
+    works, as well as validate that the API token is working properly.
+
+    Require ROLLBAR_TOKEN environment variable to be set.
+    """
+
+    integration = True
+
+    @testing.gen_test
+    def integration_test_1a_init_without_environment_creds(self):
+        # Un-set the token now and make sure the init fails
+        rollbar.TOKEN = None
+        with self.assertRaises(exceptions.InvalidCredentials):
+            rollbar.Deploy(
+                'Unit Test Action',
+                {'environment': 'kingpin-integration-testing',
+                 'revision': version.__version__,
+                 'local_username': 'Kingpin Integration Testing',
+                 'comment': 'Integration Tests Are Good, MmmKay'})
+
+        # Reload the rollbar package so it gets our environment variable back.
+        reload(rollbar)
+
+    @testing.gen_test
+    def integration_test_2a_execute_with_invalid_creds(self):
+        actor = rollbar.Deploy(
+            'Unit Test Action',
+            {'environment': 'kingpin-integration-testing',
+             'revision': version.__version__,
+             'local_username': 'Kingpin Integration Testing',
+             'comment': 'Integration Tests Are Good, MmmKay'}, dry=True)
+
+        # Valid response test
+        actor._token = 'Invalid'
+        with self.assertRaises(exceptions.InvalidCredentials):
+            yield actor.execute()
+
+    @testing.gen_test
+    def integration_test_2b_execute_dry(self):
+        actor = rollbar.Deploy(
+            'Unit Test Action',
+            {'environment': 'kingpin-integration-testing',
+             'revision': version.__version__,
+             'local_username': 'Kingpin Integration Testing',
+             'comment': 'This should never appear in Rollbar'}, dry=True)
+        res = yield actor.execute()
+        self.assertEquals(res, None)
+
+    @testing.gen_test
+    def integration_test_2c_execute_real(self):
+        actor = rollbar.Deploy(
+            'Unit Test Action',
+            {'environment': 'kingpin-integration-testing',
+             'revision': version.__version__,
+             'local_username': 'Kingpin Integration Testing',
+             'comment': 'Integration Tests Are Good, MmmKay'})
+
+        res = yield actor.execute()
+        self.assertEquals(res, None)
+
+    @testing.gen_test
+    def integration_test_2d_execute_real_with_rollbar_username(self):
+        actor = rollbar.Deploy(
+            'Unit Test Action',
+            {'environment': 'kingpin-integration-testing',
+             'revision': version.__version__,
+             'local_username': 'Kingpin Integration Testing',
+             'rollbar_username': 'Kingpin Integration Username',
+             'comment': 'Now, with a rollbar_username too!'})
+
+        res = yield actor.execute()
+        self.assertEquals(res, None)

--- a/kingpin/actors/test/test_rollbar.py
+++ b/kingpin/actors/test/test_rollbar.py
@@ -1,0 +1,236 @@
+"""Tests for the actors.rollbar package"""
+
+import json
+import mock
+import StringIO
+
+from tornado import gen
+from tornado import httpclient
+from tornado import testing
+
+from kingpin.actors import rollbar
+from kingpin.actors import exceptions
+
+
+__author__ = 'Matt Wise <matt@nextdoor.com>'
+
+
+class FakeHTTPClientClass(object):
+
+    '''Fake HTTPClient object for testing'''
+
+    response_value = None
+
+    @gen.coroutine
+    def fetch(self, *args, **kwargs):
+        raise gen.Return(self.response_value)
+
+
+class FakeExceptionRaisingHTTPClientClass(object):
+
+    '''Fake HTTPClient object for testing'''
+
+    response_value = None
+
+    @gen.coroutine
+    def fetch(self, *args, **kwargs):
+        raise self.response_value
+
+
+class TestRollbarBase(testing.AsyncTestCase):
+
+    """Unit tests for the Rollbar base actor."""
+
+    def setUp(self, *args, **kwargs):
+        # For most tests, mock out the TOKEN
+        super(TestRollbarBase, self).setUp()
+        rollbar.TOKEN = 'Unittest'
+
+    def test_build_potential_args(self):
+        potential_args = {
+            'foo': 'bar',
+            'baz': 'bat',
+        }
+        expected_args = dict(potential_args)
+        expected_args['access_token'] = rollbar.TOKEN
+
+        actor = rollbar.RollbarBase('Unittest Deploy', {})
+        args = actor._build_potential_args(potential_args)
+
+        self.assertEquals(args, expected_args)
+
+    @testing.gen_test
+    def test_init_without_environment_creds(self):
+        # Un-set the token now and make sure the init fails
+        rollbar.TOKEN = None
+        with self.assertRaises(exceptions.InvalidCredentials):
+            rollbar.RollbarBase('Unittest Deploy', {})
+
+    @testing.gen_test
+    def test_fetch_wrapper(self):
+        actor = rollbar.RollbarBase('Unit Test Action', {})
+
+        # Valid response test
+        response_dict = {'status': 'sent'}
+        response_body = json.dumps(response_dict)
+        http_response = httpclient.HTTPResponse(
+            httpclient.HTTPRequest('/'), code=200,
+            buffer=StringIO.StringIO(response_body))
+
+        with mock.patch.object(actor, '_get_http_client') as m:
+            m.return_value = FakeHTTPClientClass()
+            m.return_value.response_value = http_response
+            res = yield actor._fetch_wrapper('http://fake.com')
+            self.assertEquals(res, response_dict)
+
+    @testing.gen_test
+    def test_fetch_wrapper_with_403(self):
+        actor = rollbar.RollbarBase('Unit Test Action', {})
+        response_dict = {'err': 1, 'messsage': 'access token not found: xxx'}
+        response_body = json.dumps(response_dict)
+        http_response = httpclient.HTTPError(
+            code=403, response=response_body)
+
+        with mock.patch.object(actor, '_get_http_client') as m:
+            m.return_value = FakeExceptionRaisingHTTPClientClass()
+            m.return_value.response_value = http_response
+
+            with self.assertRaises(exceptions.InvalidCredentials):
+                yield actor._fetch_wrapper('http://fake.com')
+
+    @testing.gen_test
+    def test_fetch_wrapper_with_422(self):
+        actor = rollbar.RollbarBase('Unit Test Action', {})
+        response_dict = {'err': 1, 'messsage': 'Unprocessable Entity'}
+        response_body = json.dumps(response_dict)
+        http_response = httpclient.HTTPError(
+            code=422, response=response_body)
+
+        with mock.patch.object(actor, '_get_http_client') as m:
+            m.return_value = FakeExceptionRaisingHTTPClientClass()
+            m.return_value.response_value = http_response
+
+            with self.assertRaises(exceptions.RecoverableActorFailure):
+                yield actor._fetch_wrapper('http://fake.com')
+
+    @testing.gen_test
+    def test_fetch_wrapper_with_429(self):
+        actor = rollbar.RollbarBase('Unit Test Action', {})
+        response_dict = {'err': 1, 'messsage': 'Too Many Requests'}
+        response_body = json.dumps(response_dict)
+        http_response = httpclient.HTTPError(
+            code=429, response=response_body)
+
+        with mock.patch.object(actor, '_get_http_client') as m:
+            m.return_value = FakeExceptionRaisingHTTPClientClass()
+            m.return_value.response_value = http_response
+
+            with self.assertRaises(exceptions.RecoverableActorFailure):
+                yield actor._fetch_wrapper('http://fake.com')
+
+    @testing.gen_test
+    def test_fetch_wrapper_with_other_failure(self):
+        actor = rollbar.RollbarBase('Unit Test Action', {})
+        response_dict = {'err': 1, 'messsage': 'Something bad happened'}
+        response_body = json.dumps(response_dict)
+        http_response = httpclient.HTTPError(
+            code=123, response=response_body)
+
+        with mock.patch.object(actor, '_get_http_client') as m:
+            m.return_value = FakeExceptionRaisingHTTPClientClass()
+            m.return_value.response_value = http_response
+
+            with self.assertRaises(exceptions.RecoverableActorFailure):
+                yield actor._fetch_wrapper('http://fake.com')
+
+    @testing.gen_test
+    def test_project(self):
+        actor = rollbar.RollbarBase('Unit Test Action', {})
+        response_dict = {'err': 0, 'result': '...'}
+        response_body = json.dumps(response_dict)
+        http_response = httpclient.HTTPResponse(
+            httpclient.HTTPRequest('/'), code=200,
+            buffer=StringIO.StringIO(response_body))
+
+        with mock.patch.object(actor, '_get_http_client') as m:
+            m.return_value = FakeHTTPClientClass()
+            m.return_value.response_value = http_response
+            res = yield actor._project()
+        self.assertEquals(res, response_dict)
+
+
+class TestDeploy(testing.AsyncTestCase):
+
+    """Unit tests for the Rollbar Deploy actor."""
+
+    def setUp(self, *args, **kwargs):
+        # For most tests, mock out the TOKEN
+        super(TestDeploy, self).setUp()
+        rollbar.TOKEN = 'Unittest'
+
+    @testing.gen_test
+    def test_deploy(self):
+        actor = rollbar.Deploy(
+            'Unit Test Action',
+            {'environment': 'unittest',
+             'revision': '0001a',
+             'local_username': 'bob',
+             'comment': 'weeee'})
+
+        @gen.coroutine
+        def fake_fetch_wrapper(*args, **kwargs):
+            raise gen.Return('123')
+        actor._fetch_wrapper = fake_fetch_wrapper
+        res = yield actor._deploy()
+        self.assertEquals(res, '123')
+
+    @testing.gen_test
+    def test_deploy_with_rollbar_username(self):
+        actor = rollbar.Deploy(
+            'Unit Test Action',
+            {'environment': 'unittest',
+             'revision': '0001a',
+             'local_username': 'bob',
+             'rollbar_username': 'bob@rollbar.com',
+             'comment': 'weeee'})
+
+        @gen.coroutine
+        def fake_fetch_wrapper(*args, **kwargs):
+            raise gen.Return('123')
+        actor._fetch_wrapper = fake_fetch_wrapper
+        res = yield actor._deploy()
+        self.assertEquals(res, '123')
+
+    @testing.gen_test
+    def test_execute_dry(self):
+        actor = rollbar.Deploy(
+            'Unit Test Action',
+            {'environment': 'unittest',
+             'revision': '0001a',
+             'local_username': 'bob',
+             'rollbar_username': 'bob@rollbar.com',
+             'comment': 'weeee'}, dry=True)
+
+        @gen.coroutine
+        def fake_project(*args, **kwargs):
+            raise gen.Return('123')
+        actor._project = fake_project
+        res = yield actor._execute()
+        self.assertEquals(res, None)
+
+    @testing.gen_test
+    def test_execute(self):
+        actor = rollbar.Deploy(
+            'Unit Test Action',
+            {'environment': 'unittest',
+             'revision': '0001a',
+             'local_username': 'bob',
+             'rollbar_username': 'bob@rollbar.com',
+             'comment': 'weeee'})
+
+        @gen.coroutine
+        def fake_deploy(*args, **kwargs):
+            raise gen.Return('123')
+        actor._deploy = fake_deploy
+        res = yield actor._execute()
+        self.assertEquals(res, None)


### PR DESCRIPTION
This actor interacts with the Rollbar API to send 'Deploy' messages
during your code deployments. Dry mode validates the API access by
reaching out and getting a list of projects with the API key. Wet
(non-dry) mode actually sends the Deploy API call.

https://rollbar.com/docs/deploys_other/
https://rollbar.com/docs/api/projects/#list-your-projects
