### PR TITLE
Allow contexts to be stored in a separate file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,34 @@ ability to define usable tokens, but any actor can then reference these tokens.
     2015-01-14 15:02:22,165 INFO      [DRY: Notify Engineering] Sending message "Hey room .. I'm done with the release. Get back to work" to Hipchat room "Engineering"
     2015-01-14 15:02:22,239 INFO      [DRY: Notify Cust Service] Sending message "Hey room .. I'm done with the release. Have a nice day" to Hipchat room "Cust Service"
 
+*Contextual tokens stored in separate file*
+
+When multiple kingping json files need to leverage the same context for different purposes it is useful to put the contexts into a stand alone file and then reference that file.
+
+    /* kingpin.json */
+    { "desc": "Send ending notifications...",
+      "actor": "group.Async",
+      "options": {
+        "context-file": "data/notification-rooms.json",
+        "acts": [
+          { "desc": "Notify {ROOM}",
+            "actor": "hipchat.Message",
+            "options": {
+                "room": "{ROOM}",
+                "message": "Hey room .. I'm done with the release. {WISDOM}"
+            }
+          }
+        ]
+      }
+    }
+
+    /* data/notification-rooms.json */
+    [
+      { "ROOM": "Engineering", "WISDOM": "Get back to work" },
+      { "ROOM": "Cust Service", "WISDOM": "Have a nice day" }
+    ]
+
+This refactoring will yield in the same result as the above example.
 
 ##### Early Actor Instantiation
 

--- a/docs/actors/group.Async.md
+++ b/docs/actors/group.Async.md
@@ -6,6 +6,7 @@ waiting until all of them finish before returning.
 **Options**
 
   * `acts` - An array of individual Actor definitions.
+  * `context-file` - path to a file containing a list of dictionaries.
   * `contexts` - A list of dictionaries with _contextual tokens_ to pass into
     the actors at instantiation time. If the list has more than one element,
     then every actor defined in `acts` will be instantiated once for each item

--- a/docs/actors/group.Sync.md
+++ b/docs/actors/group.Sync.md
@@ -6,6 +6,7 @@ in the order that they were defined.
 **Options**
 
   * `acts` - An array of individual Actor definitions.
+  * `context-file` - path to a file containing a list of dictionaries.
   * `contexts` - A list of dictionaries with _contextual tokens_ to pass into
     the actors at instantiation time. If the list has more than one element,
     then every actor defined in `acts` will be instantiated once for each item

--- a/examples/test/context.json
+++ b/examples/test/context.json
@@ -1,0 +1,6 @@
+/* A file of contexts to be used in an actor 
+   as an option `contexts-file`. */
+[
+  {'key': 'value1'},
+  {'key': 'value2'}
+]

--- a/examples/test/context.json
+++ b/examples/test/context.json
@@ -1,6 +1,6 @@
 /* A file of contexts to be used in an actor 
    as an option `contexts-file`. */
 [
-  {'key': 'value1'},
-  {'key': 'value2'}
+  {"key": "value1"},
+  {"key": "value2"}
 ]

--- a/kingpin/actors/test/test_group.py
+++ b/kingpin/actors/test/test_group.py
@@ -87,6 +87,23 @@ class TestBaseGroupActor(TestGroupActorBaseClass):
         ret = actor._build_actions()
         self.assertEquals(4, len(ret))
 
+    def test_build_actions_with_context_file(self):
+        acts = [dict(self.actor_returns)]
+
+        with mock.patch.object(group.BaseGroupActor,
+                               '_build_action_group') as action_builder:
+            action_builder.return_value = acts
+            group.BaseGroupActor(
+                'ContextFile Actor',
+                {'acts': acts, 'context-file': 'examples/test/context.json'},
+                init_context={'init': 'stuff'})
+
+        self.assertEquals(2, len(action_builder.mock_calls))
+        action_builder.assert_has_calls([
+            mock.call(context={'init': 'stuff', 'key': 'value1'}),
+            mock.call(context={'init': 'stuff', 'key': 'value2'})
+        ])
+
     def test_build_actions_with_contexts(self):
         acts = [dict(self.actor_returns),
                 dict(self.actor_returns),


### PR DESCRIPTION
This change allows putting a list of ELBs / Arrays that we operate on into a separate file -- so that various script files can have a single source of information.

cc: @diranged @bemsha 