### PR TITLE
Issue #56: Make each Integration test suite optional.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 .coverage
 .venv
 .build
+docs/.ropeproject
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ BUILD_DIRS = bin .build build include lib lib64 man share package *.egg
 
 .PHONY: all build clean test docs
 
+# Only execute a subset of our integration tests by default
+INTEGRATION_TESTS ?= aws,rightscale,http,rollbar,slack,pingdom
+
 all: build
 
 build: .build
@@ -24,7 +27,8 @@ test: build docs
 	python setup.py test pep8 pyflakes
 
 integration: build
-	PYFLAKES_NODOCTEST=True python setup.py integration pep8 pyflakes
+	INTEGRATION_TESTS=$(INTEGRATION_TESTS) PYFLAKES_NODOCTEST=True \
+		python setup.py integration pep8 pyflakes
 
 pack: kingpin.zip
 	@python kingpin.zip --help 2>&1 >/dev/null && echo Success || echo Fail

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ BUILD_DIRS = bin .build build include lib lib64 man share package *.egg
 .PHONY: all build clean test docs
 
 # Only execute a subset of our integration tests by default
-INTEGRATION_TESTS ?= aws,rightscale,http,rollbar,slack,pingdom
+INTEGRATION_TESTS ?= aws,rightscale,http,rollbar,slack
 
 all: build
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -60,40 +60,20 @@ operations in your accounts, and rely on particular environments being setup
 in order to run. These tests are great to run though to validate that your
 credentials are all correct.
 
-Specific integration test notes are below, describing what is required to run
-each set of tests.
-
 *Executing the tests*
 
 .. code-block:: bash
 
-    HIPCHAT_TOKEN=<xxx> RIGHTSCALE_TOKEN=<xxx> make integration
+    HIPCHAT_TOKEN=<xxx> RIGHTSCALE_TOKEN=<xxx> INTEGRATION_TESTS=<comma separated list> make integration
 
-    PYFLAKES_NODOCTEST=True python setup.py integration pep8 pyflakes
-    running integration
-    integration_01_clone_dry (integration_server_array.IntegrationServerArray) ... ok
+    ...
     integration_02a_clone (integration_server_array.IntegrationServerArray) ... ok
-    integration_02b_clone_with_duplicate_array (integration_server_array.IntegrationServerArray) ... ok
-    integration_03a_update_params (integration_server_array.IntegrationServerArray) ... ok
-    integration_03b_update_with_invalid_params (integration_server_array.IntegrationServerArray) ... ok
-    integration_04_launch (integration_server_array.IntegrationServerArray) ... ok
-    integration_05_destroy (integration_server_array.IntegrationServerArray) ... ok
     integration_test_execute_real (integration_hipchat.IntegrationHipchatMessage) ... ok
     integration_test_execute_with_invalid_creds (integration_hipchat.IntegrationHipchatMessage) ... ok
     integration_test_init_without_environment_creds (integration_hipchat.IntegrationHipchatMessage) ... ok
 
-    Name                                     Stmts   Miss  Cover   Missing
-    ----------------------------------------------------------------------
-    kingpin                                      0      0   100%   
-    kingpin.actors                               0      0   100%   
-    kingpin.actors.base                         62      5    92%   90, 95, 146, 215-216
-    kingpin.actors.exceptions                    4      0   100%   
-    kingpin.actors.hipchat                      58      5    91%   59, 111-118
-    kingpin.actors.misc                         17      5    71%   47-49, 57-62
-    kingpin.actors.rightscale                    0      0   100%   
-    kingpin.actors.rightscale.api              137     46    66%   153-164, 251-258, 343-346, 381-382, 422-445, 466-501
-    kingpin.actors.rightscale.base              31      3    90%   36, 49, 79
-    kingpin.actors.rightscale.server_array     195     49    75%   59-62, 68-72, 79, 174, 190-196, 213-216, 249-250, 253-256, 278-281, 303-305, 377-380, 437-440, 501-505, 513-547
+    ...
+
     kingpin.utils                               67     30    55%   57-69, 78, 93-120, 192-202
     ----------------------------------------------------------------------
     TOTAL                                      571    143    75%   
@@ -104,21 +84,48 @@ each set of tests.
     running pep8
     running pyflakes
 
