### PR TITLE
Add actor 'initialization context' support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ Each _actor_ configuration includes the same three parameters: _actor_, _desc_
 and _options_.
 
 The simplest script will have a single configuration that executes a single
-_actor_. More complex scripts can be created with our _group.Sync_ and
-_group.Async_ actors which can be used to group together multiple _actors_ and
+_actor_. More complex scripts can be created with our `group.Sync` and
+`group.Async` actors which can be used to group together multiple _actors_ and
 execute them in a predictable order.
 
 ##### Schema Description
@@ -163,6 +163,8 @@ it works just fine.
 
 ##### Token-replacement
 
+###### Environmental Tokens
+
 In an effort to allow for more re-usable JSON files, _tokens_ can be inserted
 into the raw JSON file like this `%TOKEN_NAME%`. These will then be dynamically
 swapped with environment variables found at execution time. Any missing
@@ -186,6 +188,61 @@ and these examples of execution.
     2014-09-01 21:30:03,886 INFO      [Hipchat: Notify Oncall Room (DRY Mode)] Beginning
     2014-09-01 21:30:03,886 INFO      [Hipchat: Notify Oncall Room (DRY Mode)] Sending message "Beginning release 0001a" to Hipchat room "Oncall"
     ...
+
+###### Contextual Tokens
+
+Once the initial JSON files have been loaded up, we have a second layer of
+_tokens_ that can be referenced. These tokens are known as _contextual tokens_.
+These _contextual tokens_ are used during-runtime to swap out _strings_ with
+_variables_. Currently only the `group.Sync` and `group.Async` actors have the
+ability to define usable tokens, but any actor can then reference these tokens.
+
+*Contextual tokens for simple variable behavior*
+
+    { "desc": "Send out hipchat notifications",
+      "actor": "group.Sync",
+      "options": {
+          "contexts": [ { "ROOM": "Systems" } ],
+          "acts": [
+              { "desc": "Notify {ROOM}",
+                "actor": "hipchat.Message",
+                "options": {
+                  "room": "{ROOM}",
+                    "message": "Hey room .. I'm done with something"
+                }
+              }
+          ]
+      }
+    }
+
+    2015-01-14 15:03:16,840 INFO      [DRY: Send out hipchat notifications] Beginning 1 actions
+    2015-01-14 15:03:16,840 INFO      [DRY: Notify Systems] Sending message "Hey room .. I'm done with something" to Hipchat room "Systems"
+
+
+*Contextual tokens used for iteration*
+
+    { "desc": "Send ending notifications...", "actor": "group.Async",
+      "options": {
+        "contexts": [
+          { "ROOM": "Engineering", "WISDOM": "Get back to work" },
+          { "ROOM": "Cust Service", "WISDOM": "Have a nice day" }
+        ],
+        "acts": [
+          { "desc": "Notify {ROOM}",
+            "actor": "hipchat.Message",
+            "options": {
+                "room": "{ROOM}",
+                "message": "Hey room .. I'm done with the release. {WISDOM}"
+            }
+          }
+        ]
+      }
+    }
+
+    2015-01-14 15:02:22,165 INFO      [DRY: Send ending notifications...] Beginning 2 actions
+    2015-01-14 15:02:22,165 INFO      [DRY: Notify Engineering] Sending message "Hey room .. I'm done with the release. Get back to work" to Hipchat room "Engineering"
+    2015-01-14 15:02:22,239 INFO      [DRY: Notify Cust Service] Sending message "Hey room .. I'm done with the release. Have a nice day" to Hipchat room "Cust Service"
+
 
 ##### Early Actor Instantiation
 

--- a/docs/actors/group.Async.md
+++ b/docs/actors/group.Async.md
@@ -6,15 +6,32 @@ waiting until all of them finish before returning.
 **Options**
 
   * `acts` - An array of individual Actor definitions.
+  * `contexts` - A list of dictionaries with _contextual tokens_ to pass into
+    the actors at instantiation time. If the list has more than one element,
+    then every actor defined in `acts` will be instantiated once for each item
+    in the `contexts` list.
 
 Examples
 
