### PR TITLE
Improve the timeout system...

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,8 @@ with an environment variable:
 
   * `DEFAULT_TIMEOUT` - Time (in seconds) to use as the default actor timeout.
 
+Here is an example log output when the timer is exceeded:
+
     $ DEFAULT_TIMEOUT=1 SLEEP=10 kingpin -j examples/sleep.json
     11:55:16   INFO      Rehearsing... Break a leg!
     11:55:16   INFO      [DRY: Kingpin] Preparing actors from examples/sleep.json
@@ -260,9 +262,40 @@ You can disable the timeout on any actor by setting `timeout: 0` in your JSON.
 
 *Group Actor Timeouts*
 
-Note, Group Actors are unique and have their `default_timeout` set to 0
-(_disabled_) by default. You can, of course, override this with your own
-`timeout: xx` setting in the JSON.
+Group actors are special -- as they do nothing but execute other actors.
+Although they support the `timeout: x` setting, they default to disabling the
+timeout (`timeout: 0`). This is done because the individual timeouts are
+generally owned by the individual actors. A single actor that fails will
+propagate its exception up the chain and through the Group actor just like any
+other actor failure.
+
+As an example... If you take the following example code:
+
+    { "desc": "Outer group",
+      "actor": "group.Sync",
+      "options": {
+        "acts": [
+          { "desc": "Sleep 10 seconds, but fail",
+            "actor": "misc.Sleep",
+            "timeout": 1,
+            "warn_on_failure": true,
+            "options": {
+              "sleep": 10
+            }
+          },
+          { "desc": "Sleep 2 seconds, but don't fail",
+            "actor": "misc.Sleep",
+            "options": {
+              "sleep": 2
+            }
+          }
+        ]
+      }
+    }
+
+The first `misc.Sleep` actor will fail, but only warn (`warn_on_failure=True`)
+about the failure. The parent `group.Sync` actor will continue on and allow the
+second `misc.Sleep` actor to continue.
 
 ##### Token-replacement
 

--- a/README.md
+++ b/README.md
@@ -228,6 +228,32 @@ Take this example:
 The above example would fail to parse in most JSON parsers, but in `demjson`
 it works just fine.
 
+##### Timeouts
+
+By _default_, Kingpin actors are set to timeout after 3600s (1 hour). Each
+indivudal actor will raise an `ActorTimedOut` exception after this timeout has
+been reached. The `ActorTimedOut` exception is considered a
+`RecoverableActorFailure`, so the `warn_on_failure` setting applies here and
+thus the failure can be ignored if you choose to.
+
+Additionally, you can override the _global default_ setting on the commandline
+with an environment variable:
+
+  * `DEFAULT_TIMEOUT` - Time (in seconds) to use as the default actor timeout.
+
+    $ DEFAULT_TIMEOUT=1 SLEEP=10 kingpin -j examples/sleep.json
+    11:55:16   INFO      Rehearsing... Break a leg!
+    11:55:16   INFO      [DRY: Kingpin] Preparing actors from examples/sleep.json
+    11:55:16   INFO      Rehearsal OK! Performing!
+    11:55:16   INFO      Lights, camera ... action!
+    11:55:16   INFO      [Kingpin] Preparing actors from examples/sleep.json
+    11:55:17   ERROR     [Kingpin] kingpin.actors.misc.Macro._execute() execution exceeded deadline: 1s
+    11:55:17   ERROR     [Sleep for some amount of time] kingpin.actors.misc.Sleep._execute() execution exceeded deadline: 1s
+    11:55:17   CRITICAL  [Kingpin] kingpin.actors.misc.Macro._execute() execution exceeded deadline: 1s
+    11:55:17   CRITICAL  [Sleep for some amount of time] kingpin.actors.misc.Sleep._execute() execution exceeded deadline: 1s
+    11:55:17   ERROR     Kingpin encountered mistakes during the play.
+    11:55:17   ERROR     kingpin.actors.misc.Macro._execute() execution exceeded deadline: 1s
+
 ##### Token-replacement
 
 ###### Environmental Tokens

