### PR TITLE
Use kingpin.actors.utils.get_actor_class() when getting an actor from the CLI

### DIFF
--- a/kingpin/bin/deploy.py
+++ b/kingpin/bin/deploy.py
@@ -23,6 +23,7 @@ from tornado import gen
 from tornado import ioloop
 
 from kingpin import utils
+from kingpin.actors import utils as actor_utils
 from kingpin.actors import exceptions as actor_exceptions
 from kingpin.actors.misc import Macro
 from kingpin.version import __version__
@@ -80,7 +81,7 @@ def get_main_actor(dry):
         kingpin_fail('You may only specify --actor or --json, not both!')
 
     if args.actor:
-        ActorClass = utils.str_to_class(args.actor)
+        ActorClass = actor_utils.get_actor_class(args.actor)
         parameters = dict([i.split('=') for i in args.params])
         options = dict([i.split('=') for i in args.options])
 


### PR DESCRIPTION
This is the correct method to use -- it handles the various error cases,
logs appropriately and exits with the right error code.

Closes #314

@Nrvale, here's an example of it working now:
```
(.venv)Matts-MacBook:kingpin diranged$ python kingpin/bin/deploy.py --actor lasdfjk
2015-12-21 09:53:43,416 INFO      Rehearsing... Break a leg!
2015-12-21 09:53:43,416 WARNING   Could not import kingpin.actors.lasdfjk: 'module' object has no attribute 'lasdfjk'
2015-12-21 09:53:43,417 CRITICAL  Could not import lasdfjk: 'module' object has no attribute 'lasdfjk'
2015-12-21 09:53:43,417 CRITICAL  Dry run failed. Reason:
2015-12-21 09:53:43,417 CRITICAL  Unable to import "lasdfjk" as a valid Actor.
(.venv)Matts-MacBook:kingpin diranged$ echo $?
2
(.venv)Matts-MacBook:kingpin diranged$ 
```