-    { 'acts': [
-      { 'desc': 'do something', 'actor': 'server_array.Clone',
-        'options': { 'source': 'template', 'dest': 'new_array_1' } },
-      { 'desc': 'do something', 'actor': 'server_array.Clone',
-        'options': { 'source': 'template', 'dest': 'new_array_2' } },
-    ] }
+    # Clone two arrays quickly
+    { "desc": "Clone two arrays",
+      "actor": "group.Async",
+      "options": {
+        "contexts": [
+          { "ARRAY": "NewArray1" },
+          { "ARRAY": "NewArray2" }
+        ],
+        "acts": [
+          { "desc": "do something",
+            "actor": "server_array.Clone",
+            "options": {
+              "source": "template",
+              "dest": "{ARRAY}",
+            }
+          }
+        ]
+      }
+    }
 
 **Dry Mode**
 

--- a/docs/actors/group.Sync.md
+++ b/docs/actors/group.Sync.md
@@ -6,15 +6,40 @@ in the order that they were defined.
 **Options**
 
   * `acts` - An array of individual Actor definitions.
+  * `contexts` - A list of dictionaries with _contextual tokens_ to pass into
+    the actors at instantiation time. If the list has more than one element,
+    then every actor defined in `acts` will be instantiated once for each item
+    in the `contexts` list.
 
 Examples
 
-    { 'acts': [
-      { 'desc': 'sleep', 'actor': 'misc.Sleep',
-        'options': { 'sleep': 60 } },
-      { 'desc': 'do something', 'actor': 'server_array.Clone',
-        'options': { 'source': 'template', 'dest': 'new_array' } },
-    ] }
+    # Creates two arrays ... but sleeps 60 seconds between the two, then
+    # does not sleep at all after the last one.
+    { "desc": "Clone, then sleep ... then clone, then sleep shorter...",
+      "actor": "group.Sync",
+      "options": {
+        "contexts": [
+          { "ARRAY": "First", "SLEEP": "60", },
+          { "ARRAY": "Second", "SLEEP": "0", }
+        ],
+        "acts": [
+          { "desc":
+            "do something",
+            "actor": "server_array.Clone",
+            "options": {
+              "source": "template",
+              "dest": "{ARRAY}"
+            }
+          },
+          { "desc": "sleep",
+            "actor": "misc.Sleep",
+            "options": {
+              "sleep": "{SLEEP}",
+            }
+          }
+        ]
+      }
+    }
 
 **Dry Mode**
 

--- a/kingpin/actors/base.py
+++ b/kingpin/actors/base.py
@@ -257,6 +257,17 @@ class BaseActor(object):
         Raises:
             exceptions.InvalidOptions
         """
+        try:
+            self._desc = utils.populate_with_tokens(
+                self._desc,
+                context,
+                self.left_context_separator,
+                self.right_context_separator,
+                strict=strict)
+        except LookupError as e:
+            msg = 'Context for description failed: %s' % e
+            raise exceptions.InvalidOptions(msg)
+
         # Convert our self._options dict into a string for fast parsing
         options_string = json.dumps(self._options)
 
@@ -271,14 +282,9 @@ class BaseActor(object):
                 self.left_context_separator,
                 self.right_context_separator,
                 strict=strict)
-            self._desc = utils.populate_with_tokens(
-                self._desc,
-                context,
-                self.left_context_separator,
-                self.right_context_separator,
-                strict=strict)
         except LookupError as e:
-            raise exceptions.InvalidOptions(e)
+            msg = 'Context for options failed: %s' % e
+            raise exceptions.InvalidOptions(msg)
 
         # Finally, convert the string back into a dict and store it.
         self._options = json.loads(new_options_string)

--- a/kingpin/actors/base.py
+++ b/kingpin/actors/base.py
@@ -107,16 +107,22 @@ class BaseActor(object):
                 This is usually driven by the group.Sync/Async actors.
         """
         self._type = '%s.%s' % (self.__module__, self.__class__.__name__)
