### PR TITLE
Bugfix our auto-actor-importer code.

### DIFF
--- a/kingpin/actors/utils.py
+++ b/kingpin/actors/utils.py
@@ -74,18 +74,19 @@ def get_actor_class(actor):
     """
     expected_exceptions = (AttributeError, ImportError, TypeError)
 
-    try:
-        # Try to load our local actors up first. Assume that the
-        # 'kingpin.actors.' prefix was not included in the name.
-        full_actor = 'kingpin.actors.%s' % actor
-        ref = utils.str_to_class(full_actor)
-    except expected_exceptions as e:
-        log.warning('Could not import %s: %s' % (full_actor, e))
+    # Try to load our local actors up first. Assume that the
+    # 'kingpin.actors.' prefix was not included in the name.
+    for prefix in ['kingpin.actors', 'actors', None]:
         try:
-            ref = utils.str_to_class(actor)
-        except expected_exceptions:
-            log.critical('Could not import %s: %s' % (actor, e))
-            msg = 'Unable to import "%s" as a valid Actor.' % actor
-            raise exceptions.InvalidActor(msg)
+            if prefix:
+                full_actor = '.'.join([prefix, actor])
+            else:
+                full_actor = actor
+            return utils.str_to_class(full_actor)
+        except expected_exceptions as e:
+            log.exception(e)
+            pass
 
-    return ref
+    log.critical('Could not import %s: %s' % (actor, e))
+    msg = 'Unable to import "%s" as a valid Actor.' % actor
+    raise exceptions.InvalidActor(msg)

--- a/kingpin/actors/utils.py
+++ b/kingpin/actors/utils.py
@@ -76,17 +76,12 @@ def get_actor_class(actor):
 
     # Try to load our local actors up first. Assume that the
     # 'kingpin.actors.' prefix was not included in the name.
-    for prefix in ['kingpin.actors', 'actors', None]:
+    for prefix in ['', 'kingpin.actors.', 'actors.']:
+        full_actor = prefix + actor
         try:
-            if prefix:
-                full_actor = '.'.join([prefix, actor])
-            else:
-                full_actor = actor
             return utils.str_to_class(full_actor)
         except expected_exceptions as e:
-            log.exception(e)
-            pass
+            log.debug('Tried importing "%s" but failed: %s' % (full_actor, e))
 
-    log.critical('Could not import %s: %s' % (actor, e))
     msg = 'Unable to import "%s" as a valid Actor.' % actor
     raise exceptions.InvalidActor(msg)

--- a/kingpin/test/test_utils.py
+++ b/kingpin/test/test_utils.py
@@ -22,7 +22,7 @@ class TestUtils(unittest.TestCase):
         returned_class = utils.str_to_class(class_string_name)
         self.assertEquals(testing.AsyncTestCase, returned_class)
 
-        class_string_name = 'misc.Sleep'
+        class_string_name = 'kingpin.actors.misc.Sleep'
         returned_class = utils.str_to_class(class_string_name)
         self.assertEquals(misc.Sleep, returned_class)
 

--- a/kingpin/utils.py
+++ b/kingpin/utils.py
@@ -23,6 +23,7 @@ from logging import handlers
 import datetime
 import demjson
 import functools
+import importlib
 import logging
 import os
 import re
@@ -77,24 +78,7 @@ def str_to_class(string):
     class_name = string_elements.pop()
     module_name = '.'.join(string_elements)
 
-    for prefix in ['kingpin.actors', 'actors']:
-        try:
-            prefixed_module_name = "%s.%s" % (prefix, module_name)
-
-            # load the module, will raise ImportError if module cannot be
-            # loaded or if that module has a failed import inside of it.
-            m = __import__(prefixed_module_name, globals(), locals(),
-                           class_name)
-
-            # get the class, will raise AttributeError if class cannot be found
-            return getattr(m, class_name)
-
-        except ImportError:
-            # pass right now -- will try one more time at the end of this class
-            # to import the raw string without any kingpin prefixes.
-            pass
-
-    m = __import__(module_name, globals(), locals(), class_name)
+    m = importlib.import_module(module_name)
     return getattr(m, class_name)
 
 


### PR DESCRIPTION
We had a bunch of duplicated code causing multiple imports to happen
that didn't have to. Also, the __import__ module wasn't working as I had
hoped it would. Using importlib.import_module() is _much_ simpler, and
removing the bogus extra loop in the kingpin.utils.str_to_class() method
makes everything easier to understand.

@siminm 