### PR TITLE
Set the default timeout for the misc.Macro actor to 0 (unlimited).

### DIFF
--- a/kingpin/actors/misc.py
+++ b/kingpin/actors/misc.py
@@ -43,6 +43,11 @@ class Macro(base.BaseActor):
 
     """Execute a kingpin JSON file."""
 
+    # By default, group actors have no timeout. We rely on the individual
+    # actors to expire on their own. This is, of course, overrideable in the
+    # JSON.
+    default_timeout = 0
+
     all_options = {
         'macro': (str, REQUIRED,
                   "Path to a Kingpin JSON file. http(s)://, file:///, "


### PR DESCRIPTION
Just like the Group actors, the Macro actor does nothing but call other
actors. Its timeout should be 0 by default.