### PR TITLE
Use a 120s timeout when interacting with PackageCloud

### DIFF
--- a/kingpin/actors/packagecloud.py
+++ b/kingpin/actors/packagecloud.py
@@ -89,7 +89,7 @@ class PackagecloudBase(base.BaseActor):
             raise exceptions.InvalidCredentials(
                 'Missing the "PACKAGECLOUD_TOKEN" environment variable.')
 
-        rest_client = api.RestClient()
+        rest_client = api.RestClient(timeout=120)
         self._packagecloud_client = PackagecloudAPI(client=rest_client)
 
     @gen.coroutine


### PR DESCRIPTION
Without this, Tornado defaults to a `20s` timeout and then throws a 599 error on its own. The PackageCloud API sometimes takes a while to respond if you're asking for a ton of data.