### PR TITLE
Handle 401 and 403 response codes the same.

### DIFF
--- a/kingpin/actors/rollbar.py
+++ b/kingpin/actors/rollbar.py
@@ -81,7 +81,7 @@ class RollbarBase(base.HTTPBaseActor):
             # These are HTTPErrors that we know about, and can log specific
             # error messages for.
 
-            if e.code == 403:
+            if e.code in (401, 403):
                 raise exceptions.InvalidCredentials(
                     'The "ROLLBAR_TOKEN" is invalid')
             elif e.code == 422:

--- a/kingpin/actors/test/test_rollbar.py
+++ b/kingpin/actors/test/test_rollbar.py
@@ -84,6 +84,21 @@ class TestRollbarBase(testing.AsyncTestCase):
             self.assertEquals(res, response_dict)
 
     @testing.gen_test
+    def test_fetch_wrapper_with_401(self):
+        actor = rollbar.RollbarBase('Unit Test Action', {})
+        response_dict = {'err': 1, 'messsage': 'Unauthorized'}
+        response_body = json.dumps(response_dict)
+        http_response = httpclient.HTTPError(
+            code=401, response=response_body)
+
+        with mock.patch.object(actor, '_get_http_client') as m:
+            m.return_value = FakeExceptionRaisingHTTPClientClass()
+            m.return_value.response_value = http_response
+
+            with self.assertRaises(exceptions.InvalidCredentials):
+                yield actor._fetch_wrapper('http://fake.com')
+
+    @testing.gen_test
     def test_fetch_wrapper_with_403(self):
         actor = rollbar.RollbarBase('Unit Test Action', {})
         response_dict = {'err': 1, 'messsage': 'access token not found: xxx'}


### PR DESCRIPTION
Rollbar has changed their response code on invalid_credentials
to respond with a 401 instead of a 403. Support both, just in case
they return to the old model.