--- a/README.md
+++ b/README.md
@@ -254,6 +254,16 @@ with an environment variable:
     11:55:17   ERROR     Kingpin encountered mistakes during the play.
     11:55:17   ERROR     kingpin.actors.misc.Macro._execute() execution exceeded deadline: 1s
 
+*Disabling the Timeout*
+
+You can disable the timeout on any actor by setting `timeout: 0` in your JSON.
+
+*Group Actor Timeouts*
+
+Note, Group Actors are unique and have their `default_timeout` set to 0
+(_disabled_) by default. You can, of course, override this with your own
+`timeout: xx` setting in the JSON.
+
 ##### Token-replacement
 
 ###### Environmental Tokens

--- a/docs/actors/group.Async.md
+++ b/docs/actors/group.Async.md
@@ -11,6 +11,14 @@ waiting until all of them finish before returning.
     then every actor defined in `acts` will be instantiated once for each item
     in the `contexts` list.
 
+**Timeouts**
+
+Timeouts are disabled specifically in this actor. The sub-actors can still
+raise their own `ActorTimedOut` exceptions, but since the group actors run an
+arbitrary number of sub actors, we have chosen to not have this actor
+specifically raise its own `ActorTimedOut` exception unless the user sets the
+`timeout` setting.
+
 Examples
 
     # Clone two arrays quickly

--- a/docs/actors/group.Sync.md
+++ b/docs/actors/group.Sync.md
@@ -11,6 +11,14 @@ in the order that they were defined.
     then every actor defined in `acts` will be instantiated once for each item
     in the `contexts` list.
 
+**Timeouts**
+
+Timeouts are disabled specifically in this actor. The sub-actors can still
+raise their own `ActorTimedOut` exceptions, but since the group actors run an
+arbitrary number of sub actors, we have chosen to not have this actor
+specifically raise its own `ActorTimedOut` exception unless the user sets the
+`timeout` setting.
+
 Examples
 
     # Creates two arrays ... but sleeps 60 seconds between the two, then

--- a/examples/test/base/nested_sleep_timeouts.json
+++ b/examples/test/base/nested_sleep_timeouts.json
@@ -1,0 +1,22 @@
+/* This script is used to test a race condition where the outer-actor
+raises an ActorTimedOut exception moments before the inner-actor raises
+the same exception. Tornado, by default, raises an 'Exception in Future
+<...> after timeout' exception to let the user know that an exception
+was raised after the initial timeout happened. Our code works around this
+by explicitly defining ActorTimedOut as a 'quiet' exception in this case */
+{ "desc": "Outer group",
+  "actor": "group.Sync",
+  "timeout": 1,
+  "options": {
+    "acts": [
+      { "desc": "Sleep 10 seconds, but fail",
+        "actor": "misc.Sleep",
+        "timeout": 1,
+        "options": {
+          "sleep": 10
+        }
+      }
+    ]
+  }
+}
+

--- a/kingpin/actors/base.py
+++ b/kingpin/actors/base.py
@@ -53,6 +53,10 @@ __author__ = 'Matt Wise <matt@nextdoor.com>'
 if os.getenv('URLLIB_DEBUG', None):
     utils.super_httplib_debug_logging()
 
+# Allow the user to override the default_timeout for all actors by setting an
+# environment variable
+DEFAULT_TIMEOUT = os.getenv('DEFAULT_TIMEOUT', 3600)
+
 
 class LogAdapter(logging.LoggerAdapter):
 
@@ -80,7 +84,7 @@ class BaseActor(object):
 
     # Set the default timeout for the gen.with_timeout() wrapper that we use to
     # monitor and control the length of execution of a single Actor.
-    default_timeout = 3600
+    default_timeout = DEFAULT_TIMEOUT
 
     # Context separators. These define the left-and-right identifiers of a
     # 'contextual token' in the actor. By default this is { and }, so a

