### PR TITLE
Add `Rate exceeded` to retriable exceptions.

### DIFF
--- a/kingpin/actors/aws/base.py
+++ b/kingpin/actors/aws/base.py
@@ -60,10 +60,12 @@ class AWSBaseActor(base.BaseActor):
         'region': (str, None, 'AWS Region (or zone) to connect to.')
     }
 
+    # Special constant expected by @support._retry decorator
     _EXCEPTIONS = {
-        BotoServerError: {
+        BotoServerError: {  # Match the `<message>` part of the exception
             'LoadBalancerNotFound': ELBNotFound,
-            'InvalidClientTokenId': exceptions.InvalidCredentials
+            'InvalidClientTokenId': exceptions.InvalidCredentials,
+            'Rate exceeded': None
         },
     }
 

--- a/kingpin/actors/support/api.py
+++ b/kingpin/actors/support/api.py
@@ -112,8 +112,7 @@ def _retry(f):
                     pass
                 elif default_exc is not False:
                     raise default_exc(str(e))
-
-                if default_exc is False:
+                elif default_exc is False:
                     # Reaching this part means no exception was matched
                     # and no default was specified.
                     log.debug('No explicit behavior for this exception'


### PR DESCRIPTION
Close #250 (again)

* Delay in retry decorator bumped because original delay was
  insignificant enough to still end up failing