### PR TITLE
actors.rightscale.server_array integration test fixes.

### DIFF
--- a/kingpin/actors/rightscale/test/integration_server_array.py
+++ b/kingpin/actors/rightscale/test/integration_server_array.py
@@ -123,7 +123,7 @@ class IntegrationServerArray(testing.AsyncTestCase):
             'Update %s' % self.clone_name,
             {'array': self.clone_name,
              'params': {'elasticity_params': {'bounds': {
-                        'min_count': '1', 'max_count': '2'}},
+                        'min_count': '1', 'max_count': '1'}},
                         'status': 'enabled',
                         'description': 'Unit Tests: %s' % UUID}})
         ret = yield actor.execute()
@@ -147,8 +147,8 @@ class IntegrationServerArray(testing.AsyncTestCase):
     @testing.gen_test(timeout=10)
     def integration_04c_update_with_invalid_params(self):
         actor = server_array.Update(
-            'Update %s' % self.template_array,
-            {'array': self.template_array,
+            'Update %s' % self.clone_name,
+            {'array': self.clone_name,
              'params': {
                  'elasticity_params': {
                      'bounds': {'min_count': '5', 'max_count': '1'}}}})
@@ -160,14 +160,14 @@ class IntegrationServerArray(testing.AsyncTestCase):
     def integration_04d_update_missing_array(self):
         # Patch the array with some new min_instance settings, then launch it
         actor = server_array.Update(
-            'Update %s' % self.clone_name,
-            {'array': self.clone_name,
+            'Update missing array',
+            {'array': 'unit-test-fake-array',
              'params': {'elasticity_params': {'bounds': {
-                        'min_count': '1', 'max_count': '2'}},
+                        'min_count': '1', 'max_count': '1'}},
                         'status': 'enabled',
                         'description': 'Unit Tests: %s' % UUID}})
-        ret = yield actor.execute()
-        self.assertEquals(ret, None)
+        with self.assertRaises(exceptions.RecoverableActorFailure):
+            yield actor.execute()
 
     @attr('integration', 'dry')
     @testing.gen_test(timeout=30)


### PR DESCRIPTION
1. Ensure that we never launch more than 1 instance, even if
   that instance takes forever. Effectively disables RS AutoScaling.
2. Fix an integration test that was supposed to break and throw/catch
   an exception, but wasn't because it was a bad copy-paste.