### PR TITLE
 Clean up all AWS Actors: Use retrying.retry with common backoff settings...

### DIFF
--- a/kingpin/actors/aws/settings.py
+++ b/kingpin/actors/aws/settings.py
@@ -27,9 +27,12 @@ AWS_ACCESS_KEY_ID = os.getenv('AWS_ACCESS_KEY_ID', '')
 AWS_SECRET_ACCESS_KEY = os.getenv('AWS_SECRET_ACCESS_KEY', '')
 
 SQS_RETRY_DELAY = 30
-CF_WAIT_MAX = 30000
 
 
+# Common Settings for the retrying.retry() decorator
+#
+# Use like this: @retrying.retry(**settings.RETRYING_SETTINGS)
+#
 def is_retriable_exception(exception):
     """Return true if this AWS exception is transient and should be retried.
 
@@ -46,3 +49,27 @@ def is_retriable_exception(exception):
 
     # Boto exceptions should have a code attribute
     return exception.error_code in retry_codes
+
+
+RETRYING_SETTINGS = {
+    # Verify if we need to retry with the is_retriable_exception
+    # method described above.
+    'retry_on_exception': is_retriable_exception,
+
+    # Wait up to 10 times
+    'stop_max_attempt_number': 10,
+
+    # Add 250ms of random jitter to every retry
+    'wait_jitter_max': 250,
+
+    # Add 250ms of sleep to every retry
+    'wait_fixed': 250,
+
+    # Now add between 250-2000ms to every retry
+    'wait_random_min': 250,
+    'wait_random_max': 2000,
+
+    # Finally, add in an exponential backoff timer with a 10s limit
+    'wait_exponential_multiplier': 100,
+    'wait_exponential_max': 10000
+}

--- a/kingpin/actors/aws/test/integration_sqs.py
+++ b/kingpin/actors/aws/test/integration_sqs.py
@@ -84,7 +84,7 @@ class IntegrationSQS(testing.AsyncTestCase):
                                     'region': self.region})
 
         log.debug('New queue should be empty')
-        queue = actor.conn.get_queue(self.queue_name)
+        queue = actor.sqs_conn.get_queue(self.queue_name)
         self.assertEquals(queue.count(), 0)
 
         done = yield actor.execute()

--- a/kingpin/actors/aws/test/test_elb.py
+++ b/kingpin/actors/aws/test/test_elb.py
@@ -19,6 +19,8 @@ class TestRegisterInstance(testing.AsyncTestCase):
         super(TestRegisterInstance, self).setUp()
         settings.AWS_ACCESS_KEY_ID = 'unit-test'
         settings.AWS_SECRET_ACCESS_KEY = 'unit-test'
+        settings.RETRYING_SETTINGS = {'stop_max_attempt_number': 1}
+        reload(elb_actor)
 
     @testing.gen_test
     def test_add(self):
@@ -135,6 +137,8 @@ class TestDeregisterInstance(testing.AsyncTestCase):
         super(TestDeregisterInstance, self).setUp()
         settings.AWS_ACCESS_KEY_ID = 'unit-test'
         settings.AWS_SECRET_ACCESS_KEY = 'unit-test'
+        settings.RETRYING_SETTINGS = {'stop_max_attempt_number': 1}
+        reload(elb_actor)
 
     @testing.gen_test
     def test_remove(self):
@@ -209,6 +213,8 @@ class TestWaitUntilHealthy(testing.AsyncTestCase):
         super(TestWaitUntilHealthy, self).setUp()
         settings.AWS_ACCESS_KEY_ID = 'unit-test'
         settings.AWS_SECRET_ACCESS_KEY = 'unit-test'
+        settings.RETRYING_SETTINGS = {'stop_max_attempt_number': 1}
+        reload(elb_actor)
 
     @testing.gen_test
     def test_require_env(self):
@@ -281,7 +287,7 @@ class TestWaitUntilHealthy(testing.AsyncTestCase):
     def test_execute_fail(self):
 
         actor = elb_actor.WaitUntilHealthy(
-            'Unit Test ACtion', {'name': 'unit-test-queue',
+            'Unit Test Action', {'name': 'unit-test-queue',
                                  'region': 'us-west-2',
                                  'count': 7})
         # ELB not found...
@@ -326,6 +332,8 @@ class TestSetCert(testing.AsyncTestCase):
         super(TestSetCert, self).setUp()
         settings.AWS_ACCESS_KEY_ID = 'unit-test'
         settings.AWS_SECRET_ACCESS_KEY = 'unit-test'
+        settings.RETRYING_SETTINGS = {'stop_max_attempt_number': 1}
+        reload(elb_actor)
 
     @testing.gen_test
     def test_check_access(self):


### PR DESCRIPTION
....

The AWS API is pretty sensitive when it comes to hammering it with
requests. We had all kinds of different retry logic in our code here as
we worked to deal with that.

This change wipes out all of that logic and puts it into a single
location -- the AWSBaseActor.thread() method. This provides us a single
common location to handle retrying. With this, we no longer use the
kingpin.actors.support.api._retry() method (which was sort of abused
here anyways).

The retrying logic is described in the kingpin.actors.aws.settings
module ... but has significant jitter, randomness, and exponential
backoffs applied.