### PR TITLE
Make rightscale.api.find_by_name_and_keys() return only a list or a s…

### DIFF
--- a/kingpin/actors/rightscale/api.py
+++ b/kingpin/actors/rightscale/api.py
@@ -243,7 +243,7 @@ class RightScale(object):
             **kwargs: Any additional keys-and-values to use in the search.
 
         Returns:
-            RightScale Resource Objects
+            One RightScale Resource Object or a List of objects.
         """
         filter_keys = []
         for key, val in kwargs.items():
@@ -255,7 +255,7 @@ class RightScale(object):
             return found
 
         if len(found) < 1:
-            return None
+            return []
 
         if len(found) == 1:
             return found[0]

--- a/kingpin/actors/rightscale/mci.py
+++ b/kingpin/actors/rightscale/mci.py
@@ -44,7 +44,7 @@ class Create(MCIBaseActor):
     """Creates a RightScale Multi Cloud Image.
 
     Options match the documentation in RightScale:
-    http://reference.rightscale.com/api1.5/resources/ResourceDeployments.html
+    http://reference.rightscale.com/api1.5/resources/ResourceMultiCloudImages.html
 
     **Options**
 

--- a/kingpin/actors/rightscale/test/test_api.py
+++ b/kingpin/actors/rightscale/test/test_api.py
@@ -116,7 +116,7 @@ class TestRightScale(testing.AsyncTestCase):
         ret = yield self.client.find_by_name_and_keys(
             collection=mock.MagicMock(), exact=True,
             name='FakeResource', href='/123')
-        self.assertEquals(ret, None)
+        self.assertEquals(ret, [])
 
         # Now create a fake Rightscale resource collection object.
         collection = mock.MagicMock(name='collection')


### PR DESCRIPTION
…ingle object.

Instead of returning None, return an empty list. This is more consistent
with the way the original stolen method works anyways.