### PR TITLE
Support Tornado 4.1+ by ensuring all exceptions are caught and handled.

### DIFF
--- a/kingpin/actors/aws/base.py
+++ b/kingpin/actors/aws/base.py
@@ -19,7 +19,6 @@ import re
 
 from boto import utils
 from boto.exception import BotoServerError
-from concurrent import futures
 from tornado import concurrent
 from tornado import gen
 from tornado import ioloop
@@ -37,14 +36,16 @@ log = logging.getLogger(__name__)
 
 __author__ = 'Mikhail Simin <mikhail@nextdoor.com>'
 
-EXECUTOR = futures.ThreadPoolExecutor(10)
+EXECUTOR = concurrent.futures.ThreadPoolExecutor(10)
 
 
 class ELBNotFound(exceptions.RecoverableActorFailure):
+
     """Raised when an ELB is not found"""
 
 
 class InvalidMetaData(exceptions.UnrecoverableActorFailure):
+
     """Raised when fetching AWS metadata."""
 
 

--- a/kingpin/actors/aws/cloudformation.py
+++ b/kingpin/actors/aws/cloudformation.py
@@ -18,7 +18,6 @@ import logging
 
 from boto import cloudformation
 from boto.exception import BotoServerError
-from concurrent import futures
 from retrying import retry
 from tornado import concurrent
 from tornado import gen
@@ -39,7 +38,7 @@ __author__ = 'Matt Wise <matt@nextdoor.com>'
 # decorator. We would like this to be a class variable so its shared
 # across RightScale objects, but we see testing IO errors when we
 # do this.
-EXECUTOR = futures.ThreadPoolExecutor(10)
+EXECUTOR = concurrent.futures.ThreadPoolExecutor(10)
 
 
 # Used by the retrying.retry decorator

--- a/kingpin/actors/aws/elb.py
+++ b/kingpin/actors/aws/elb.py
@@ -18,7 +18,6 @@ import logging
 import math
 
 from boto.exception import BotoServerError
-from concurrent import futures
 from retrying import retry
 from tornado import concurrent
 from tornado import gen
@@ -39,7 +38,7 @@ __author__ = 'Mikhail Simin <mikhail@nextdoor.com>'
 # decorator. We would like this to be a class variable so its shared
 # across RightScale objects, but we see testing IO errors when we
 # do this.
-EXECUTOR = futures.ThreadPoolExecutor(10)
+EXECUTOR = concurrent.futures.ThreadPoolExecutor(10)
 
 
 class CertNotFound(exceptions.UnrecoverableActorFailure):

--- a/kingpin/actors/aws/iam.py
+++ b/kingpin/actors/aws/iam.py
@@ -17,7 +17,6 @@
 import logging
 
 from boto.exception import BotoServerError
-from concurrent import futures
 from retrying import retry
 from tornado import concurrent
 from tornado import gen
@@ -37,7 +36,7 @@ __author__ = 'Mikhail Simin <mikhail@nextdoor.com>'
 # decorator. We would like this to be a class variable so its shared
 # across RightScale objects, but we see testing IO errors when we
 # do this.
-EXECUTOR = futures.ThreadPoolExecutor(10)
+EXECUTOR = concurrent.futures.ThreadPoolExecutor(10)
 
 
 class IAMBaseActor(base.AWSBaseActor):

--- a/kingpin/actors/aws/sqs.py
+++ b/kingpin/actors/aws/sqs.py
@@ -18,7 +18,6 @@ import logging
 import re
 import time
 
-from concurrent import futures
 from tornado import concurrent
 from tornado import gen
 from tornado import ioloop
@@ -41,7 +40,7 @@ __author__ = 'Mikhail Simin <mikhail@nextdoor.com>'
 # decorator. We would like this to be a class variable so its shared
 # across RightScale objects, but we see testing IO errors when we
 # do this.
-EXECUTOR = futures.ThreadPoolExecutor(10)
+EXECUTOR = concurrent.futures.ThreadPoolExecutor(10)
 
 
 class QueueNotFound(exceptions.RecoverableActorFailure):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,8 @@
 # General App Requirements
 
-# 4.0+ is required for the @gen.with_timeout decorator. However, 4.1+ has a new
-# behavior that we havn't figured out how to properly handle yet.
-#
-# https://github.com/Nextdoor/kingpin/issues/232
-# https://github.com/tornadoweb/tornado/issues/1378
-#
+# 4.0+ is required for the @gen.with_timeout decorator.
 # http://tornado.readthedocs.org/en/latest/gen.html#tornado.gen.with_timeout
-tornado>=4.0,<4.1
+tornado>=4.0
 
 # Used to make synchronous tasks asynchronous
 futures


### PR DESCRIPTION
Tornado 4.1 was much louder about exceptions that it did not believe had been handled in asynchronous Future objects. This patch cleans up our use of these Futures while also creating much more clear output to the user about which instances failed to execute a script.

This also handles issue #229, as well as #236.