### PR TITLE
Issue 306: Wait for all ELB connections to drain.

### DIFF
--- a/kingpin/actors/aws/elb.py
+++ b/kingpin/actors/aws/elb.py
@@ -540,16 +540,7 @@ class DeregisterInstance(base.AWSBaseActor):
             yield utils.tornado_sleep(timeout)
 
     @gen.coroutine
-    def _execute(self):
-        elb = yield self._find_elb(self.option('elb'))
-        instances = self.option('instances')
-
-        if not instances:
-            self.log.debug('No instance provided. Using current instance id.')
-            iid = yield self._get_meta_data('instance-id')
-            instances = [iid]
-            self.log.debug('Instances is: %s' % instances)
-
+    def _remove_wrapper(self, elb, instances):
         if type(instances) is not list:
             instances = [instances]
 
@@ -558,3 +549,16 @@ class DeregisterInstance(base.AWSBaseActor):
         if not self._dry:
             yield self._remove(elb, instances)
             self.log.info('Done.')
+
+    @gen.coroutine
+    def _execute(self):
+        instances = self.option('instances')
+
+        if not instances:
+            self.log.debug('No instance provided. Using current instance id.')
+            iid = yield self._get_meta_data('instance-id')
+            instances = [iid]
+            self.log.debug('Instances is: %s' % instances)
+
+        elb = yield self._find_elb(self.option('elb'))
+        yield self._remove_wrapper(elb, instances)

--- a/kingpin/actors/test/integration_hipchat.py
+++ b/kingpin/actors/test/integration_hipchat.py
@@ -46,7 +46,7 @@ class IntegrationHipchatMessage(testing.AsyncTestCase):
 
         # Valid response test
         actor._token = 'Invalid'
-        with self.assertRaises(exceptions.InvalidCredentials):
+        with self.assertRaises(exceptions.RecoverableActorFailure):
             yield actor.execute()
 
     @testing.gen_test(timeout=60)


### PR DESCRIPTION
By default, the safe thing to do is to determine the "connection
draining" time configured in the ELB and wait until that time has passed
before we return from the actor. Without this, a host might move on to
another state while still handling web requests.