### PR TITLE
Force Tornado < 4.1 due to a behavioral change in Exception logging.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,13 @@
 # General App Requirements
 
-# 4.0+ is required for the @gen.with_timeout decorator
+# 4.0+ is required for the @gen.with_timeout decorator. However, 4.1+ has a new
+# behavior that we havn't figured out how to properly handle yet.
+#
+# https://github.com/Nextdoor/kingpin/issues/232
+# https://github.com/tornadoweb/tornado/issues/1378
 #
 # http://tornado.readthedocs.org/en/latest/gen.html#tornado.gen.with_timeout
-tornado>=4.0
+tornado>=4.0,<4.1
 
 # Used to make synchronous tasks asynchronous
 futures


### PR DESCRIPTION
Something in the way our code is calling multiple tasks and yielding on
them is causing Tornado 4.1 to log out all the exceptions again,
regardless of whether we're doing it or not. Until this is resolved,
pinning our Tornado to < 4.1.

I have opened an issue with the Tornado team asking for guidance:
https://github.com/tornadoweb/tornado/issues/1378

This handles #232 -- where really we're handling the code fine, but there is extra logging being generated by Tornado that we were not expecting.