-        self._desc = utils.populate_with_tokens(
-            desc, init_context,
-            self.left_context_separator,
-            self.right_context_separator)
         self._options = options
         self._dry = dry
         self._warn_on_failure = warn_on_failure
         self._condition = condition
         self._init_context = init_context
 
+        # Patch our actor description. This needs to happen separately from the
+        # _fill_in_context() method because it has to happen before we setup
+        # our logger object.
+        try:
+            self._desc = utils.populate_with_tokens(
+                desc, init_context,
+                self.left_context_separator,
+                self.right_context_separator)
+        except LookupError as e:
+            raise exceptions.InvalidOptions(e)
 
         self._setup_log()
         self._setup_defaults()

--- a/kingpin/actors/base.py
+++ b/kingpin/actors/base.py
@@ -78,8 +78,20 @@ class BaseActor(object):
     # }
     all_options = {}
 
+    # Context separators. These define the left-and-right identifiers of a
+    # 'contextual parameter' in the actor. By default this is { and }, so a
+    # contextual paramter looks like '{KEY}'.
+    left_context_separator = '{'
+    right_context_separator = '}'
+
+    # Ensure that at __init__ time, if the self._options dict is not completely
+    # filled in properly (meaning there are no left-over {KEY}'s), we throw an
+    # exception. This will change in the future when we have some concept of a
+    # second 'global runtime context object'.
+    strict_init_context = True
+
     def __init__(self, desc, options, dry=False, warn_on_failure=False,
-                 condition=True):
+                 condition=True, init_context={}):
         """Initializes the Actor.
 
         Args:
@@ -90,19 +102,36 @@ class BaseActor(object):
             warn_on_failure: (Bool) Whether this actor ignores its return
                              value and always succeeds (but warns).
             condition: (Bool) Whether to run this actor.
+            init_context: (Dict) Key/Value pairs used at instantiation
+                time to replace {KEY} strings in the actor definition.
+                This is usually driven by the group.Sync/Async actors.
         """
         self._type = '%s.%s' % (self.__module__, self.__class__.__name__)
-        self._desc = desc
+        self._desc = utils.populate_with_tokens(
+            desc, init_context,
+            self.left_context_separator,
+            self.right_context_separator)
         self._options = options
         self._dry = dry
         self._warn_on_failure = warn_on_failure
         self._condition = condition
+        self._init_context = init_context
+
 
         self._setup_log()
         self._setup_defaults()
         self._validate_options()  # Relies on _setup_log() above
 
-        self.log.debug('Initialized (warn_on_failure=%s)' % warn_on_failure)
+        # Fill in any options with the supplied initialization context. Be
+        # strict about this -- but in the future, when we have a
+        # runtime_context object, we may loosen this restriction).
+        self.log.debug('Init Context: %s' % self._init_context)
+        self._fill_in_contexts(context=self._init_context,
+                               strict=self.strict_init_context)
+
+        self.log.debug('Initialized (warn_on_failure=%s, '
+                       'strict_init_context=%s)' %
+                       (warn_on_failure, self.strict_init_context))
 
     def _setup_log(self):
         """Create a customized logging object based on the LogAdapter."""
@@ -217,6 +246,41 @@ class BaseActor(object):
             check = bool(value)
 
         return check
+
+    def _fill_in_contexts(self, context={}, strict=True):
+        """Parses self._options and updates it with the supplied context.
+
+        Parses the objects self._options dict (by converting it into a JSON
+        string, substituting, and then turning it back into a dict) and
+        replaces any {KEY}s with the valoues from the context dict that was
+        supplied.
+
+        Args:
+            strict: bool whether or not to allow missing context keys to be
+                    skipped over.
+
+        Raises:
+            exceptions.InvalidOptions
+        """
+        # Convert our self._options dict into a string for fast parsing
+        options_string = json.dumps(self._options)
+
+        # Generate a new string with the values parsed out. At this point, if
+        # any value is un-matched, an exception is raised and execution fails.
+        # This stops execution during a DRY run, before any live changes are
+        # made.
+        try:
+            new_options_string = utils.populate_with_tokens(
+                options_string,
+                context,
+                self.left_context_separator,
+                self.right_context_separator,
+                strict=strict)
+        except LookupError as e:
+            raise exceptions.InvalidOptions(e)
+
+        # Finally, convert the string back into a dict and store it.
+        self._options = json.loads(new_options_string)
 
     @gen.coroutine
     @timer

