### PR TITLE
Allow setting of the 'strictness' of the rightscale.server_array.Clone actor

### DIFF
--- a/docs/actors/rightscale.server_array.Clone.md
+++ b/docs/actors/rightscale.server_array.Clone.md
@@ -1,16 +1,52 @@
 ##### rightscale.server_array.Clone
 
 Clones a ServerArray in RightScale and renames it to the newly supplied name.
+By default, this actor is extremely strict about validating that the `source`
+array already exists, and that the `dest` array does not yet exist. This
+behavior can be overridden though if your Kingpin script creates the
+`source`, or destroys an existing `dest` ServerArray sometime before this actor
+executes.
 
 **Options**
 
   * `source` - The name of the ServerArray to clone
+  * `source_strict` - Whether or not to fail if the source ServerArray does
+                      not exist. (default: True)
   * `dest`   - The new name for your cloned ServerArray
+  * `strict_dest` - Whether or not to fail if the destination ServerArray
+                    already exists. (default: True)
 
 Examples
 
     # Clone my-template-array to my-new-array
-    { 'source': 'my-template-array', 'dest': 'my-new-array' }
+    { "desc": "Clone my array",
+      "actor": "rightscale.server_array.Clone",
+      "options": {
+        "source": "my-template-array",
+        "dest": "my-new-array"
+      }
+    }
+
+    # Clone an array that was created sometime earlier in the Kingpin JSON, and
+    # thus does not exist yet during the dry run.
+    { "desc": "Clone that array we created earlier",
+      "actor": "rightscale.server_array.Clone",
+      "options": {
+        "source": "my-template-array",
+        "strict_source": false,
+        "dest": "my-new-array"
+      }
+    }
+
+    # Clone an array into a destination name that was destroyed sometime
+    # earlier in the Kingpin JSON.
+    { "desc": "Clone that array we created earlier",
+      "actor": "rightscale.server_array.Clone",
+      "options": {
+        "source": "my-template-array",
+        "dest": "my-new-array",
+        "strict_dest": false,
+      }
 
 **Dry Mode**
 

--- a/examples/rightscale_rolling_array_relaunch.json
+++ b/examples/rightscale_rolling_array_relaunch.json
@@ -1,0 +1,42 @@
+{ "desc": "Rolling relaunch of %ARRAY%",
+  "actor": "group.Sync",
+  "options": {
+    "acts": [
+
+        { "desc": "Rename %ARRAY% to %ARRAY%.orig",
+          "actor": "rightscale.server_array.Update",
+          "options": {
+            "array": "%ARRAY%",
+            "params": {
+              "name": "%ARRAY%.orig"
+            }
+          }
+        },
+
+        { "desc": "Clone %ARRAY%.orig to %ARRAY%",
+          "actor": "rightscale.server_array.Clone",
+          "options": {
+            "source": "%ARRAY%.orig",
+            "strict_source": false,
+            "dest": "%ARRAY%",
+            "strict_dest": false
+          }
+        },
+
+        { "desc": "Launch %ARRAY%",
+          "actor": "rightscale.server_array.Launch",
+          "options": {
+            "array": "%ARRAY%",
+            "enable": true
+          }
+        },
+
+        { "desc": "Destroy %ARRAY%.orig",
+          "actor": "rightscale.server_array.Destroy",
+          "options": {
+            "array": "%ARRAY%.orig"
+          }
+        }
+    ]
+  }
+}

--- a/kingpin/actors/rightscale/test/test_server_array.py
+++ b/kingpin/actors/rightscale/test/test_server_array.py
@@ -132,6 +132,18 @@ class TestCloneActor(testing.AsyncTestCase):
         self.client_mock = mock.MagicMock()
         self.actor._client = self.client_mock
 
+    def test_less_strict_source_and_dest(self):
+        self.actor = server_array.Clone('Copy UnitTestArray to NewUnitArray',
+                                        {'source': 'unittestarray',
+                                         'strict_source': False,
+                                         'dest': 'newunitarray',
+                                         'strict_dest': False})
+
+        self.assertEquals(self.actor._source_raise_on, None)
+        self.assertEquals(self.actor._dest_raise_on, None)
+        self.assertEquals(self.actor._source_allow_mock, True)
+        self.assertEquals(self.actor._dest_allow_mock, True)
+
     @testing.gen_test
     def test_execute(self):
 


### PR DESCRIPTION
(Solves issue #222 without writing a whole new actor)

The only reason that a "relaunch" of an existing ServerArray couldn't be
automated with existing actors was that the
rightscale.server_array.Clone actor was extremely strict about whether
the source/destination arrays already existed or not. By allowing this
to be configurable, you can write a script that acts on not-yet-existing
arrays.

Included in this change is an example of a "relaunch" Kingpin script.