### PR TITLE
Take in Kingpin actor definition on the commandline

### DIFF
--- a/docs/basicuse.rst
+++ b/docs/basicuse.rst
@@ -386,3 +386,36 @@ Early Actor Instantiation
 Again, in an effort to prevent mid-run errors, we pre-instantiate all Actor
 objects all at once before we ever begin executing code. This ensures that
 major typos or misconfigurations in the JSON will be caught early on.
+
+Command-line Execution without JSON
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For the simple case of executing a single actor without too many options, you
+are able to pass these options in on the commandline to avoid writing any JSON.
+
+.. code-block:: bash
+
+    $ kingpin --actor misc.Sleep --param warn_on_failure=true --option sleep=5
+    17:54:53   INFO      Rehearsing... Break a leg!
+    17:54:53   INFO      [DRY: Kingpin] Preparing actors from {"actor":"misc.Sleep","desc":"Commandline Execution","options":{"sleep":"5"},"warn_on_failure":"true"}
+    17:54:53   INFO      Rehearsal OK! Performing!
+    17:54:53   INFO      [Kingpin] Preparing actors from {"actor":"misc.Sleep","desc":"Commandline Execution","options":{"sleep":"5"},"warn_on_failure":"true"}
+    17:54:53   INFO
+    17:54:53   WARNING   Lights, camera ... action!
+    17:54:53   INFO
+
+You can stack as many ``--option`` and `--param`` command line options as you wish.
+
+.. code-block:: bash
+
+    $ kingpin --actor misc.Sleep --param warn_on_failure=true --param condition=false --option "sleep=0.1"
+    17:59:46   INFO      Rehearsing... Break a leg!
+    17:59:46   INFO      [DRY: Kingpin] Preparing actors from {"actor":"misc.Sleep","condition":"false","desc":"Commandline Execution","options":{"sleep":"0.1"},"warn_on_failure":"true"}
+    17:59:46   WARNING   [DRY: Commandline Execution] Skipping execution. Condition: false
+    17:59:46   INFO      Rehearsal OK! Performing!
+    17:59:46   INFO      [Kingpin] Preparing actors from {"actor":"misc.Sleep","condition":"false","desc":"Commandline Execution","options":{"sleep":"0.1"},"warn_on_failure":"true"}
+    17:59:46   INFO
+    17:59:46   WARNING   Lights, camera ... action!
+    17:59:46   INFO
+    17:59:46   WARNING   [Commandline Execution] Skipping execution. Condition: false
+

--- a/kingpin/actors/misc.py
+++ b/kingpin/actors/misc.py
@@ -166,6 +166,12 @@ class Macro(base.BaseActor):
         open the local file and return a buffer to that file.
         """
 
+        if self.option('macro').startswith('{'):
+            buf = StringIO.StringIO()
+            buf.write(self.option('macro'))
+            buf.seek(0)
+            return buf
+
         remote = ('http://', 'https://')
         if self.option('macro').startswith(remote):
             client = httpclient.HTTPClient()

--- a/kingpin/actors/test/test_misc.py
+++ b/kingpin/actors/test/test_misc.py
@@ -38,6 +38,17 @@ class TestMacro(testing.AsyncTestCase):
             self.assertEquals(schema_validate.call_count, 1)
             self.assertEquals(actor.initial_actor, get_actor())
 
+    def test_init_raw_json(self):
+        json_script = ('{"desc": "",'
+                       ' "actor": "misc.Sleep",'
+                       ' "options": {"sleep": 0.1}}')
+        misc.Macro._get_config_from_json = mock.Mock()
+        misc.Macro._check_schema = mock.Mock()
+        with mock.patch('kingpin.actors.utils.get_actor'):
+            with mock.patch.object(httpclient.HTTPClient, 'fetch'):
+                misc.Macro('Unit Test', {'macro': json_script,
+                                         'tokens': {}})
+
     def test_init_remote(self):
         misc.Macro._get_config_from_json = mock.Mock()
         misc.Macro._check_schema = mock.Mock()

--- a/kingpin/bin/deploy.py
+++ b/kingpin/bin/deploy.py
@@ -15,7 +15,7 @@
 """CLI Script Runner for Kingpin."""
 
 import logging
-import optparse
+import argparse
 import os
 import sys
 
@@ -24,6 +24,7 @@ from tornado import ioloop
 
 from kingpin import utils
 from kingpin.actors import exceptions as actor_exceptions
+from kingpin.actors import utils as actor_utils
 from kingpin.actors.misc import Macro
 from kingpin.version import __version__
 
@@ -38,26 +39,30 @@ __author__ = 'Matt Wise (matt@nextdoor.com)'
 logging.getLogger('boto').setLevel(logging.CRITICAL)
 
 # Initial option handler to set up the basic application environment.
-usage = 'usage: %prog [json file] <options>'
-parser = optparse.OptionParser(usage=usage, version=__version__,
-                               add_help_option=True)
+parser = argparse.ArgumentParser(description='Kingpin v%s' % __version__)
 parser.set_defaults(verbose=True)
 
 # Job Configuration
-parser.add_option('-j', '--json', dest='json',
-                  help='Path to JSON Deployment File')
-parser.add_option('-d', '--dry', dest='dry', action='store_true',
-                  help='Executes a dry run only.')
+parser.add_argument('-j', '--json', dest='json',
+                    help='Path to JSON Deployment File')
+parser.add_argument('-a', '--actor', dest='actor',
+                    help='Name of an Actor to execute (overrides --json)')
+parser.add_argument('-p', '--param', dest='params', action='append',
+                    help='Actor Parameter to set (ie, warn_on_failure=true)')
+parser.add_argument('-o', '--option', dest='options', action='append',
+                    help='Actor Options to set (ie, elb_name=foobar)')
+parser.add_argument('-d', '--dry', dest='dry', action='store_true',
+                    help='Executes a dry run only.')
 
 # Logging Configuration
-parser.add_option('-l', '--level', dest='level', default='info',
-                  help='Set logging level (INFO|WARN|DEBUG|ERROR)')
-parser.add_option('', '--debug', dest='level_debug', default=False,
-                  action='store_true', help='Equivalent to --level=DEBUG')
-parser.add_option('-c', '--color', dest='color', default=False,
-                  action='store_true', help='Colorize the log output')
+parser.add_argument('-l', '--level', dest='level', default='info',
+                    help='Set logging level (INFO|WARN|DEBUG|ERROR)')
+parser.add_argument('-D', '--debug', dest='level_debug', default=False,
+                    action='store_true', help='Equivalent to --level=DEBUG')
+parser.add_argument('-c', '--color', dest='color', default=False,
+                    action='store_true', help='Colorize the log output')
 
-(options, args) = parser.parse_args()
+args = parser.parse_args()
 
 
 def kingpin_fail(message):
@@ -71,25 +76,33 @@ def main():
 
     env_tokens = dict(os.environ)
 
-    try:
-        json_file = options.json or sys.argv[1] if sys.argv else None
-    except Exception as e:
-        kingpin_fail(
-            '%s You must specify --json or provide it as first argument.' % e)
+    # Sanity check - did the user supply both a JSON script && an individual
+    # actor? If so, print the help!
+    if args.json and args.actor:
+        kingpin_fail('You may only specify --actor or --json, not both!')
 
+    if args.actor:
+        json_file = utils.get_script_from_args(args)
+    else:
+        try:
+            json_file = args.json or sys.argv[1] if sys.argv else None
+        except Exception as e:
+            kingpin_fail(
+                '%s You must specify --json or provide it as first argument.' % e)
     # Begin doing real stuff!
     if os.environ.get('SKIP_DRY', False):
         log.warn('')
         log.warn('*** You have disabled the dry run.')
         log.warn('*** Execution will begin with no expectation of success.')
         log.warn('')
-    elif not options.dry:
+    elif not args.dry:
         log.info('Rehearsing... Break a leg!')
         try:
             dry_actor = Macro(desc='Kingpin',
                               options={'macro': json_file,
                                        'tokens': env_tokens},
                               dry=True)
+
             yield dry_actor.execute()
         except actor_exceptions.ActorException as e:
             log.critical('Dry run failed. Reason:')
@@ -102,7 +115,8 @@ def main():
         runner = Macro(desc='Kingpin',
                        options={'macro': json_file,
                                 'tokens': env_tokens},
-                       dry=options.dry)
+                       dry=args.dry)
+
         log.info('')
         log.warn('Lights, camera ... action!')
         log.info('')
@@ -115,9 +129,9 @@ def main():
 
 def begin():
     # Set up logging before we do anything else
-    if options.level_debug:
-        options.level = 'DEBUG'
-    utils.setup_root_logger(level=options.level, color=options.color)
+    if args.level_debug:
+        args.level = 'DEBUG'
+    utils.setup_root_logger(level=args.level, color=args.color)
 
     try:
         ioloop.IOLoop.instance().run_sync(main)

--- a/kingpin/bin/deploy.py
+++ b/kingpin/bin/deploy.py
@@ -24,7 +24,6 @@ from tornado import ioloop
 
 from kingpin import utils
 from kingpin.actors import exceptions as actor_exceptions
-from kingpin.actors import utils as actor_utils
 from kingpin.actors.misc import Macro
 from kingpin.version import __version__
 
@@ -88,7 +87,8 @@ def main():
             json_file = args.json or sys.argv[1] if sys.argv else None
         except Exception as e:
             kingpin_fail(
-                '%s You must specify --json or provide it as first argument.' % e)
+                '%s You must specify --json or provide it as first argument.'
+                % e)
     # Begin doing real stuff!
     if os.environ.get('SKIP_DRY', False):
         log.warn('')

--- a/kingpin/schema.py
+++ b/kingpin/schema.py
@@ -51,7 +51,7 @@ SCHEMA_1_0 = {
         },
 
         # Not required. In code, will default to False.
-        'warn_on_failure': {'type': 'boolean'},
+        'warn_on_failure': {'type': ['boolean', 'string']},
 
         # Not required. In code, will default to <actor>.default_timeout
         'timeout': {'type': ['string', 'integer', 'number']},

--- a/kingpin/test/test_utils.py
+++ b/kingpin/test/test_utils.py
@@ -1,3 +1,4 @@
+import demjson
 import StringIO
 import logging
 import os
@@ -99,6 +100,20 @@ class TestUtils(unittest.TestCase):
 
         with self.assertRaises(Exception):
             raises_exc()
+
+    def test_get_script_from_args(self):
+        fake_args = mock.MagicMock('args')
+        fake_args.actor = 'FakeActor'
+        fake_args.params = ['key=value', 'key2=value2']
+        fake_args.options = ['key=value', 'key2=value2']
+
+        res = demjson.decode(utils.get_script_from_args(fake_args))
+
+        self.assertEquals(res['actor'], 'FakeActor')
+        self.assertEquals(res['key'], 'value')
+        self.assertEquals(res['key2'], 'value2')
+        self.assertEquals(res['options']['key'], 'value')
+        self.assertEquals(res['options']['key2'], 'value2')
 
 
 class TestSetupRootLoggerUtils(unittest.TestCase):

--- a/kingpin/test/test_utils.py
+++ b/kingpin/test/test_utils.py
@@ -12,6 +12,7 @@ import rainbow_logging_handler
 import requests
 
 from kingpin import utils
+from kingpin import exceptions
 
 
 class TestUtils(unittest.TestCase):
@@ -114,6 +115,14 @@ class TestUtils(unittest.TestCase):
         self.assertEquals(res['key2'], 'value2')
         self.assertEquals(res['options']['key'], 'value')
         self.assertEquals(res['options']['key2'], 'value2')
+
+    def test_get_script_from_args_bad_input(self):
+        fake_args = mock.MagicMock('args')
+        fake_args.actor = 'FakeActor'
+        fake_args.params = ['keyvalue']
+
+        with self.assertRaises(exceptions.InvalidJSON):
+            demjson.decode(utils.get_script_from_args(fake_args))
 
 
 class TestSetupRootLoggerUtils(unittest.TestCase):

--- a/kingpin/utils.py
+++ b/kingpin/utils.py
@@ -35,6 +35,8 @@ from tornado import ioloop
 import httplib
 import rainbow_logging_handler
 
+from kingpin import exceptions
+
 __author__ = 'Matt Wise (matt@nextdoor.com)'
 
 log = logging.getLogger(__name__)
@@ -399,15 +401,19 @@ def get_script_from_args(args):
         'options': {}
     }
 
-    if args.params:
-        for arg in args.params:
-            (key, val) = arg.split('=')
-            config[key] = val
+    try:
+        if args.params:
+            for arg in args.params:
+                (key, val) = arg.split('=')
+                config[key] = val
 
-    if args.options:
-        for arg in args.options:
-            (key, val) = arg.split('=')
-            config['options'][key] = val
+        if args.options:
+            for arg in args.options:
+                (key, val) = arg.split('=')
+                config['options'][key] = val
 
+    except ValueError:
+        raise exceptions.InvalidJSON(
+            'All arguments and parameters must be in the form of key=value')
     log.debug('Generated config object: %s' % config)
     return demjson.encode(config)

--- a/kingpin/utils.py
+++ b/kingpin/utils.py
@@ -388,6 +388,9 @@ def get_script_from_args(args):
 
     Args:
         args: The ArgumentParser object
+
+    Returns:
+        A JSON-formatted Kingpin script.
     """
     log.debug('Generating a JSON-script from an ArgumentParser object')
     config = {
@@ -407,4 +410,4 @@ def get_script_from_args(args):
             config['options'][key] = val
 
     log.debug('Generated config object: %s' % config)
-    return str(config)
+    return demjson.encode(config)

--- a/kingpin/utils.py
+++ b/kingpin/utils.py
@@ -381,3 +381,30 @@ def create_repeating_log(logger, message, handle=None, **kwargs):
 def clear_repeating_log(handle):
     """Stops the timeout function from being called."""
     ioloop.IOLoop.current().remove_timeout(handle.timeout_id)
+
+
+def get_script_from_args(args):
+    """Creates a proper Kingpin script from the CLI options.
+
+    Args:
+        args: The ArgumentParser object
+    """
+    log.debug('Generating a JSON-script from an ArgumentParser object')
+    config = {
+        'desc': 'Commandline Execution',
+        'actor': args.actor,
+        'options': {}
+    }
+
+    if args.params:
+        for arg in args.params:
+            (key, val) = arg.split('=')
+            config[key] = val
+
+    if args.options:
+        for arg in args.options:
+            (key, val) = arg.split('=')
+            config['options'][key] = val
+
+    log.debug('Generated config object: %s' % config)
+    return str(config)


### PR DESCRIPTION
@siminm, this is a wip .. but whatcha think so far? Basically I want us to be able to easily run simple actors on the commandline without generating JSON.

```
(.venv)Matts-MacBook:kingpin diranged$ ./kingpin/bin/deploy.py -c  --actor misc.Sleep -p warn_on_failure=true -o sleep=2
17:15:52   INFO      Rehearsing... Break a leg!
17:15:52   INFO      [DRY: Kingpin] Preparing actors from {'warn_on_failure': 'true', 'options': {'sleep': '2'}, 'actor': 'misc.Sleep', 'desc': 'Commandline Execution'}
17:15:52   INFO      Rehearsal OK! Performing!
17:15:52   INFO      [Kingpin] Preparing actors from {'warn_on_failure': 'true', 'options': {'sleep': '2'}, 'actor': 'misc.Sleep', 'desc': 'Commandline Execution'}
17:15:53   INFO      
17:15:53   WARNING   Lights, camera ... action!
17:15:53   INFO      
(.venv)Matts-MacBook:kingpin diranged$ 
```

Just an example..