### PR TITLE
Disable the cross-actor RightScale API Object sharing.

### DIFF
--- a/kingpin/actors/rightscale/base.py
+++ b/kingpin/actors/rightscale/base.py
@@ -35,8 +35,6 @@ class RightScaleBaseActor(base.BaseActor):
 
     """Abstract class for creating RightScale cloud actors."""
 
-    CLIENTS = {}
-
     def __init__(self, *args, **kwargs):
         """Initializes the Actor."""
         super(RightScaleBaseActor, self).__init__(*args, **kwargs)
@@ -45,30 +43,7 @@ class RightScaleBaseActor(base.BaseActor):
             raise exceptions.InvalidCredentials(
                 'Missing the "RIGHTSCALE_TOKEN" environment variable.')
 
-        self._client = self._get_client(TOKEN, ENDPOINT)
-
-    def _get_client(self, token, endpoint):
-        """Returns an api.RightScale() object.
-
-        Returns either an already-configured api.RightScale() object from the
-        class-level self.CLIENT dict, or generates a new one, stores it, and
-        returns it.
-
-        We use this struture to ensure that no matter how many RightScale
-        Actors we have, we use a single API object for every "set of unique
-        credentials" that we have (TOKEN/ENDPOINT combination).
-
-        args:
-            token: RightScale API Refresh Token
-            endpoint: RightScale API Endpoint
-        """
-        key = "%s_%s" % (token, endpoint)
-        if key not in self.CLIENTS:
-            self.CLIENTS[key] = api.RightScale(token=token, endpoint=endpoint)
-            self.log.debug('Generating new client: %s' % self.CLIENTS[key])
-
-        self.log.debug('Returning client: %s' % self.CLIENTS[key])
-        return self.CLIENTS[key]
+        self._client = api.RightScale(token=TOKEN, endpoint=ENDPOINT)
 
     def _generate_rightscale_params(self, prefix, params):
         """Utility function for creating RightScale-style parameters.

--- a/kingpin/actors/rightscale/test/test_base.py
+++ b/kingpin/actors/rightscale/test/test_base.py
@@ -15,26 +15,6 @@ class TestRightScaleBaseActor(testing.AsyncTestCase):
         super(TestRightScaleBaseActor, self).setUp()
         base.TOKEN = 'unittest'
 
-    def test_get_client_returns_same(self):
-        actor = base.RightScaleBaseActor('Unit Test Action', {})
-        fresh_client = actor._get_client('token', 'endpoint')
-        new_client = actor._get_client('token', 'endpoint')
-        self.assertEquals(fresh_client, new_client)
-
-    def test_get_client_returns_same_cross_actors(self):
-        actor1 = base.RightScaleBaseActor('Unit Test Action', {})
-        actor2 = base.RightScaleBaseActor('Unit Test Action', {})
-
-        client1 = actor1._get_client('token', 'endpoint')
-        client2 = actor2._get_client('token', 'endpoint')
-        self.assertEquals(client1, client2)
-
-    def test_get_client_returns_unique(self):
-        actor = base.RightScaleBaseActor('Unit Test Action', {})
-        fresh_client = actor._get_client('token', 'endpoint')
-        new_client = actor._get_client('token2', 'endpoint')
-        self.assertNotEquals(fresh_client, new_client)
-
     @testing.gen_test
     def test_init_without_environment_creds(self):
         # Un-set the token and make sure the init fails


### PR DESCRIPTION
The python-rightscale library is supposed to
(https://github.com/brantai/python-rightscale/commit/2a8c0f572c4b13de03cbf67a1253c135b45ff2ca)
honor the RightScale OAUTH2 token expiration date and generate a new
token when it expires. This code worked when I wrote it and individually
tested it inside the confines of that library itself.

However, we are still seeing cases where extremely long running
processes in Kingpin will hit a 403 error from RightSCale roughly 2
hours after the initial OAUTH token was created. Given the complexity of
firing off all of our API calls into little mini threads everywhere, I'm
concerned that there is some kind of non-thread-safe code issue here.

To simplify things, I'm removing the cross-actor RightScale API object
sharing. Each actor will instantiate its own RightScale API object and
that object will get its own fresh OAUTH token. At the bare minimum this
means that the 2-hour timeout applies to each individual actor, rather
than the entire execution of the Kingpin script.

The long term fix here is likely to write a fresh API client for
RightScale based on our kingpin.actors.support.api module.