-kingpin.actor.rightscale.server\_array
-''''''''''''''''''''''''''''''''''''''
+Executing Only Certain Test Suites
+''''''''''''''''''''''''''''''''''
 
-These tests clone a ServerArray, modify it, launch it, and destroy it.  They
-rely on an existing ServerArray template being available and launchable in
-your environment. For simple testing, I recommend just using a standard
-RightScale ServerTemplate.
+Because not everyone will use or need to test all of our actors, you can
+execute only certain subsets of our integration tests if you wish. Simply set
+the `INTEGRATION_TESTS` environment variable to a comma-separated list of test
+suites. See below for the list.
 
-**Required RightScale Resources**
+*Executing only the HTTP Tests*
 
--  ServerArray: *kingpin-integration-testing*
-    Any ServerArray that launches a server in your environment.
--  RightScript: *kingpin-integration-testing-script*
-    Should be a script that sleeps for a specified amount of time.
-    **Requires ``SLEEP`` input**
+.. code-block:: bash
+
+    (.venv)Matts-MacBook-2:kingpin diranged$ INTEGRATION_TESTS=http make integration
+    INTEGRATION_TESTS=http PYFLAKES_NODOCTEST=True \
+                           python setup.py integration pep8 pyflakes
+    running integration
+    integration_base_get (integration_api.IntegrationRestConsumer) ... ok
+    integration_delete (integration_api.IntegrationRestConsumer) ... ok
+    integration_get_basic_auth (integration_api.IntegrationRestConsumer) ... ok
+    integration_get_basic_auth_401 (integration_api.IntegrationRestConsumer) ... ok
+    integration_get_json (integration_api.IntegrationRestConsumer) ... ok
+    integration_get_with_args (integration_api.IntegrationRestConsumer) ... ok
+    integration_post (integration_api.IntegrationRestConsumer) ... ok
+    integration_put (integration_api.IntegrationRestConsumer) ... ok
+    integration_status_401 (integration_api.IntegrationRestConsumer) ... ok
+    integration_status_403 (integration_api.IntegrationRestConsumer) ... ok
+    integration_status_500 (integration_api.IntegrationRestConsumer) ... ok
+    integration_status_501 (integration_api.IntegrationRestConsumer) ... ok
+    ...
+
+*List of Built-In Integration Test Suites*
+
+* aws
+* librato
+* rightscale
+* http
+* hipchat
+* pingdom
+* rollbar
+* pingdom
+* slack
+
 
 Class/Object Architecture
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/kingpin/actors/aws/test/integration_base.py
+++ b/kingpin/actors/aws/test/integration_base.py
@@ -23,7 +23,7 @@ class IntegrationBase(testing.AsyncTestCase):
     region = 'us-east-1'
     elb_name = 'kingpin-integration-test'
 
-    @attr('integration')
+    @attr('aws', 'integration')
     @testing.gen_test(timeout=60)
     def integration_01a_check_credentials(self):
 
@@ -38,7 +38,7 @@ class IntegrationBase(testing.AsyncTestCase):
 
         reload(settings)
 
-    @attr('integration')
+    @attr('aws', 'integration')
     @testing.gen_test(timeout=60)
     def integration_02a_find_elb(self):
 

--- a/kingpin/actors/aws/test/integration_cloudformation.py
+++ b/kingpin/actors/aws/test/integration_cloudformation.py
@@ -43,7 +43,7 @@ class IntegrationCreate(testing.AsyncTestCase):
     region = 'us-east-1'
     bucket_name = 'kingpin-%s' % UUID
 
-    @attr('integration')
+    @attr('aws', 'integration')
     @testing.gen_test(timeout=600)
     def integration_01_create_stack(self):
         actor = cloudformation.Create(
@@ -59,7 +59,7 @@ class IntegrationCreate(testing.AsyncTestCase):
         done = yield actor.execute()
         self.assertEquals(done, None)
 
-    @attr('integration')
+    @attr('aws', 'integration')
     @testing.gen_test(timeout=60)
     def integration_02_create_duplicate_stack_should_fail(self):
         actor = cloudformation.Create(
@@ -75,7 +75,7 @@ class IntegrationCreate(testing.AsyncTestCase):
         with self.assertRaises(cloudformation.StackAlreadyExists):
             yield actor.execute()
 
-    @attr('integration')
+    @attr('aws', 'integration')
     @testing.gen_test(timeout=600)
     def integration_03_delete_stack(self):
         actor = cloudformation.Delete(
@@ -86,7 +86,7 @@ class IntegrationCreate(testing.AsyncTestCase):
         done = yield actor.execute()
         self.assertEquals(done, None)
 
-    @attr('integration')
+    @attr('aws', 'integration')
     @testing.gen_test(timeout=60)
     def integration_04_delete_missing_stack_should_fail(self):
         actor = cloudformation.Delete(

--- a/kingpin/actors/aws/test/integration_elb.py
+++ b/kingpin/actors/aws/test/integration_elb.py
@@ -42,7 +42,7 @@ class IntegrationELB(testing.AsyncTestCase):
     elb_name = 'kingpin-integration-test'
     region = 'us-east-1'
 
-    @attr('integration')
+    @attr('aws', 'integration')
     @testing.gen_test(timeout=60)
     def integration_01a_check_elb_health(self):
         actor = elb.WaitUntilHealthy(
@@ -55,7 +55,7 @@ class IntegrationELB(testing.AsyncTestCase):
 
         self.assertEquals(done, None)
 
-    @attr('integration')
+    @attr('aws', 'integration')
     @testing.gen_test
     def integration_01b_check_elb_not_found(self):
         actor = elb.WaitUntilHealthy(
@@ -67,7 +67,7 @@ class IntegrationELB(testing.AsyncTestCase):
         with self.assertRaises(exceptions.RecoverableActorFailure):
             yield actor.execute()
 
-    @attr('integration')
+    @attr('aws', 'integration')
     @testing.gen_test(timeout=60)
     def integration_02_wait_for_elb_health(self):
         actor = elb.WaitUntilHealthy(

--- a/kingpin/actors/aws/test/integration_iam.py
+++ b/kingpin/actors/aws/test/integration_iam.py
@@ -20,7 +20,7 @@ class IntegrationIAM(testing.AsyncTestCase):
     cert_name = 'kingpin-integration-test'
     region = 'us-east-1'
 
-    @attr('integration')
+    @attr('aws', 'integration')
     @testing.gen_test(timeout=60)
     def integration_01a_upload_cert_dry(self):
         actor = iam.UploadCert(
@@ -32,7 +32,7 @@ class IntegrationIAM(testing.AsyncTestCase):
 
         yield actor.execute()
 
-    @attr('integration')
+    @attr('aws', 'integration')
     @testing.gen_test(timeout=60)
     def integration_01b_upload_cert(self):
         actor = iam.UploadCert(
@@ -43,7 +43,7 @@ class IntegrationIAM(testing.AsyncTestCase):
 
         yield actor.execute()
 
-    @attr('integration')
+    @attr('aws', 'integration')
     @testing.gen_test(timeout=60)
     def integration_02a_delete_cert_dry(self):
         actor = iam.DeleteCert(
@@ -53,7 +53,7 @@ class IntegrationIAM(testing.AsyncTestCase):
 
         yield actor.execute()
 
-    @attr('integration')
+    @attr('aws', 'integration')
     @testing.gen_test(timeout=60)
     def integration_02b_delete_cert(self):
         actor = iam.DeleteCert(

--- a/kingpin/actors/aws/test/integration_sqs.py
+++ b/kingpin/actors/aws/test/integration_sqs.py
@@ -44,7 +44,7 @@ class IntegrationSQS(testing.AsyncTestCase):
     queue_name = 'integration-test-%s' % UUID
     region = 'us-east-1'
 
-    @attr('integration', 'dry')
+    @attr('aws', 'integration', 'dry')
     @testing.gen_test(timeout=60)
     def integration_01a_create_queue_dry(self):
         actor = sqs.Create(
@@ -55,7 +55,7 @@ class IntegrationSQS(testing.AsyncTestCase):
         done = yield actor.execute()
         self.assertEquals(done, None)
 
-    @attr('integration')
+    @attr('aws', 'integration')
     @testing.gen_test(timeout=60)
     def integration_01b_create_queue(self):
         actor = sqs.Create(
@@ -65,7 +65,7 @@ class IntegrationSQS(testing.AsyncTestCase):
         done = yield actor.execute()
         self.assertEquals(done, None)
 
-    @attr('integration', 'dry')
+    @attr('aws', 'integration', 'dry')
     @testing.gen_test(timeout=60)
     def integration_02a_monitor_queue_dry(self):
         actor = sqs.WaitUntilEmpty('Wait until empty',
@@ -75,7 +75,7 @@ class IntegrationSQS(testing.AsyncTestCase):
         done = yield actor.execute()
         self.assertEquals(done, None)
 
-    @attr('integration')
+    @attr('aws', 'integration')
     @testing.gen_test(timeout=60)
     def integration_02b_monitor_queue(self):
 
@@ -91,7 +91,7 @@ class IntegrationSQS(testing.AsyncTestCase):
         yield utils.tornado_sleep()
         self.assertEquals(done, None)
 
-    @attr('integration', 'dry')
+    @attr('aws', 'integration', 'dry')
     @testing.gen_test()
     def integration_03a_delete_queue_dry(self):
         actor = sqs.Delete('Delete %s' % self.queue_name,
@@ -103,7 +103,7 @@ class IntegrationSQS(testing.AsyncTestCase):
         done = yield actor.execute()
         self.assertEquals(done, None)
 
-    @attr('integration')
+    @attr('aws', 'integration')
     @testing.gen_test(timeout=120)  # Delete actor sleeps and retries.
     def integration_03b_delete_queue(self):
         actor = sqs.Delete('Delete %s' % self.queue_name,
@@ -113,7 +113,7 @@ class IntegrationSQS(testing.AsyncTestCase):
         done = yield actor.execute()
         self.assertEquals(done, None)
 
-    @attr('integration')
+    @attr('aws', 'integration')
     @testing.gen_test(timeout=120)  # Delete actor sleeps and retries.
     def integration_03c_delete_fake_queue(self):
         settings.SQS_RETRY_DELAY = 0

--- a/kingpin/actors/misc.py
+++ b/kingpin/actors/misc.py
@@ -346,10 +346,15 @@ class GenericHTTP(base.HTTPBaseActor):
         if self._dry:
             raise gen.Return(self._execute_dry())
 
+        # Only generate a JSON text string if a populated dict was passed to
+        # data-json.
+        datajson = None
+        if self.option('data-json'):
+            datajson = json.dumps(self.option('data-json'))
+
         escaped_post = (
-                urllib.urlencode(self.option('data')) or
-                json.dumps(self.option('data-json')) or
-                None)
+            urllib.urlencode(self.option('data')) or
+            datajson or None)
 
         try:
             yield self._fetch(self.option('url'),

--- a/kingpin/actors/rightscale/test/integration_alerts.py
+++ b/kingpin/actors/rightscale/test/integration_alerts.py
@@ -43,7 +43,7 @@ class IntegrationAlerts(testing.AsyncTestCase):
         self.template_array = 'kingpin-integration-testing'
         self.test_alert_name = 'unit-test-alert-%s' % UUID
 
-    @attr('integration', 'dry')
+    @attr('aws', 'integration', 'dry')
     @testing.gen_test(timeout=60)
     def integration_01a_create_alert_dry(self):
         actor = alerts.Create(
@@ -65,7 +65,7 @@ class IntegrationAlerts(testing.AsyncTestCase):
         ret = yield actor.execute()
         self.assertEquals(ret, None)
 
-    @attr('integration')
+    @attr('aws', 'integration')
     @testing.gen_test(timeout=60)
     def integration_02a_create_alert(self):
         actor = alerts.Create(
@@ -86,7 +86,7 @@ class IntegrationAlerts(testing.AsyncTestCase):
         ret = yield actor.execute()
         self.assertEquals(ret, None)
 
-    @attr('integration')
+    @attr('aws', 'integration')
     @testing.gen_test(timeout=60)
     def integration_02b_create_second_alert(self):
         actor = alerts.Create(
@@ -107,7 +107,7 @@ class IntegrationAlerts(testing.AsyncTestCase):
         ret = yield actor.execute()
         self.assertEquals(ret, None)
 
-    @attr('integration')
+    @attr('aws', 'integration')
     @testing.gen_test(timeout=60)
     def integratin_03a_destroy_alert(self):
         actor = alerts.Destroy(
@@ -118,7 +118,7 @@ class IntegrationAlerts(testing.AsyncTestCase):
         ret = yield actor.execute()
         self.assertEquals(ret, None)
 
-    @attr('integration')
+    @attr('aws', 'integration')
     @testing.gen_test(timeout=60)
     def integratin_03a_destroy_alert_should_fail(self):
         # The alerts were all deleted in the previous tests, we hope.

--- a/kingpin/actors/rightscale/test/integration_deployment.py
+++ b/kingpin/actors/rightscale/test/integration_deployment.py
@@ -18,7 +18,7 @@ class IntegrationDeployment(testing.AsyncTestCase):
         super(IntegrationDeployment, self).setUp(*args, **kwargs)
         self.deployment_name = 'Kingpin Deployment Integration Test %s' % UUID
 
-    @attr('integration', 'dry')
+    @attr('rightscale', 'integration', 'dry')
     @testing.gen_test()
     def integration_01a_create_deployment_dry(self):
         actor = deployment.Create('Integ. Test',
@@ -27,7 +27,7 @@ class IntegrationDeployment(testing.AsyncTestCase):
 
         yield actor.execute()
 
-    @attr('integration')
+    @attr('rightscale', 'integration')
     @testing.gen_test(timeout=60)
     def integration_01b_create_deployment(self):
         actor = deployment.Create('Integ. Test',
@@ -35,7 +35,7 @@ class IntegrationDeployment(testing.AsyncTestCase):
 
         yield actor.execute()
 
-    @attr('integration', 'dry')
+    @attr('rightscale', 'integration', 'dry')
     @testing.gen_test()
     def integration_02a_destroy_deployment_dry(self):
         actor = deployment.Destroy('Integ. Test',
@@ -44,7 +44,7 @@ class IntegrationDeployment(testing.AsyncTestCase):
 
         yield actor.execute()
 
-    @attr('integration')
+    @attr('rightscale', 'integration')
     @testing.gen_test(timeout=60)
     def integration_02b_destroy_deployment(self):
         actor = deployment.Destroy('Integ. Test',

--- a/kingpin/actors/rightscale/test/integration_mci.py
+++ b/kingpin/actors/rightscale/test/integration_mci.py
@@ -26,7 +26,7 @@ class IntegrationMCI(testing.AsyncTestCase):
              'm1.small', 'user_data': 'cd /bin/bash'}
         ]
 
-    @attr('integration', 'dry')
+    @attr('rightscale', 'integration', 'dry')
     @testing.gen_test(timeout=60)
     def integration_01a_create_mci_dry(self):
         actor = mci.Create('Integ. Test',
@@ -35,7 +35,7 @@ class IntegrationMCI(testing.AsyncTestCase):
                            dry=True)
         yield actor.execute()
 
-    @attr('integration')
+    @attr('rightscale', 'integration')
     @testing.gen_test(timeout=60)
     def integration_01b_create_mci(self):
         actor = mci.Create('Integ. Test',
@@ -43,7 +43,7 @@ class IntegrationMCI(testing.AsyncTestCase):
                             'images': self.images})
         yield actor.execute()
 
-    @attr('integration', 'dry')
+    @attr('rightscale', 'integration', 'dry')
     @testing.gen_test(timeout=60)
     def integration_02a_destroy_mci_dry(self):
         actor = mci.Destroy('Integ. Test',
@@ -51,7 +51,7 @@ class IntegrationMCI(testing.AsyncTestCase):
                             dry=True)
         yield actor.execute()
 
-    @attr('integration')
+    @attr('rightscale', 'integration')
     @testing.gen_test(timeout=60)
     def integration_02b_destroy_mci(self):
         actor = mci.Destroy('Integ. Test',

--- a/kingpin/actors/rightscale/test/integration_server_array.py
+++ b/kingpin/actors/rightscale/test/integration_server_array.py
@@ -45,7 +45,7 @@ class IntegrationServerArray(testing.AsyncTestCase):
         self.template_script = 'kingpin-integration-testing-script'
         self.clone_name = 'kingpin-%s' % UUID
 
-    @attr('integration', 'dry')
+    @attr('rightscale', 'integration', 'dry')
     @testing.gen_test(timeout=60)
     def integration_01a_clone_dry(self):
         actor = server_array.Clone(
@@ -56,7 +56,7 @@ class IntegrationServerArray(testing.AsyncTestCase):
         ret = yield actor.execute()
         self.assertEquals(ret, None)
 
-    @attr('integration', 'dry')
+    @attr('rightscale', 'integration', 'dry')
     @testing.gen_test(timeout=60)
     def integration_01b_clone_dry_with_missing_template(self):
         actor = server_array.Clone(
@@ -67,7 +67,7 @@ class IntegrationServerArray(testing.AsyncTestCase):
         with self.assertRaises(exceptions.RecoverableActorFailure):
             yield actor.execute()
 
-    @attr('integration')
+    @attr('rightscale', 'integration')
     @testing.gen_test(timeout=60)
     def integration_02a_clone(self):
         actor = server_array.Clone(
@@ -77,7 +77,7 @@ class IntegrationServerArray(testing.AsyncTestCase):
         ret = yield actor.execute()
         self.assertEquals(ret, None)
 
-    @attr('integration')
+    @attr('rightscale', 'integration')
     @testing.gen_test(timeout=30)
     def integration_02b_clone_with_duplicate_array(self):
         actor = server_array.Clone(
@@ -87,7 +87,7 @@ class IntegrationServerArray(testing.AsyncTestCase):
         with self.assertRaises(exceptions.RecoverableActorFailure):
             yield actor.execute()
 
-    @attr('integration')
+    @attr('rightscale', 'integration')
     @testing.gen_test(timeout=30)
     def integration_02c_clone_with_missing_template(self):
         actor = server_array.Clone(
@@ -97,7 +97,7 @@ class IntegrationServerArray(testing.AsyncTestCase):
         with self.assertRaises(base.ArrayNotFound):
             yield actor.execute()
 
-    @attr('integration', 'dry')
+    @attr('rightscale', 'integration', 'dry')
     @testing.gen_test(timeout=60)
     def integration_03a_update_dry(self):
         actor = server_array.Update(
@@ -106,7 +106,7 @@ class IntegrationServerArray(testing.AsyncTestCase):
         ret = yield actor.execute()
         self.assertEquals(ret, None)
 
-    @attr('integration', 'dry')
+    @attr('rightscale', 'integration', 'dry')
     @testing.gen_test(timeout=60)
     def integration_03b_update_dry_missing_array(self):
         actor = server_array.Update(
@@ -116,7 +116,7 @@ class IntegrationServerArray(testing.AsyncTestCase):
         ret = yield actor.execute()
         self.assertEquals(ret, None)
 
-    @attr('integration')
+    @attr('rightscale', 'integration')
     @testing.gen_test(timeout=60)
     def integration_04a_update_params(self):
         # Patch the array with some new min_instance settings, then launch it
@@ -130,7 +130,7 @@ class IntegrationServerArray(testing.AsyncTestCase):
         ret = yield actor.execute()
         self.assertEquals(ret, None)
 
-    @attr('integration')
+    @attr('rightscale', 'integration')
     @testing.gen_test(timeout=60)
     def integration_04b_update_inputs(self):
         # There is no way to validate that the actual inputs were set right,
@@ -144,7 +144,7 @@ class IntegrationServerArray(testing.AsyncTestCase):
         ret = yield actor.execute()
         self.assertEquals(ret, None)
 
-    @attr('integration')
+    @attr('rightscale', 'integration')
     @testing.gen_test(timeout=10)
     def integration_04c_update_with_invalid_params_422(self):
         actor = server_array.Update(
@@ -156,7 +156,7 @@ class IntegrationServerArray(testing.AsyncTestCase):
         with self.assertRaises(exceptions.RecoverableActorFailure):
             yield actor.execute()
 
-    @attr('integration')
+    @attr('rightscale', 'integration')
     @testing.gen_test(timeout=10)
     def integration_04d_update_with_invalid_params_400(self):
         actor = server_array.Update(
@@ -171,7 +171,7 @@ class IntegrationServerArray(testing.AsyncTestCase):
         with self.assertRaises(exceptions.RecoverableActorFailure):
             yield actor.execute()
 
-    @attr('integration')
+    @attr('rightscale', 'integration')
     @testing.gen_test(timeout=60)
     def integration_04e_update_missing_array(self):
         # Patch the array with some new min_instance settings, then launch it
@@ -185,7 +185,7 @@ class IntegrationServerArray(testing.AsyncTestCase):
         with self.assertRaises(exceptions.RecoverableActorFailure):
             yield actor.execute()
 
-    @attr('integration')
+    @attr('rightscale', 'integration')
     @testing.gen_test(timeout=60)
     def integration_04f_update_next_instance(self):
         # This is a quick test. It executes a long path of code to find the
@@ -199,7 +199,7 @@ class IntegrationServerArray(testing.AsyncTestCase):
 
         yield actor.execute()
 
-    @attr('integration', 'dry')
+    @attr('rightscale', 'integration', 'dry')
     @testing.gen_test(timeout=30)
     def integration_05a_launch_dry(self):
         # Launch the machines and wait until they boot
@@ -213,7 +213,7 @@ class IntegrationServerArray(testing.AsyncTestCase):
     # Note: These tests can run super slow -- the server boot time
     # itself may take 5-10 minutes, and sometimes Amazon and RightScale
     # slowdown. Give this test up to 30m to execute before we bail out.
-    @attr('integration')
+    @attr('rightscale', 'integration')
     @testing.gen_test(timeout=1800)
     def integration_05b_launch(self):
         # Launch the machines and wait until they boot
@@ -225,7 +225,7 @@ class IntegrationServerArray(testing.AsyncTestCase):
         ret = yield actor.execute()
         self.assertEquals(ret, None)
 
-    @attr('integration', 'dry')
+    @attr('rightscale', 'integration', 'dry')
     @testing.gen_test(timeout=120)
     def integration_06a_execute_dry(self):
         actor = server_array.Execute(
@@ -237,7 +237,7 @@ class IntegrationServerArray(testing.AsyncTestCase):
         ret = yield actor.execute()
         self.assertEquals(ret, None)
 
-    @attr('integration')
+    @attr('rightscale', 'integration')
     @testing.gen_test(timeout=480)
     def integration_06b_execute(self):
         actor = server_array.Execute(
@@ -248,7 +248,7 @@ class IntegrationServerArray(testing.AsyncTestCase):
         ret = yield actor.execute()
         self.assertEquals(ret, None)
 
-    @attr('integration', 'dry')
+    @attr('rightscale', 'integration', 'dry')
     @testing.gen_test(timeout=120)
     def integration_06c_execute_missing_script_dry(self):
         actor = server_array.Execute(
@@ -259,7 +259,7 @@ class IntegrationServerArray(testing.AsyncTestCase):
         with self.assertRaises(exceptions.InvalidOptions):
             yield actor.execute()
 
-    @attr('integration')
+    @attr('rightscale', 'integration')
     @testing.gen_test(timeout=120)
     def integration_06d_execute_incorrect_inputs(self):
         actor = server_array.Execute(
@@ -270,7 +270,7 @@ class IntegrationServerArray(testing.AsyncTestCase):
         with self.assertRaises(exceptions.RecoverableActorFailure):
             yield actor.execute()
 
-    @attr('integration', 'dry')
+    @attr('rightscale', 'integration', 'dry')
     @testing.gen_test(timeout=120)
     def integration_06d_execute_missing_recipe_dry(self):
         actor = server_array.Execute(
@@ -282,7 +282,7 @@ class IntegrationServerArray(testing.AsyncTestCase):
         with self.assertRaises(exceptions.InvalidOptions):
             yield actor.execute()
 
-    @attr('integration')
+    @attr('rightscale', 'integration')
     @testing.gen_test(timeout=120)
     def integration_06d_execute_missing_recipe(self):
         actor = server_array.Execute(
@@ -293,7 +293,7 @@ class IntegrationServerArray(testing.AsyncTestCase):
         with self.assertRaises(exceptions.RecoverableActorFailure):
             yield actor.execute()
 
-    @attr('integration', 'dry')
+    @attr('rightscale', 'integration', 'dry')
     @testing.gen_test(timeout=120)
     def integration_07a_destroy_dry(self):
         actor = server_array.Destroy(
@@ -303,7 +303,7 @@ class IntegrationServerArray(testing.AsyncTestCase):
         ret = yield actor.execute()
         self.assertEquals(ret, None)
 
-    @attr('integration')
+    @attr('rightscale', 'integration')
     @testing.gen_test(timeout=600)
     def integration_07b_destroy(self):
         actor = server_array.Destroy(
@@ -312,7 +312,7 @@ class IntegrationServerArray(testing.AsyncTestCase):
         ret = yield actor.execute()
         self.assertEquals(ret, None)
 
-    @attr('integration')
+    @attr('rightscale', 'integration')
     @testing.gen_test(timeout=600)
     def integration_07b_destroy_missing_array(self):
         # Re-run the same destroy.. this time it should fail

--- a/kingpin/actors/support/test/integration_api.py
+++ b/kingpin/actors/support/test/integration_api.py
@@ -1,5 +1,7 @@
 """Integration tests for the kingpin.actors.support.api module"""
 
+from nose.plugins.attrib import attr
+
 from tornado import testing
 from tornado import httpclient
 
@@ -61,18 +63,21 @@ class IntegrationRestConsumer(testing.AsyncTestCase):
 
     integration = True
 
+    @attr('http', 'integration')
     @testing.gen_test(timeout=60)
     def integration_base_get(self):
         httpbin = HTTPBinRestConsumer()
         ret = yield httpbin.http_get()
         self.assertIn('DOCTYPE', ret)
 
+    @attr('http', 'integration')
     @testing.gen_test(timeout=60)
     def integration_get_json(self):
         httpbin = HTTPBinRestConsumer()
         ret = yield httpbin.get().http_get()
         self.assertEquals(ret['url'], 'http://httpbin.org/get')
 
+    @attr('http', 'integration')
     @testing.gen_test(timeout=60)
     def integration_get_basic_auth(self):
         httpbin = HTTPBinRestConsumerBasicAuthed()
@@ -80,18 +85,21 @@ class IntegrationRestConsumer(testing.AsyncTestCase):
         self.assertEquals(
             ret, {'authenticated': True, 'user': 'username'})
 
+    @attr('http', 'integration')
     @testing.gen_test(timeout=60)
     def integration_get_basic_auth_401(self):
         httpbin = HTTPBinRestConsumer()
         with self.assertRaises(exceptions.InvalidCredentials):
             yield httpbin.basic_auth().http_get()
 
+    @attr('http', 'integration')
     @testing.gen_test(timeout=60)
     def integration_get_with_args(self):
         httpbin = HTTPBinRestConsumer()
         ret = yield httpbin.get().http_get(foo='bar', baz='bat')
         self.assertEquals(ret['url'], 'http://httpbin.org/get?baz=bat&foo=bar')
 
+    @attr('http', 'integration')
     @testing.gen_test(timeout=60)
     def integration_post(self):
         httpbin = HTTPBinRestConsumer()
@@ -99,6 +107,7 @@ class IntegrationRestConsumer(testing.AsyncTestCase):
         self.assertEquals(ret['url'], 'http://httpbin.org/post')
         self.assertEquals(ret['form'], {'foo': 'bar', 'baz': 'bat'})
 
+    @attr('http', 'integration')
     @testing.gen_test(timeout=60)
     def integration_put(self):
         httpbin = HTTPBinRestConsumer()
@@ -106,6 +115,7 @@ class IntegrationRestConsumer(testing.AsyncTestCase):
         self.assertEquals(ret['url'], 'http://httpbin.org/put')
         self.assertEquals(ret['data'], 'foo=bar&baz=bat')
 
+    @attr('http', 'integration')
     @testing.gen_test(timeout=60)
     def integration_delete(self):
         httpbin = HTTPBinRestConsumer()
@@ -114,42 +124,49 @@ class IntegrationRestConsumer(testing.AsyncTestCase):
             ret['url'],
             'http://httpbin.org/delete?baz=bat&foo=bar')
 
+    @attr('http', 'integration')
     @testing.gen_test(timeout=60)
     def integration_status_401(self):
         httpbin = HTTPBinRestConsumer()
         with self.assertRaises(exceptions.InvalidCredentials):
             yield httpbin.status(res='401').http_get()
 
+    @attr('http', 'integration')
     @testing.gen_test(timeout=60)
     def integration_status_403(self):
         httpbin = HTTPBinRestConsumer()
         with self.assertRaises(exceptions.InvalidCredentials):
             yield httpbin.status(res='403').http_get()
 
+    @attr('http', 'integration')
     @testing.gen_test(timeout=60)
     def integration_status_500(self):
         httpbin = HTTPBinRestConsumer()
         with self.assertRaises(httpclient.HTTPError):
             yield httpbin.status(res='500').http_get()
 
+    @attr('http', 'integration')
     @testing.gen_test(timeout=60)
     def integration_status_501(self):
         httpbin = HTTPBinRestConsumer()
         with self.assertRaises(exceptions.RecoverableActorFailure):
             yield httpbin.status(res='501').http_get()
 
+    @attr('http', 'integration')
     @testing.gen_test(timeout=60)
     def integration_status_502(self):
         httpbin = HTTPBinRestConsumer()
         with self.assertRaises(httpclient.HTTPError):
             yield httpbin.status(res='502').http_get()
 
+    @attr('http', 'integration')
     @testing.gen_test(timeout=60)
     def integration_status_503(self):
         httpbin = HTTPBinRestConsumer()
         with self.assertRaises(httpclient.HTTPError):
             yield httpbin.status(res='503').http_get()
 
+    @attr('http', 'integration')
     @testing.gen_test(timeout=60)
     def integration_status_504(self):
         httpbin = HTTPBinRestConsumer()

--- a/kingpin/actors/test/integration_hipchat.py
+++ b/kingpin/actors/test/integration_hipchat.py
@@ -1,5 +1,7 @@
 """Tests for the actors.hipchat package"""
 
+from nose.plugins.attrib import attr
+
 from tornado import testing
 
 from kingpin.actors import hipchat
@@ -21,6 +23,7 @@ class IntegrationHipchatMessage(testing.AsyncTestCase):
 
     integration = True
 
+    @attr('hipchat', 'integration')
     @testing.gen_test(timeout=60)
     def integration_test_init_without_environment_creds(self):
         message = 'Unit test message'
@@ -36,6 +39,7 @@ class IntegrationHipchatMessage(testing.AsyncTestCase):
         # Reload the hipchat library to re-get the token
         reload(hipchat)
 
+    @attr('hipchat', 'integration')
     @testing.gen_test(timeout=60)
     def integration_test_execute_with_invalid_creds(self):
         message = 'Unit test message'
@@ -49,6 +53,7 @@ class IntegrationHipchatMessage(testing.AsyncTestCase):
         with self.assertRaises(exceptions.InvalidCredentials):
             yield actor.execute()
 
+    @attr('hipchat', 'integration')
     @testing.gen_test(timeout=60)
     def integration_test_execute_real(self):
         message = 'Unit test message'
@@ -72,6 +77,7 @@ class IntegrationHipchatTopic(testing.AsyncTestCase):
 
     integration = True
 
+    @attr('hipchat', 'integration')
     @testing.gen_test(timeout=60)
     def integration_test_init_without_environment_creds(self):
         topic = 'Unit test topic'
@@ -87,6 +93,7 @@ class IntegrationHipchatTopic(testing.AsyncTestCase):
         # Reload the hipchat library to re-get the token
         reload(hipchat)
 
+    @attr('hipchat', 'integration')
     @testing.gen_test(timeout=60)
     def integration_test_execute_with_invalid_creds(self):
         topic = 'Unit test topic'
@@ -100,6 +107,7 @@ class IntegrationHipchatTopic(testing.AsyncTestCase):
         with self.assertRaises(exceptions.InvalidCredentials):
             yield actor.execute()
 
+    @attr('hipchat', 'integration')
     @testing.gen_test(timeout=60)
     def integration_test_execute_real(self):
         topic = 'Unit test topic'

--- a/kingpin/actors/test/integration_librato.py
+++ b/kingpin/actors/test/integration_librato.py
@@ -23,7 +23,7 @@ class IntegrationLibratoAnnotation(testing.AsyncTestCase):
 
     integration = True
 
-    @attr('integration', 'dry')
+    @attr('librato', 'integration', 'integration', 'dry')
     @testing.gen_test
     def integration_test_init_without_token(self):
         # Un-set auth token and make sure the init fails
@@ -35,7 +35,7 @@ class IntegrationLibratoAnnotation(testing.AsyncTestCase):
                  'description': 'unittest',
                  'name': 'unittest'}, dry=True)
 
-    @attr('integration', 'dry')
+    @attr('librato', 'integration', 'dry')
     @testing.gen_test
     def integration_test_init_without_email(self):
         # Un-set auth email and make sure the init fails
@@ -47,7 +47,7 @@ class IntegrationLibratoAnnotation(testing.AsyncTestCase):
                  'description': 'unittest',
                  'name': 'unittest'}, dry=True)
 
-    @attr('integration', 'dry')
+    @attr('librato', 'integration', 'dry')
     @testing.gen_test
     def integration_test_execute_with_invalid_token(self):
         # Set auth token to invalid value and make sure execute fails
@@ -62,7 +62,7 @@ class IntegrationLibratoAnnotation(testing.AsyncTestCase):
         with self.assertRaises(exceptions.InvalidCredentials):
             yield actor.execute()
 
-    @attr('integration', 'dry')
+    @attr('librato', 'integration', 'dry')
     @testing.gen_test
     def integration_test_execute_with_invalid_email(self):
         # Set auth email to invalid value and make sure execute fails
@@ -77,7 +77,7 @@ class IntegrationLibratoAnnotation(testing.AsyncTestCase):
         with self.assertRaises(exceptions.InvalidCredentials):
             yield actor.execute()
 
-    @attr('integration', 'dry')
+    @attr('librato', 'integration', 'dry')
     @testing.gen_test
     def integration_test_execute_dry(self):
         actor = librato.Annotation(
@@ -89,7 +89,7 @@ class IntegrationLibratoAnnotation(testing.AsyncTestCase):
         res = yield actor.execute()
         self.assertEquals(res, None)
 
-    @attr('integration')
+    @attr('librato', 'integration')
     @testing.gen_test
     def integration_test_execute(self):
         actor = librato.Annotation(

--- a/kingpin/actors/test/integration_misc.py
+++ b/kingpin/actors/test/integration_misc.py
@@ -3,6 +3,8 @@
 import os
 import time
 
+from nose.plugins.attrib import attr
+
 from tornado import testing
 
 from kingpin.actors import exceptions
@@ -16,12 +18,14 @@ class IntegrationGenericHTTP(testing.AsyncTestCase):
 
     integration = True
 
+    @attr('http', 'integration')
     @testing.gen_test(timeout=60)
     def integration_get(self):
         actor = misc.GenericHTTP('Test', {'url': 'http://httpbin.org/get'})
 
         yield actor.execute()
 
+    @attr('http', 'integration')
     @testing.gen_test(timeout=60)
     def integration_post(self):
         actor = misc.GenericHTTP('Test', {
@@ -30,6 +34,7 @@ class IntegrationGenericHTTP(testing.AsyncTestCase):
 
         yield actor.execute()
 
+    @attr('http', 'integration')
     @testing.gen_test(timeout=60)
     def integration_auth(self):
         actor = misc.GenericHTTP('Test', {
@@ -39,6 +44,7 @@ class IntegrationGenericHTTP(testing.AsyncTestCase):
 
         yield actor.execute()
 
+    @attr('http', 'integration')
     @testing.gen_test(timeout=60)
     def integration_auth_fail(self):
         actor = misc.GenericHTTP('Test', {
@@ -54,6 +60,7 @@ class IntegrationMacro(testing.AsyncTestCase):
 
     integration = True
 
+    @attr('http', 'integration')
     @testing.gen_test
     def integration_execute(self):
         actor = misc.Macro('Test', {
@@ -66,12 +73,14 @@ class IntegrationMacro(testing.AsyncTestCase):
         runtime = end - start
         self.assertTrue(runtime > 0.1)
 
+    @attr('http', 'integration')
     @testing.gen_test
     def integration_fail_without_env(self):
         # Actor should fail if tokens aren't passed for env. variables.
         with self.assertRaises(exceptions.UnrecoverableActorFailure):
             misc.Macro('Test', {'macro': 'examples/test/sleep.json'})
 
+    @attr('http', 'integration')
     @testing.gen_test
     def integration_execute_remote(self):
         gh_src = 'https://raw.githubusercontent.com/Nextdoor/kingpin/master'
@@ -80,6 +89,7 @@ class IntegrationMacro(testing.AsyncTestCase):
             'macro': gh_src + '/examples/test/sleep.json',
             'tokens': dict(os.environ)})
 
+    @attr('http', 'integration', 'dry')
     @testing.gen_test
     def integration_execute_dry(self):
         actor = misc.Macro('Test', {

--- a/kingpin/actors/test/integration_pingdom.py
+++ b/kingpin/actors/test/integration_pingdom.py
@@ -1,5 +1,7 @@
 """Tests for the pingdom actors"""
 
+from nose.plugins.attrib import attr
+
 from tornado import testing
 
 from kingpin import utils
@@ -15,6 +17,7 @@ class IntegrationPingdom(testing.AsyncTestCase):
 
     check_name = 'kingpin-integration-test'
 
+    @attr('pingdom', 'integration')
     @testing.gen_test(timeout=60)
     def integration_01a_test_pause(self):
 
@@ -28,6 +31,7 @@ class IntegrationPingdom(testing.AsyncTestCase):
 
         self.assertEquals(check['status'], 'paused')
 
+    @attr('pingdom', 'integration')
     @testing.gen_test(timeout=60)
     def integration_02a_test_unpause(self):
 

--- a/kingpin/actors/test/integration_rollbar.py
+++ b/kingpin/actors/test/integration_rollbar.py
@@ -1,5 +1,7 @@
 """Tests for the actors.rollbar package"""
 
+from nose.plugins.attrib import attr
+
 from tornado import testing
 
 from kingpin import version
@@ -22,6 +24,7 @@ class IntegrationRollbarDeploy(testing.AsyncTestCase):
 
     integration = True
 
+    @attr('rollbar', 'integration')
     @testing.gen_test(timeout=60)
     def integration_test_1a_init_without_environment_creds(self):
         # Un-set the token now and make sure the init fails
@@ -37,6 +40,7 @@ class IntegrationRollbarDeploy(testing.AsyncTestCase):
         # Reload the rollbar package so it gets our environment variable back.
         reload(rollbar)
 
+    @attr('rollbar', 'integration', 'dry')
     @testing.gen_test(timeout=60)
     def integration_test_2a_execute_with_invalid_creds(self):
         actor = rollbar.Deploy(
@@ -51,6 +55,7 @@ class IntegrationRollbarDeploy(testing.AsyncTestCase):
         with self.assertRaises(exceptions.InvalidCredentials):
             yield actor.execute()
 
+    @attr('rollbar', 'integration', 'dry')
     @testing.gen_test(timeout=60)
     def integration_test_2b_execute_dry(self):
         actor = rollbar.Deploy(
@@ -62,6 +67,7 @@ class IntegrationRollbarDeploy(testing.AsyncTestCase):
         res = yield actor.execute()
         self.assertEquals(res, None)
 
+    @attr('rollbar', 'integration')
     @testing.gen_test(timeout=60)
     def integration_test_2c_execute_real(self):
         actor = rollbar.Deploy(
@@ -74,6 +80,7 @@ class IntegrationRollbarDeploy(testing.AsyncTestCase):
         res = yield actor.execute()
         self.assertEquals(res, None)
 
+    @attr('rollbar', 'integration')
     @testing.gen_test(timeout=60)
     def integration_test_2d_execute_real_with_rollbar_username(self):
         actor = rollbar.Deploy(

--- a/kingpin/actors/test/integration_slack.py
+++ b/kingpin/actors/test/integration_slack.py
@@ -1,5 +1,7 @@
 """Tests for the actors.slack package"""
 
+from nose.plugins.attrib import attr
+
 from tornado import testing
 
 from kingpin.actors import slack
@@ -23,6 +25,7 @@ class IntegrationSlackMessage(testing.AsyncTestCase):
     message = 'Unit test message'
     channel = '#kingpin-integration'
 
+    @attr('slack', 'integration', 'dry')
     @testing.gen_test(timeout=2)
     def integration_test_init_without_environment_creds(self):
         # Un-set the token now and make sure the init fails
@@ -36,6 +39,7 @@ class IntegrationSlackMessage(testing.AsyncTestCase):
         # Reload the slack library to re-get the token
         reload(slack)
 
+    @attr('slack', 'integration', 'dry')
     @testing.gen_test(timeout=2)
     def integration_test_execute_with_invalid_creds(self):
         # Un-set the token now and make sure the init fails
@@ -53,6 +57,7 @@ class IntegrationSlackMessage(testing.AsyncTestCase):
         # Reload the slack library to re-get the token
         reload(slack)
 
+    @attr('slack', 'integration')
     @testing.gen_test(timeout=60)
     def integration_test_execute_invalid_room(self):
         actor = slack.Message(
@@ -62,6 +67,7 @@ class IntegrationSlackMessage(testing.AsyncTestCase):
         with self.assertRaises(exceptions.RecoverableActorFailure):
             yield actor.execute()
 
+    @attr('slack', 'integration', 'dry')
     @testing.gen_test(timeout=60)
     def integration_test_execute_dry(self):
         actor = slack.Message(
@@ -71,6 +77,7 @@ class IntegrationSlackMessage(testing.AsyncTestCase):
         res = yield actor.execute()
         self.assertEquals(res, None)
 
+    @attr('slack', 'integration')
     @testing.gen_test(timeout=60)
     def integration_test_execute_real(self):
         actor = slack.Message(

--- a/kingpin/actors/test/test_misc.py
+++ b/kingpin/actors/test/test_misc.py
@@ -170,6 +170,15 @@ class TestGenericHTTP(testing.AsyncTestCase):
         yield actor.execute()
 
     @testing.gen_test
+    def test_execute_data_json(self):
+        actor = misc.GenericHTTP('Unit Test Action',
+                                 {'url': 'http://example.com',
+                                  'data-json': {'foo': 'bar'}})
+        actor._fetch = mock_tornado({'success': {'code': 200}})
+
+        yield actor.execute()
+
+    @testing.gen_test
     def test_execute_fail(self):
         actor = misc.GenericHTTP('Unit Test Action',
                                  {'url': 'http://example.com'})

--- a/setup.py
+++ b/setup.py
@@ -109,12 +109,17 @@ class UnitTestCommand(Command):
 
 class IntegrationTestCommand(UnitTestCommand):
     description = 'Run full integration tests and unit tests'
+    tests = os.environ.get('INTEGRATION_TESTS', 'integration')
+
     args = [PACKAGE,
             '--with-coverage',
             '--cover-package=%s' % PACKAGE,
             '-v',
             '--include=integration',
-            '--attr=integration']
+            ]
+
+    for test in tests.split(','):
+        args.append('--attr=%s' % test)
 
 
 class CleanHook(clean):


### PR DESCRIPTION
This commit finally closes issue #56 -- making each set of integration
tests optional by passing different attributes to the test suite runner.