### PR TITLE
Fix documentation code-block bugs with latest Sphinx.

### DIFF
--- a/docs/basicuse.rst
+++ b/docs/basicuse.rst
@@ -1,7 +1,7 @@
 Basic Use
 ---------
 
-.. code-block:: bash
+.. code-block:: guess
 
     $ kingpin --help
     Usage: kingpin [json file] <options>
@@ -356,7 +356,7 @@ then reference that file. Context files support `token-replacement`_ just like
         "contexts": {
           "file": "data/notification-rooms.json",
           "tokens": {
-            "USER": "%USER%,
+            "USER": "%USER%",
           }
         },
         "acts": [


### PR DESCRIPTION
Sphinx 1.3.5 is much more sensitive to the LaTeX parser failing to
highlight due to formatting issues. Two bug fixes in our docs here to
help make the Sphinx happy again.