### PR TITLE
Use REQUIRED constant instead of None for options

### DIFF
--- a/kingpin/actors/aws/elb.py
+++ b/kingpin/actors/aws/elb.py
@@ -28,6 +28,7 @@ from kingpin import utils
 from kingpin.actors import base
 from kingpin.actors import exceptions
 from kingpin.actors.aws import settings as aws_settings
+from kingpin.constants import REQUIRED
 
 log = logging.getLogger(__name__)
 
@@ -60,10 +61,10 @@ class WaitUntilHealthy(base.BaseActor):
     """Waits till a specified number of instances are "InService"."""
 
     all_options = {
-        'name': (str, None, 'Name of the ELB'),
-        'count': ((int, str), None,
+        'name': (str, REQUIRED, 'Name of the ELB'),
+        'count': ((int, str), REQUIRED,
                   'Specific count, or percentage of instances to wait for.'),
-        'region': (str, None, 'AWS region name, like us-west-2')
+        'region': (str, REQUIRED, 'AWS region name, like us-west-2')
     }
 
     # Get references to existing objects that are used by the

--- a/kingpin/actors/aws/sqs.py
+++ b/kingpin/actors/aws/sqs.py
@@ -30,6 +30,7 @@ from kingpin import utils
 from kingpin.actors import base
 from kingpin.actors import exceptions
 from kingpin.actors.aws import settings as aws_settings
+from kingpin.constants import REQUIRED
 
 log = logging.getLogger(__name__)
 
@@ -62,8 +63,8 @@ class SQSBaseActor(base.BaseActor):
     # This actor should not be instantiated, but unit testing requires that
     # it's all options are defined properly here.
     all_options = {
-        'name': (str, None, 'Queue name to do nothing with.'),
-        'region': (str, None, 'AWS region name like us-west-2')
+        'name': (str, REQUIRED, 'Queue name to do nothing with.'),
+        'region': (str, REQUIRED, 'AWS region name like us-west-2')
     }
 
     # Get references to existing objects that are used by the
@@ -130,8 +131,8 @@ class Create(SQSBaseActor):
     """Creates a new SQS Queue."""
 
     all_options = {
-        'name': (str, None, 'Name or pattern for SQS queues.'),
-        'region': (str, None, 'AWS region for SQS, such as us-west-2')
+        'name': (str, REQUIRED, 'Name or pattern for SQS queues.'),
+        'region': (str, REQUIRED, 'AWS region for SQS, such as us-west-2')
     }
 
     @concurrent.run_on_executor
@@ -183,8 +184,8 @@ class Delete(SQSBaseActor):
     """Deletes an existing SQS Queue."""
 
     all_options = {
-        'name': (str, None, 'Name or pattern for SQS queues.'),
-        'region': (str, None, 'AWS region for SQS, such as us-west-2'),
+        'name': (str, REQUIRED, 'Name or pattern for SQS queues.'),
+        'region': (str, REQUIRED, 'AWS region for SQS, such as us-west-2'),
         'idempotent': (bool, False, 'Continue if queues are already deleted.')
     }
 
@@ -248,8 +249,8 @@ class WaitUntilEmpty(SQSBaseActor):
     """Waits for one or more SQS Queues to become empty."""
 
     all_options = {
-        'name': (str, None, 'Name or pattern for SQS queues.'),
-        'region': (str, None, 'AWS region for SQS, such as us-west-2'),
+        'name': (str, REQUIRED, 'Name or pattern for SQS queues.'),
+        'region': (str, REQUIRED, 'AWS region for SQS, such as us-west-2'),
         'required': (bool, False, 'At least 1 queue must be found.')
     }
 

--- a/kingpin/actors/base.py
+++ b/kingpin/actors/base.py
@@ -39,6 +39,7 @@ from tornado import httputil
 
 from kingpin import utils
 from kingpin.actors import exceptions
+from kingpin.constants import REQUIRED
 
 log = logging.getLogger(__name__)
 
@@ -68,11 +69,11 @@ class BaseActor(object):
     #     'option_name': (type, default, "Long description of the option"),
     # }
     #
-    # If `default` is `None` then the option requires user specified input
+    # If `default` is REQUIRED then the option requires user specified input
     #
     # Example:
     # {
-    #    'room': (str, None, 'Hipchat room to notify'),
+    #    'room': (str, REQUIRED, 'Hipchat room to notify'),
     #    'from': (str, 'Kingpin', 'User that sends the message')
     # }
     all_options = {}
@@ -117,8 +118,7 @@ class BaseActor(object):
         for option, definition in self.all_options.items():
             if option not in self._options:
                 default = definition[1]
-                # `None` means it's required. Don't set the default
-                if default is not None:
+                if default is not REQUIRED:
                     self._options.update({option: default})
 
     def _validate_options(self):
@@ -132,10 +132,9 @@ class BaseActor(object):
         """
 
         # Loop through all_options, and find the required ones
-        # Required options have `None` as their default value.
         required = [opt_name
                     for (opt_name, definition) in self.all_options.items()
-                    if definition[1] is None]
+                    if definition[1] == REQUIRED]
 
         self.log.debug('Checking for required options: %s' % required)
         option_errors = []

--- a/kingpin/actors/group.py
+++ b/kingpin/actors/group.py
@@ -22,6 +22,7 @@ from tornado import gen
 from kingpin.actors import base
 from kingpin.actors import exceptions
 from kingpin.actors import utils
+from kingpin.constants import REQUIRED
 
 log = logging.getLogger(__name__)
 
@@ -37,7 +38,7 @@ class BaseGroupActor(base.BaseActor):
     """
 
     all_options = {
-        'acts': (list, None, "Array of actor definitions.")
+        'acts': (list, REQUIRED, "Array of actor definitions.")
     }
 
     def __init__(self, *args, **kwargs):

--- a/kingpin/actors/hipchat.py
+++ b/kingpin/actors/hipchat.py
@@ -23,6 +23,7 @@ from tornado import httpclient
 from kingpin import utils
 from kingpin.actors import base
 from kingpin.actors import exceptions
+from kingpin.constants import REQUIRED
 
 log = logging.getLogger(__name__)
 
@@ -122,8 +123,8 @@ class Message(HipchatBase):
     """Simple Hipchat Message sending actor."""
 
     all_options = {
-        'room': (str, None, 'Hipchat room name'),
-        'message': (str, None, 'Message to send')
+        'room': (str, REQUIRED, 'Hipchat room name'),
+        'message': (str, REQUIRED, 'Message to send')
     }
 
     @gen.coroutine
@@ -191,8 +192,8 @@ class Topic(HipchatBase):
     """Simple Hipchat Room Topic Setter"""
 
     all_options = {
-        'room': (str, None, 'Hipchat room name'),
-        'topic': (str, None, 'Topic to set')
+        'room': (str, REQUIRED, 'Hipchat room name'),
+        'topic': (str, REQUIRED, 'Topic to set')
     }
 
     @gen.coroutine

--- a/kingpin/actors/librato.py
+++ b/kingpin/actors/librato.py
@@ -24,6 +24,7 @@ from tornado import httpclient
 from kingpin import utils
 from kingpin.actors import base
 from kingpin.actors import exceptions
+from kingpin.constants import REQUIRED
 
 log = logging.getLogger(__name__)
 
@@ -44,9 +45,9 @@ class Annotation(base.HTTPBaseActor):
     http://dev.librato.com/v1/post/annotations/:name"""
 
     all_options = {
-        'title': (str, None, "Annotation title"),
-        'description': (str, None, "Annotation description"),
-        'name': (str, None, "Name of the metric to annotate")
+        'title': (str, REQUIRED, "Annotation title"),
+        'description': (str, REQUIRED, "Annotation description"),
+        'name': (str, REQUIRED, "Name of the metric to annotate")
     }
 
     def __init__(self, *args, **kwargs):

--- a/kingpin/actors/misc.py
+++ b/kingpin/actors/misc.py
@@ -27,10 +27,11 @@ from tornado import httpclient
 from kingpin.actors import utils as actor_utils
 from kingpin import exceptions as kingpin_exceptions
 
+from kingpin import schema
 from kingpin import utils
 from kingpin.actors import base
 from kingpin.actors import exceptions
-from kingpin import schema
+from kingpin.constants import REQUIRED
 
 log = logging.getLogger(__name__)
 
@@ -43,7 +44,7 @@ class Macro(base.BaseActor):
     """Execute a kingpin JSON file."""
 
     all_options = {
-        'macro': (str, None,
+        'macro': (str, REQUIRED,
                   "Path to a Kingpin JSON file. http(s)://, file:///, "
                   "absolute or relative file paths."),
         'tokens': (dict, {}, "Tokens passed into the JSON file.")
@@ -161,7 +162,7 @@ class Sleep(base.BaseActor):
     """Simple actor that just sleeps for an arbitrary amount of time."""
 
     all_options = {
-        'sleep': ((int, float), None, 'Number of seconds to do nothing.')
+        'sleep': ((int, float), REQUIRED, 'Number of seconds to do nothing.')
     }
 
     @gen.coroutine
@@ -179,7 +180,7 @@ class GenericHTTP(base.HTTPBaseActor):
     """Simple HTTP get/post sending actor."""
 
     all_options = {
-        'url': (str, None, 'Domain name + query string to fetch'),
+        'url': (str, REQUIRED, 'Domain name + query string to fetch'),
         'data': (dict, {}, 'Data to attach as a POST query'),
         'username': (str, '', 'HTTPAuth username'),
         'password': (str, '', 'HTTPAuth password')

--- a/kingpin/actors/rightscale/server_array.py
+++ b/kingpin/actors/rightscale/server_array.py
@@ -25,6 +25,7 @@ from kingpin import utils
 from kingpin.actors import exceptions
 from kingpin.actors.rightscale import api
 from kingpin.actors.rightscale import base
+from kingpin.constants import REQUIRED
 
 log = logging.getLogger(__name__)
 
@@ -118,8 +119,8 @@ class Clone(ServerArrayBaseActor):
     """Clones a RightScale Server Array."""
 
     all_options = {
-        'source': (str, None, 'Name of the ServerArray to clone.'),
-        'dest': (str, None, 'Name to give the cloned ServerArray.')
+        'source': (str, REQUIRED, 'Name of the ServerArray to clone.'),
+        'dest': (str, REQUIRED, 'Name to give the cloned ServerArray.')
     }
 
     @gen.coroutine
@@ -177,7 +178,7 @@ class Update(ServerArrayBaseActor):
     """
 
     all_options = {
-        'array': (str, None, 'ServerArray name to Update'),
+        'array': (str, REQUIRED, 'ServerArray name to Update'),
         'params': (dict, {}, 'ServerArray RightScale parameters'),
         'inputs': (dict, {}, 'ServerArray inputs for launching.')
     }
@@ -266,7 +267,7 @@ class Terminate(ServerArrayBaseActor):
     """Terminate all instances in a RightScale Server Array."""
 
     all_options = {
-        'array': (str, None, 'ServerArray name to Terminate')
+        'array': (str, REQUIRED, 'ServerArray name to Terminate')
     }
 
     @gen.coroutine
@@ -360,7 +361,7 @@ class Destroy(ServerArrayBaseActor):
     ServerArray in RightScale."""
 
     all_options = {
-        'array': (str, None, 'ServerArray name to Destroy')
+        'array': (str, REQUIRED, 'ServerArray name to Destroy')
     }
 
     @gen.coroutine
@@ -413,7 +414,7 @@ class Launch(ServerArrayBaseActor):
     """Launches the min_instances in a RightScale Server Array."""
 
     all_options = {
-        'array': (str, None, 'ServerArray name to launch'),
+        'array': (str, REQUIRED, 'ServerArray name to launch'),
         'count': (
             int, False,
             "Number of server to launch. Default: up to array's min count"),
@@ -582,10 +583,12 @@ class Execute(ServerArrayBaseActor):
     """
 
     all_options = {
-        'array': (str, None, 'ServerArray name on which to execute a script.'),
-        'script': (str, None, 'RightScale RightScript or Recipe to execute.'),
-        'inputs': (dict, {}, ('Inputs needed by the script. '
-                              'Read _generate_rightscale_params.'))
+        'array': (str, REQUIRED,
+                  'ServerArray name on which to execute a script.'),
+        'script': (str, REQUIRED,
+                   'RightScale RightScript or Recipe to execute.'),
+        'inputs': (dict, {}, (
+            'Inputs needed by the script. Read _generate_rightscale_params.'))
     }
 
     @gen.coroutine

--- a/kingpin/actors/rollbar.py
+++ b/kingpin/actors/rollbar.py
@@ -24,6 +24,7 @@ from tornado import httpclient
 from kingpin import utils
 from kingpin.actors import base
 from kingpin.actors import exceptions
+from kingpin.constants import REQUIRED
 
 log = logging.getLogger(__name__)
 
@@ -131,8 +132,8 @@ class Deploy(RollbarBase):
 
     """
     all_options = {
-        'environment': (str, None, 'Name of the environment being deployed'),
-        'revision': (str, None, 'Revision number/sha being deployed'),
+        'environment': (str, REQUIRED, 'Name of the environment to deploy'),
+        'revision': (str, REQUIRED, 'Revision number/sha being deployed'),
         'local_username': (str, 'Kingpin', 'User who deployed'),
         'rollbar_username': (str, '', 'Rollbar username'),
         'comment': (str, '', 'Deploy comment')

--- a/kingpin/actors/test/test_base.py
+++ b/kingpin/actors/test/test_base.py
@@ -1,4 +1,5 @@
 """Tests for the actors.base package."""
+from __future__ import absolute_import
 import StringIO
 import json
 import os
@@ -14,6 +15,7 @@ from kingpin import utils
 from kingpin.actors import base
 from kingpin.actors import exceptions
 from kingpin.actors.test.helper import mock_tornado
+from kingpin.constants import REQUIRED
 
 
 __author__ = 'Matt Wise <matt@nextdoor.com>'
@@ -83,24 +85,24 @@ class TestBaseActor(testing.AsyncTestCase):
         self.assertEquals(10, requests_logger.level)
 
     def test_validate_options(self):
-        self.actor.all_options = {'test': (str, None, '')}
+        self.actor.all_options = {'test': (str, REQUIRED, '')}
         self.actor._options = {'a': 'b'}
         with self.assertRaises(exceptions.InvalidOptions):
             ret = self.actor._validate_options()
 
-        self.actor.all_options = {'test': (str, None, '')}
+        self.actor.all_options = {'test': (str, REQUIRED, '')}
         self.actor._options = {'test': 'b'}
         ret = self.actor._validate_options()
         self.assertEquals(None, ret)
 
-        self.actor.all_options = {'test': (str, None, ''),
-                                  'test2': (str, None, '')}
+        self.actor.all_options = {'test': (str, REQUIRED, ''),
+                                  'test2': (str, REQUIRED, '')}
         self.actor._options = {'test': 'b', 'test2': 'b'}
         ret = self.actor._validate_options()
         self.assertEquals(None, ret)
 
     def test_validation_issues(self):
-        self.actor.all_options = {'needed': (str, None, ''),
+        self.actor.all_options = {'needed': (str, REQUIRED, ''),
                                   'optional': (str, '', '')}
 
         # Requirement not satisfied

--- a/kingpin/constants.py
+++ b/kingpin/constants.py
@@ -1,0 +1,19 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2014 Nextdoor.com, Inc
+
+__author__ = 'Mikhail Simin <mikhail@nextdoor.com>'
+
+
+class REQUIRED(object):
+    """Meta class to identify required arguments for actors."""


### PR DESCRIPTION
Sometimes None is a valid default value, and it should not be reserved
to identify a required parameter. This change converts all actors to use
a REQUIRED identifier (meta class).