### PR TITLE
New Actor: rightscale.server_array.UpdateNextInstance

### DIFF
--- a/kingpin/actors/rightscale/test/integration_server_array.py
+++ b/kingpin/actors/rightscale/test/integration_server_array.py
@@ -185,6 +185,20 @@ class IntegrationServerArray(testing.AsyncTestCase):
         with self.assertRaises(exceptions.RecoverableActorFailure):
             yield actor.execute()
 
+    @attr('integration')
+    @testing.gen_test(timeout=60)
+    def integration_04f_update_next_instance(self):
+        # This is a quick test. It executes a long path of code to find the
+        # 'default AMI image' for the ServerTemplate of the cloned array, and
+        # then just sets the 'image_href' setting to that HREF. Basically its a
+        # no-op, but it executes a ton of API calls which we want to test.
+        actor = server_array.UpdateNextInstance(
+            'Update %s' % self.clone_name,
+            {'array': self.clone_name,
+             'params': {'image_href': 'default'}})
+
+        yield actor.execute()
+
     @attr('integration', 'dry')
     @testing.gen_test(timeout=30)
     def integration_05a_launch_dry(self):

--- a/kingpin/actors/rightscale/test/test_api.py
+++ b/kingpin/actors/rightscale/test/test_api.py
@@ -66,6 +66,13 @@ class TestRightScale(testing.AsyncTestCase):
             self.assertEquals(None, ret)
 
     @testing.gen_test
+    def test_show(self):
+        mock_rsr = mock.MagicMock(name='resource')
+        mock_rsr.show.return_value = 1
+        ret = yield self.client.show(mock_rsr)
+        self.assertEquals(1, ret)
+
+    @testing.gen_test
     def test_find_cookbook(self):
         self.client._client = mock.Mock()
         resource = mock.Mock(name='Resource')
@@ -177,14 +184,14 @@ class TestRightScale(testing.AsyncTestCase):
         self.assertEquals(None, ret)
 
     @testing.gen_test
-    def test_update_server_array(self):
+    def test_update(self):
         # Create a mock and the params we're going to pass in
         sa_mock = mock.MagicMock()
         sa_mock.self.update.return_value = True
         sa_mock.self.show.return_value = 'test'
         params = {'server_array[name]': 'new_name'}
 
-        ret = yield self.client.update_server_array(sa_mock, params)
+        ret = yield self.client.update(sa_mock, params)
         sa_mock.self.update.assert_called_once_with(params=params)
 
         self.assertEquals(ret, 'test')
@@ -199,7 +206,7 @@ class TestRightScale(testing.AsyncTestCase):
             array.next_instance.show().inputs.index())
 
     @testing.gen_test
-    def test_update_server_array_inputs(self):
+    def test_update_inputs(self):
         ni_mock = mock.MagicMock(name='next_instance')
         ni_mock.inputs.multi_update.return_value = None
         sa_mock = mock.MagicMock(name='server_array')


### PR DESCRIPTION
Sometimes you want to update the 'Next Instance' settings of a
RightScale Array -- these include things like the Server Template, IP
Association settings, AMI Image HREFs and more.

This actor searches for your ServerArray, grabs its 'Next Instance'
object, and then updates that object with the parameters you've passed
in.

Additionally, a custom helper has been added so that if you use
'default' as your 'image_href', we automatically discover the default
AMI image for your MCI and associate that image_href for you.

CC: @siminm