### PR TITLE
Bugfix on IAM Group deletion.

### DIFF
--- a/kingpin/actors/aws/iam/entities.py
+++ b/kingpin/actors/aws/iam/entities.py
@@ -742,8 +742,9 @@ class Group(EntityBaseActor):
             users = [user['user_name'] for user in
                      raw['get_group_response']['get_group_result']['users']]
         except BotoServerError as e:
-            raise exceptions.RecoverableActorFailure(
-                'An unexpected API error occurred: %s' % e)
+            if e.status != 404:
+                raise exceptions.RecoverableActorFailure(
+                    'An unexpected API error occurred: %s' % e)
         except KeyError:
             # No users!
             users = []


### PR DESCRIPTION
if we're ensuring that a group is absent, its OK if we get a 404 when
searching for the groups members.

Heads up @siminm, im going to merge this so our integration tests start working again.