### PR TITLE
Handle RightScales concept of 'array values'.

### DIFF
--- a/docs/actors/rightscale.server_array.Update.md
+++ b/docs/actors/rightscale.server_array.Update.md
@@ -27,7 +27,11 @@ Examples
           "elasticity_params": {
             "bounds": {
               "min_count": 4
-            }
+            },
+            "schedule": [
+              {"day": "Sunday", "max_count": 2, "min_count": 1, :"time": "07:00" },
+              {"day": "Sunday", "max_count": 2, "min_count": 2, :"time": "09:00" }
+            ]
           },
           "name": "my-really-new-name"
         }

--- a/kingpin/actors/rightscale/server_array.py
+++ b/kingpin/actors/rightscale/server_array.py
@@ -296,10 +296,12 @@ class Update(ServerArrayBaseActor):
         try:
             yield self._client.update_server_array(array, self._params)
         except requests.exceptions.HTTPError as e:
-            if e.response.status_code == 422:
+            if e.response.status_code in (422, 400):
                 msg = ('Invalid parameters supplied to patch array "%s"' %
                        self.option('array'))
                 raise exceptions.RecoverableActorFailure(msg)
+
+            raise
 
         raise gen.Return()
 

--- a/kingpin/actors/rightscale/test/integration_server_array.py
+++ b/kingpin/actors/rightscale/test/integration_server_array.py
@@ -145,7 +145,7 @@ class IntegrationServerArray(testing.AsyncTestCase):
 
     @attr('integration')
     @testing.gen_test(timeout=10)
-    def integration_04c_update_with_invalid_params(self):
+    def integration_04c_update_with_invalid_params_422(self):
         actor = server_array.Update(
             'Update %s' % self.clone_name,
             {'array': self.clone_name,
@@ -156,8 +156,23 @@ class IntegrationServerArray(testing.AsyncTestCase):
             yield actor.execute()
 
     @attr('integration')
+    @testing.gen_test(timeout=10)
+    def integration_04d_update_with_invalid_params_400(self):
+        actor = server_array.Update(
+            'Update %s' % self.clone_name,
+            {'array': self.clone_name,
+             'params': {
+                 'elasticity_params': {
+                     'schedule': [
+                         # Note the 'time' field is missing the :
+                         {'day': 'Sunday', 'min_count': '1',
+                          'max_count': '1', 'time': '0700'}]}}})
+        with self.assertRaises(exceptions.RecoverableActorFailure):
+            yield actor.execute()
+
+    @attr('integration')
     @testing.gen_test(timeout=60)
-    def integration_04d_update_missing_array(self):
+    def integration_04e_update_missing_array(self):
         # Patch the array with some new min_instance settings, then launch it
         actor = server_array.Update(
             'Update missing array',

--- a/kingpin/actors/rightscale/test/test_base.py
+++ b/kingpin/actors/rightscale/test/test_base.py
@@ -57,13 +57,52 @@ class TestRightScaleBaseActor(testing.AsyncTestCase):
                       'bounds': {
                           'min_count': 3,
                           'max_count': 10}}}
-        expected_params = {
-            'server_array[status]': 'enabled',
-            'server_array[name]': 'unittest-name',
-            'server_array[elasticity_params][bounds][max_count]': 10,
-            'server_array[elasticity_params][bounds][min_count]': 3}
+        expected_params = [
+            ('server_array[status]', 'enabled'),
+            ('server_array[name]', 'unittest-name'),
+            ('server_array[elasticity_params][bounds][max_count]', 10),
+            ('server_array[elasticity_params][bounds][min_count]', 3)]
 
         actor = base.RightScaleBaseActor('Unit Test Action', {})
         ret = actor._generate_rightscale_params('server_array', params)
 
-        self.assertEquals(expected_params, ret)
+        self.assertItemsEqual(expected_params, ret)
+
+    def test_generate_rightscale_params_with_array(self):
+        self.maxDiff = None
+        params = {'name': 'unittest-name',
+                  'status': 'enabled',
+                  'elasticity_params': {
+                      'schedule': [
+                          {'day': 'Sunday', 'max_count': 2,
+                           'min_count': 1, 'time': '07:00'},
+                          {'day': 'Monday', 'max_count': 2,
+                           'min_count': 1, 'time': '07:00'},
+                          {'day': 'Tuesday', 'max_count': 2,
+                           'min_count': 1, 'time': '07:00'}
+                      ]
+                  }}
+        expected_params = [
+            ('server_array[status]', 'enabled'),
+            ('server_array[name]', 'unittest-name'),
+
+            ('server_array[elasticity_params][schedule][][day]', 'Sunday'),
+            ('server_array[elasticity_params][schedule][][max_count]', 2),
+            ('server_array[elasticity_params][schedule][][min_count]', 1),
+            ('server_array[elasticity_params][schedule][][time]', '07:00'),
+
+            ('server_array[elasticity_params][schedule][][day]', 'Monday'),
+            ('server_array[elasticity_params][schedule][][max_count]', 2),
+            ('server_array[elasticity_params][schedule][][min_count]', 1),
+            ('server_array[elasticity_params][schedule][][time]', '07:00'),
+
+            ('server_array[elasticity_params][schedule][][day]', 'Tuesday'),
+            ('server_array[elasticity_params][schedule][][max_count]', 2),
+            ('server_array[elasticity_params][schedule][][min_count]', 1),
+            ('server_array[elasticity_params][schedule][][time]', '07:00')
+        ]
+
+        actor = base.RightScaleBaseActor('Unit Test Action', {})
+        ret = actor._generate_rightscale_params('server_array', params)
+
+        self.assertItemsEqual(expected_params, ret)


### PR DESCRIPTION
Per
http://reference.rightscale.com/api1.5/resources/ResourceServerArrays.html#create_parameters,
and
http://support.rightscale.com/12-Guides/RightScale_API_1.5/1_Overview/Parameters/index.html:

RightScale has a concept of input 'arrays' that are passed in as funny
looking key=value pairs. For example, passing in a schedule for
AutoScaling an array in RightScale looks like this:

  server_array[elasticity_params][schedule][][min_count]=1
  server_array[elasticity_params][schedule][][day]=Sunday
  server_array[elasticity_params][schedule][][max_count]=2
  server_array[elasticity_params][schedule][][time]=0700

  server_array[elasticity_params][schedule][][max_count]=2
  server_array[elasticity_params][schedule][][day]=Monday
  server_array[elasticity_params][schedule][][min_count]=1
  server_array[elasticity_params][schedule][][time]=0700

It should be noted that order only partially matters here. As long as
each group of 'day', 'max_count', 'min_count' and 'time' values are put
together, the specific order they are in does not matter. Note the
difference between the first 4 items and the second 4 items in the list
above.

This is extremely un-intuitive, but appears to be the way RightScale
works.