--- a/kingpin/actors/base.py
+++ b/kingpin/actors/base.py
@@ -293,7 +293,8 @@ class BaseActor(object):
 
         # Now we yield on the gen_with_timeout function
         try:
-            ret = yield gen.with_timeout(deadline, fut)
+            ret = yield gen.with_timeout(
+                deadline, fut, quiet_exceptions=(exceptions.ActorTimedOut))
         except gen.TimeoutError:
             msg = ('%s.%s() execution exceeded deadline: %ss' %
                    (self._type, f.__name__, self._timeout))

--- a/kingpin/actors/group.py
+++ b/kingpin/actors/group.py
@@ -36,6 +36,11 @@ class BaseGroupActor(base.BaseActor):
 
     """
 
+    # By default, group actors have no timeout. We rely on the individual
+    # actors to expire on their own. This is, of course, overrideable in the
+    # JSON.
+    default_timeout = 0
+
     all_options = {
         'contexts': (list, [], "List of contextual hashes."),
         'acts': (list, REQUIRED, "Array of actor definitions.")

--- a/kingpin/actors/misc.py
+++ b/kingpin/actors/misc.py
@@ -35,7 +35,7 @@ from kingpin.constants import REQUIRED
 
 log = logging.getLogger(__name__)
 
-__author__ = ('Matt Wise <matt@nextdoor.com>',
+__author__ = ('Matt Wise <matt@nextdoor.com>, '
               'Mikhail Simin <mikhail@nextdoor.com>')
 
 

--- a/kingpin/actors/test/test_base.py
+++ b/kingpin/actors/test/test_base.py
@@ -88,19 +88,19 @@ class TestBaseActor(testing.AsyncTestCase):
         def _execute():
             tracker.reset_mock()
             yield gen.Task(ioloop.IOLoop.current().add_timeout,
-                           time.time() + 1)
+                           time.time() + 0.2)
             tracker.call_me()
 
         self.actor._execute = _execute
 
         # Set our timeout to 2s, test should work
-        self.actor._timeout = 2
+        self.actor._timeout = 1
         yield self.actor.timeout(_execute)
         tracker.assert_has_calls(mock.call.call_me())
 
         # Now set our timeout to 500ms. Exception should be raised, and the
         # tracker should NOT be called.
-        self.actor._timeout = 0.5
+        self.actor._timeout = 0.1
         with self.assertRaises(exceptions.ActorTimedOut):
             yield self.actor.timeout(_execute)
 

--- a/kingpin/actors/test/test_base.py
+++ b/kingpin/actors/test/test_base.py
@@ -93,16 +93,23 @@ class TestBaseActor(testing.AsyncTestCase):
 
         self.actor._execute = _execute
 
-        # Set our timeout to 5s, test should work
+        # Set our timeout to 2s, test should work
         self.actor._timeout = 2
         yield self.actor.timeout(_execute)
         tracker.assert_has_calls(mock.call.call_me())
 
-        # Now set our timeout to 1s. Exception should be raised, and the
+        # Now set our timeout to 500ms. Exception should be raised, and the
         # tracker should NOT be called.
-        self.actor._timeout = 0
+        self.actor._timeout = 0.5
         with self.assertRaises(exceptions.ActorTimedOut):
             yield self.actor.timeout(_execute)
+
+        # Set the timeout to 0, which disables it. No exception should be
+        # raised
+        self.actor._timeout = 0
+        yield self.actor.timeout(_execute)
+        self.actor_timeout = None
+        yield self.actor.timeout(_execute)
 
     @testing.gen_test
     def test_httplib_debugging(self):


### PR DESCRIPTION
A few changes here to the timeouts before we release em.

  * `group.Sync`/`group.Async` actors default to *no* timeout.
  * Added `DEFAULT_TIMEOUT` as an environment variable that Kingpin will pay attention to
  * Resolved a race condition that caused extraneous logging of ActorTimedOut exceptions.