--- a/kingpin/actors/group.py
+++ b/kingpin/actors/group.py
@@ -42,7 +42,7 @@ class BaseGroupActor(base.BaseActor):
     }
 
     # Override the BaseActor strict_init_context setting. Since there may be
-    # nested-groups that have their own context parameters, we do not require
+    # nested-groups that have their own context tokens, we do not require
     # that all of the {KEY}'s inside of the self._options dict are filled in
     # the moment that this actor is instantiated.
     strict_init_context = False

--- a/kingpin/actors/group.py
+++ b/kingpin/actors/group.py
@@ -82,8 +82,10 @@ class BaseGroupActor(base.BaseActor):
 
         actions = []
         for context in self.option('contexts'):
-            combined_context = dict(self._init_context.items() + context.items())
-            self.log.debug('Building acts with parameters: %s' % combined_context)
+            combined_context = dict(self._init_context.items() +
+                                    context.items())
+            self.log.debug('Building acts with parameters: %s' %
+                           combined_context)
             for action in self._build_action_group(context=combined_context):
                 actions.append(action)
 

--- a/kingpin/actors/group.py
+++ b/kingpin/actors/group.py
@@ -37,7 +37,7 @@ class BaseGroupActor(base.BaseActor):
     """
 
     all_options = {
-        'contexts': (list, [], "List of matrix hashes."),
+        'contexts': (list, [], "List of contextual hashes."),
         'acts': (list, REQUIRED, "Array of actor definitions.")
     }
 
@@ -81,8 +81,8 @@ class BaseGroupActor(base.BaseActor):
             return self._build_action_group(self._init_context)
 
         actions = []
-        for matrix in self.option('contexts'):
-            combined_context = dict(self._init_context.items() + matrix.items())
+        for context in self.option('contexts'):
+            combined_context = dict(self._init_context.items() + context.items())
             self.log.debug('Building acts with parameters: %s' % combined_context)
             for action in self._build_action_group(context=combined_context):
                 actions.append(action)

--- a/kingpin/actors/misc.py
+++ b/kingpin/actors/misc.py
@@ -162,7 +162,7 @@ class Sleep(base.BaseActor):
     """Simple actor that just sleeps for an arbitrary amount of time."""
 
     all_options = {
-        'sleep': ((int, float), REQUIRED, 'Number of seconds to do nothing.')
+        'sleep': ((int, float, str), REQUIRED, 'Number of seconds to do nothing.')
     }
 
     @gen.coroutine
@@ -172,7 +172,7 @@ class Sleep(base.BaseActor):
         self.log.debug('Sleeping for %s seconds' % self.option('sleep'))
 
         if not self._dry:
-            yield utils.tornado_sleep(seconds=self.option('sleep'))
+            yield utils.tornado_sleep(seconds=int(self.option('sleep')))
 
 
 class GenericHTTP(base.HTTPBaseActor):

--- a/kingpin/actors/misc.py
+++ b/kingpin/actors/misc.py
@@ -162,7 +162,8 @@ class Sleep(base.BaseActor):
     """Simple actor that just sleeps for an arbitrary amount of time."""
 
     all_options = {
-        'sleep': ((int, float, str), REQUIRED, 'Number of seconds to do nothing.')
+        'sleep': ((int, float, str), REQUIRED,
+                  'Number of seconds to do nothing.')
     }
 
     @gen.coroutine
@@ -171,8 +172,13 @@ class Sleep(base.BaseActor):
 
         self.log.debug('Sleeping for %s seconds' % self.option('sleep'))
 
+        sleep = self.option('sleep')
+
+        if isinstance(sleep, basestring):
+            sleep = float(sleep)
+
         if not self._dry:
-            yield utils.tornado_sleep(seconds=int(self.option('sleep')))
+            yield utils.tornado_sleep(seconds=sleep)
 
 
 class GenericHTTP(base.HTTPBaseActor):

--- a/kingpin/actors/test/test_base.py
+++ b/kingpin/actors/test/test_base.py
@@ -208,17 +208,31 @@ class TestBaseActor(testing.AsyncTestCase):
         res = yield self.actor.execute()
         self.assertEquals(res, None)
 
-    def test_fill_in_contexts(self):
+    def test_fill_in_contexts_desc(self):
+        base.BaseActor.all_options = {
+            'test_opt': (str, REQUIRED, 'Test option')
+        }
+
         self.actor = base.BaseActor(
             desc='Unit Test Action - {NAME}',
-            options={},
+            options={'test_opt': 'Foo bar'},
             init_context={'NAME': 'TEST'})
         self.assertEquals('Unit Test Action - TEST', self.actor._desc)
 
-    def test_fill_in_contexts_bad_context(self):
         with self.assertRaises(exceptions.InvalidOptions):
             self.actor = base.BaseActor(
-                desc='Unit Test Action - {NAME}', options={}, init_context={})
+                desc='Unit Test Action',
+                options={'test_opt': 'Foo {BAZ} bar'},
+                init_context={})
+
+        with self.assertRaises(exceptions.InvalidOptions):
+            self.actor = base.BaseActor(
+                desc='Unit Test Action - {NAME}',
+                options={},
+                init_context={})
+
+        # Reset the all options so we dont break other tests
+        base.BaseActor.all_options = {}
 
 
 class TestHTTPBaseActor(testing.AsyncTestCase):

--- a/kingpin/actors/test/test_base.py
+++ b/kingpin/actors/test/test_base.py
@@ -150,7 +150,7 @@ class TestBaseActor(testing.AsyncTestCase):
             '0': False,
             'False': False,
             'FALSE': False,
-            }
+        }
         for value, should_execute in conditions.items():
             self.actor._condition = value
             self.actor._execute = mock_tornado()
@@ -207,6 +207,18 @@ class TestBaseActor(testing.AsyncTestCase):
         self.actor._warn_on_failure = True
         res = yield self.actor.execute()
         self.assertEquals(res, None)
+
+    def test_fill_in_contexts(self):
+        self.actor = base.BaseActor(
+            desc='Unit Test Action - {NAME}',
+            options={},
+            init_context={'NAME': 'TEST'})
+        self.assertEquals('Unit Test Action - TEST', self.actor._desc)
+
+    def test_fill_in_contexts_bad_context(self):
+        with self.assertRaises(exceptions.InvalidOptions):
+            self.actor = base.BaseActor(
+                desc='Unit Test Action - {NAME}', options={}, init_context={})
 
 
 class TestHTTPBaseActor(testing.AsyncTestCase):

--- a/kingpin/actors/test/test_misc.py
+++ b/kingpin/actors/test/test_misc.py
@@ -29,7 +29,7 @@ class TestMacro(testing.AsyncTestCase):
                 'desc': 'unit test',
                 'actor': 'unit test',
                 'options': {}
-                }
+            }
 
             actor = misc.Macro('Unit Test', {'macro': 'test.json',
                                              'tokens': {}})
@@ -58,7 +58,7 @@ class TestMacro(testing.AsyncTestCase):
                 'desc': 'unit test',
                 'actor': 'unit test',
                 'options': {}
-                }
+            }
 
             actor = misc.Macro('Unit Test',
                                {'macro': 'examples/test/sleep.json',
@@ -92,7 +92,7 @@ class TestMacro(testing.AsyncTestCase):
             j2d.return_value = {
                 'desc': 'unit test',
                 'options': {}  # `actor` keyword is missing
-                }
+            }
 
             with self.assertRaises(exceptions.UnrecoverableActorFailure):
                 misc.Macro('Unit Test', {'macro': 'test.json',
@@ -127,10 +127,20 @@ class TestMacro(testing.AsyncTestCase):
 
 
 class TestSleep(testing.AsyncTestCase):
+
     @testing.gen_test
     def test_execute(self):
         # Call the executor and test it out
         actor = misc.Sleep('Unit Test Action', {'sleep': 0.1})
+        res = yield actor.execute()
+
+        # Make sure we fired off an alert.
+        self.assertEquals(res, None)
+
+    @testing.gen_test
+    def test_execute_with_str(self):
+        # Call the executor and test it out
+        actor = misc.Sleep('Unit Test Action', {'sleep': '0.5'})
         res = yield actor.execute()
 
         # Make sure we fired off an alert.

--- a/kingpin/bin/deploy.py
+++ b/kingpin/bin/deploy.py
@@ -91,7 +91,8 @@ def main():
     try:
         runner = Macro(desc='Kingpin',
                        options={'macro': options.json,
-                                'tokens': env_tokens})
+                                'tokens': env_tokens},
+                       dry=options.dry)
         yield runner.execute()
     except actor_exceptions.ActorException as e:
         log.error('Kingpin encountered mistakes during the play: %s' % e)

--- a/kingpin/test/test_utils.py
+++ b/kingpin/test/test_utils.py
@@ -33,6 +33,16 @@ class TestUtils(unittest.TestCase):
         with self.assertRaises(LookupError):
             utils.populate_with_tokens(string, os.environ)
 
+    def test_populate_with_not_strict(self):
+        tokens = {'UNIT_TEST': 'FOOBAR'}
+        string = 'Unit {UNIT_TEST} {FAIL} Test'
+        expect = 'Unit FOOBAR {FAIL} Test'
+        result = utils.populate_with_tokens(
+            string, tokens,
+            left_wrapper='{', right_wrapper='}',
+            strict=False)
+        self.assertEquals(result, expect)
+
     def test_convert_json_to_dict(self):
         # Should work with string path to a file
         dirname, filename = os.path.split(os.path.abspath(__file__))


### PR DESCRIPTION
Issue #143 

This request adds the concept of an `init_context` to our `BaseActor` which can be used to dynamically fill in the actor `options` at init time. This is used to allow a single actor definition in a `group.Sync` or `group.Async` to be re-used multiple times to create new actors. For example:

```json5
{ "desc": "Send out hipchat notifications",
  "actor": "group.Sync",
  "warn_on_failure": true,
  "options": {
    "contexts": [ { "ROOM": "Systems" } ],

    "acts": [

      { "desc": "Send ending notifications to {ROOM}...", "actor": "group.Async",
        "options": {
          "contexts": [ { "APP": "App1" }, { "APP": "App2" } ],
          "acts": [
            { "desc": "Notify End {ROOM}", "actor": "hipchat.Message", "options": { "room": "{ROOM}", "message": "Hey room .. I'm done with {APP}" } }
          ]
        }
      }

    ]
  }
}
```

This creates the following run output:
```shell
14:28:19   INFO      [DRY: Kingpin] Preparing actors from test.json
14:28:19   INFO      [DRY: Send out hipchat notifications] Beginning 1 actions
14:28:19   INFO      [DRY: Send ending notifications to Systems...] Beginning 2 actions
14:28:19   INFO      [DRY: Notify End Systems] Sending message "Hey room .. I'm done with App1" to Hipchat room "Systems"
14:28:19   INFO      [DRY: Notify End Systems] Sending message "Hey room .. I'm done with App2" to Hipchat room "Systems"
14:28:19   INFO      [DRY: Notify End Systems] API Token Validated: This auth_token has access to use this method.
14:28:20   INFO      [DRY: Notify End Systems] API Token Validated: This auth_token has access to use this method.
```