### PR TITLE
Search for Actor names with the Kingpin prefixes first.

### DIFF
--- a/kingpin/test/test_utils.py
+++ b/kingpin/test/test_utils.py
@@ -11,6 +11,7 @@ import rainbow_logging_handler
 import requests
 
 from kingpin import utils
+from kingpin.actors import misc
 
 
 class TestUtils(unittest.TestCase):
@@ -19,6 +20,10 @@ class TestUtils(unittest.TestCase):
         class_string_name = 'tornado.testing.AsyncTestCase'
         returned_class = utils.str_to_class(class_string_name)
         self.assertEquals(testing.AsyncTestCase, returned_class)
+
+        class_string_name = 'misc.Sleep'
+        returned_class = utils.str_to_class(class_string_name)
+        self.assertEquals(misc.Sleep, returned_class)
 
     def test_populate_with_env(self):
         tokens = {'UNIT_TEST': 'FOOBAR'}


### PR DESCRIPTION
When you call Kingpin thorugh the `main.py` access method (using the zip
file, for example), your PYTHONPATH is not properly set so Kingpin
cannot necessarily find the actors unless they are fully qualified (eg
`actors.misc.Sleep`).

Now we attempt to start off by finding the module name with
`kingpin.actors` and then `actors` prefixed to it. We fall back to
finding the actor name without any prefix -- in case a user has
developed their own actor.