### PR TITLE
Accept 'string counts' for rightscale.server_array.Launch.

### DIFF
--- a/kingpin/actors/rightscale/test/test_server_array.py
+++ b/kingpin/actors/rightscale/test/test_server_array.py
@@ -523,6 +523,14 @@ class TestLaunchActor(testing.AsyncTestCase):
                     'enable': False
                 })
 
+        with self.assertRaises(exceptions.InvalidOptions):
+            # Bad string passed in as count
+            server_array.Launch(
+                'Unit test', {
+                    'array': 'unit test array',
+                    'count': 'foo'
+                })
+
     @testing.gen_test
     def test_wait_until_healthy(self):
         array_mock = mock.MagicMock(name='unittest')


### PR DESCRIPTION
This allows '10' to be passed in (or more likely, using contexts,
something like '{COUNT}') and then auto converts it to an int.