### PR TITLE
Don't want for empty tasks.

### DIFF
--- a/kingpin/actors/rightscale/api.py
+++ b/kingpin/actors/rightscale/api.py
@@ -425,7 +425,7 @@ class RightScale(object):
         failure.
 
         Args:
-            array: ServerArray Resource Object
+            task: RightScale Task resource object
 
         Args:
             sleep: Integer of time to wait between status checks
@@ -433,6 +433,11 @@ class RightScale(object):
         Returns:
             <booelan>
         """
+
+        if not task:
+            # If there is no task to wait on - don't wait!
+            return True
+
         while True:
             # Get the task status
             output = task.self.show()


### PR DESCRIPTION
Close #136 
- Instead of handling this situation uniquely - change the `wait_for_task()` method to check its input
