### PR TITLE
Fix the RightScale Retry Module -- Add another 422 string to NOT retry on

### DIFF
--- a/kingpin/actors/rightscale/settings.py
+++ b/kingpin/actors/rightscale/settings.py
@@ -20,9 +20,12 @@ Common settings used by many of the `kingpin.actors.rightscale` modules.
 """
 
 
+import logging
 import requests
 
 __author__ = 'Matt Wise <matt@nextdoor.com>'
+
+log = logging.getLogger(__name__)
 
 
 # Common Settings for the retrying.retry() decorator
@@ -30,21 +33,19 @@ __author__ = 'Matt Wise <matt@nextdoor.com>'
 # Use like this: @retrying.retry(**settings.RETRYING_SETTINGS)
 #
 def is_retriable_exception(exception):
-    """Return true if this AWS exception is transient and should be retried.
+    """Return true if this RightScale exception is transient.
 
     Example:
         >>> @retry(retry_on_exception=is_retriable_exception)
     """
-    not_retry_codes = (
-        '422 Client Error: Unprocessable Entity',
-    )
+    not_retry_codes = ('422',)
 
     # Only handle requests.exceptions.HTTPError exceptions
     if not isinstance(exception, requests.exceptions.HTTPError):
         return False
 
-    # Boto exceptions should have a code attribute
-    return str(exception) not in not_retry_codes
+    log.debug('Comparing "%s" to "%s".' % (str(exception), not_retry_codes))
+    return not any(code in str(exception) for code in not_retry_codes)
 
 
 RETRYING_SETTINGS = {


### PR DESCRIPTION
It looks like RightScale has a new variation of the 422 return string
that we need to catch, and _not_ retry on.

After re-enabling our integration tests, I caught this failure a few times:
```
======================================================================
ERROR: integration_06d_execute_incorrect_inputs (integration_server_array.IntegrationServerArray)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/mnt/jenkins/workspace/ops-kingpin-continuous-build/venv/local/lib/python2.7/site-packages/tornado-4.3-py2.7-linux-x86_64.egg/tornado/testing.py", line 132, in __call__
    result = self.orig_method(*args, **kwargs)
  File "/mnt/jenkins/workspace/ops-kingpin-continuous-build/venv/local/lib/python2.7/site-packages/tornado-4.3-py2.7-linux-x86_64.egg/tornado/testing.py", line 530, in post_coroutine
    self._test_generator.throw(e)
  File "/mnt/jenkins/workspace/ops-kingpin-continuous-build/kingpin/actors/rightscale/test/integration_server_array.py", line 271, in integration_06d_execute_incorrect_inputs
    yield actor.execute()
TimeoutError: Operation timed out after 120 seconds
-------------------- >> begin captured stdout << ---------------------
...
reply: 'HTTP/1.1 422 Unprocessable Entity\r\n'
header: Date: Sat, 23 Apr 2016 17:10:23 GMT
header: Content-Type: text/html; charset=utf-8
header: Transfer-Encoding: chunked
header: Connection: close
header: Status: 422 Unprocessable Entity
header: Cache-Control: no-cache
header: X-Request-Uuid: 21360b81636b45ec93232fc8b5493c43
header: Vary: Origin
header: Strict-Transport-Security: max-age=31536000; includeSubdomains;
reply: 'HTTP/1.1 422 Unprocessable Entity\r\n'
header: Date: Sat, 23 Apr 2016 17:10:23 GMT
header: Content-Type: text/html; charset=utf-8
header: Transfer-Encoding: chunked
header: Connection: close
header: Status: 422 Unprocessable Entity
header: Cache-Control: no-cache
header: X-Request-Uuid: f71af9bd0fb946daa42a83bbcf9bfd5d
header: Vary: Origin
header: Strict-Transport-Security: max-age=31536000; includeSubdomains;
send: 'POST /api/clouds/1/instances/183CMI5KQP25P/run_executable HTTP/1.1\r\nHost: us-3.rightscale.com\r\nX-API-Version: 1.5\r\nContent-Length: 82\r\nAccept-Encoding: gzip, deflate\r\nAccept: application/json\r\nUser-Agent: python-requests/2.9.1\r\nConnection: close\r\nContent-Type: application/x-www-form-urlencoded\r\nAuthorization: Bearer xxxTg=\r\n\r\nright_script_href=%2Fapi%2Fright_scripts%2F524954003&inputs%5BSLEEP%5D=bogus+field'
send: 'POST /api/clouds/1/instances/AV08K444DQKJ3/run_executable HTTP/1.1\r\nHost: us-3.rightscale.com\r\nX-API-Version: 1.5\r\nContent-Length: 82\r\nAccept-Encoding: gzip, deflate\r\nAccept: application/json\r\nUser-Agent: python-requests/2.9.1\r\nConnection: close\r\nContent-Type: application/x-www-form-urlencoded\r\nAuthorization: Bearer XXX--=\r\n\r\nright_script_href=%2Fapi%2Fright_scripts%2F524954003&inputs%5BSLEEP%5D=bogus+field'
reply: 'HTTP/1.1 422 Unprocessable Entity\r\n'
header: Date: Sat, 23 Apr 2016 17:10:24 GMT
header: Content-Type: text/html; charset=utf-8
header: Transfer-Encoding: chunked
header: Connection: close
header: Status: 422 Unprocessable Entity
header: Cache-Control: no-cache
header: X-Request-Uuid: a27a5676adfb4c80b4ec6425144ef835
header: Vary: Origin
...
```

After digging, I realized that we're doing a string-match on the 422 error code. If it doesn't match, we retry .. and retry .. and retry.. without ever returning. So on certain 422 cases, we could go into an indefinite loop that the user never sees.

It looks to me like RightScale now has multiple 422 strings that they return. There is probably a better fix where we do a smarter string match (Regex), but this looks like it should be a quick fix for now.