### PR TITLE
Add the @sync_retry decorator to the make_generic_request() call.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Version 0.2.5
+ * #239: Add the @sync_retry decorator to the make_generic_request() call. ([@diranged])
  * #228: Allow setting of the 'strictness' of the rightscale.server_array.Clone actor ([@diranged])
  * #227: Use a single api.RightScale object on all RightScale actors. ([@diranged])
  * #218: Allow wildcard/non-exact ServerArray matches in ServerArrayBaseActor._find_server_arrays() ([@diranged])

--- a/kingpin/actors/rightscale/api.py
+++ b/kingpin/actors/rightscale/api.py
@@ -673,6 +673,9 @@ class RightScale(object):
         raise gen.Return(yielded_tasks)
 
     @concurrent.run_on_executor
+    @sync_retry(stop_max_attempt_number=3,
+                wait_exponential_multiplier=1000,
+                wait_exponential_max=10000)
     def make_generic_request(self, url, post=None):
         """Make a generic API call and return a Resource Object.
 


### PR DESCRIPTION
This is just a safety check. If it fails, we should at least try a few
times.