### PR TITLE
Support both YAML and JSON for the script file.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,10 @@ clean:
 
 test: build docs
 	python setup.py test pep8 pyflakes
+	# A few simple dry-tests of yaml and json scripts to make sure that the
+	# full commandline actually works.
+	PYTHONPATH=$(HERE) python kingpin/bin/deploy.py --dry --script examples/test/sleep.json
+	PYTHONPATH=$(HERE) python kingpin/bin/deploy.py --dry --script examples/test/sleep.yaml
 
 integration: build
 	INTEGRATION_TESTS=$(INTEGRATION_TESTS) PYFLAKES_NODOCTEST=True \

--- a/examples/simple.yaml
+++ b/examples/simple.yaml
@@ -1,0 +1,43 @@
+actor: group.Sync
+desc: main stage
+options:
+  acts:
+  - actor: group.Async
+    desc: stage 1
+    options:
+      acts:
+      - actor: rightscale.server_array.Clone
+        desc: copy serverA
+        options: {dest: serverA, source: kingpin-integration-testing}
+      - actor: rightscale.server_array.Clone
+        desc: copy serverB
+        options: {dest: serverB, source: kingpin-integration-testing}
+      - actor: rightscale.server_array.Clone
+        desc: copy serverC
+        options: {dest: serverC, source: kingpin-integration-testing}
+  - actor: group.Async
+    desc: stage 2
+    options:
+      acts:
+      - actor: rightscale.server_array.Launch
+        desc: launch serverA
+        options: {array: serverA}
+      - actor: rightscale.server_array.Launch
+        desc: launch serverB
+        options: {array: serverB}
+      - actor: rightscale.server_array.Launch
+        desc: launch serverC
+        options: {array: serverC}
+  - actor: group.Async
+    desc: stage 3
+    options:
+      acts:
+      - actor: rightscale.server_array.Destroy
+        desc: copy serverA
+        options: {array: serverA, terminate: true}
+      - actor: rightscale.server_array.Destroy
+        desc: copy serverB
+        options: {array: serverB, terminate: true}
+      - actor: rightscale.server_array.Destroy
+        desc: copy serverC
+        options: {array: serverC, terminate: true}

--- a/examples/test/sleep.yaml
+++ b/examples/test/sleep.yaml
@@ -1,0 +1,4 @@
+# Used in Integration Test of the misc.Macro testing
+actor: misc.Sleep
+options:
+  sleep: 0.1

--- a/kingpin/actors/aws/base.py
+++ b/kingpin/actors/aws/base.py
@@ -262,9 +262,9 @@ class AWSBaseActor(base.BaseActor):
         self.log.debug('Parsing and validating %s' % policy)
 
         try:
-            p_doc = utils.convert_json_to_dict(json_file=policy,
-                                               tokens=os.environ)
-        except kingpin_exceptions.InvalidJSON as e:
+            p_doc = utils.convert_script_to_dict(script_file=policy,
+                                                 tokens=os.environ)
+        except kingpin_exceptions.InvalidScript as e:
             raise exceptions.UnrecoverableActorFailure('Error parsing %s: %s' %
                                                        (policy, e))
 

--- a/kingpin/bin/deploy.py
+++ b/kingpin/bin/deploy.py
@@ -43,10 +43,10 @@ parser = argparse.ArgumentParser(description='Kingpin v%s' % __version__)
 parser.set_defaults(verbose=True)
 
 # Job Configuration
-parser.add_argument('-j', '--json', dest='json',
-                    help='Path to JSON Deployment File')
+parser.add_argument('-j', '--json', '-s', '--script', dest='script',
+                    help='Path to JSON/YAML Deployment Script')
 parser.add_argument('-a', '--actor', dest='actor',
-                    help='Name of an Actor to execute (overrides --json)')
+                    help='Name of an Actor to execute (overrides --script)')
 parser.add_argument('-E', '--explain', dest='explain', action='store_true',
                     help='Explain how an actor works. Requires --actor.',
                     default=False)
@@ -81,9 +81,9 @@ def kingpin_fail(message):
 def get_main_actor(dry):
     env_tokens = dict(os.environ)
 
-    # Cannot specify a json file an an actor at the same time.
-    if args.json and args.actor:
-        kingpin_fail('You may only specify --actor or --json, not both!')
+    # Cannot specify a script file an an actor at the same time.
+    if args.script and args.actor:
+        kingpin_fail('You may only specify --actor or --script, not both!')
 
     if args.actor:
         ActorClass = actor_utils.get_actor_class(args.actor)
@@ -96,15 +96,14 @@ def get_main_actor(dry):
 
     # Actor not specified. Process JSON file.
     try:
-        json_file = args.json or sys.argv[1] if sys.argv else None
+        script = args.script or sys.argv[1] if sys.argv else None
     except Exception as e:
         kingpin_fail(
-            '%s You must specify --json or provide it as first argument.'
+            '%s You must specify --script or provide it as first argument.'
             % e)
 
     return Macro(desc='Kingpin',
-                 options={'macro': json_file,
-                          'tokens': env_tokens},
+                 options={'macro': script, 'tokens': env_tokens},
                  dry=dry)
 
 
@@ -113,7 +112,7 @@ def main():
 
     if args.actor and args.explain:
         ActorClass = actor_utils.get_actor_class(args.actor)
-        print ActorClass.__doc__
+        print(ActorClass.__doc__)
         sys.exit(0)
 
     if args.build_only:

--- a/kingpin/exceptions.py
+++ b/kingpin/exceptions.py
@@ -21,3 +21,8 @@ class KingpinException(Exception):
 class InvalidScript(KingpinException):
 
     """Raised when an invalid script schema was detected"""
+
+
+class InvalidScriptName(KingpinException):
+
+    """Raised when the script name does not end on .yaml or .json"""

--- a/kingpin/exceptions.py
+++ b/kingpin/exceptions.py
@@ -18,6 +18,6 @@ class KingpinException(Exception):
     """Base Exception """
 
 
-class InvalidJSON(KingpinException):
+class InvalidScript(KingpinException):
 
-    """Raised when an invalid JSON schema was detected"""
+    """Raised when an invalid script schema was detected"""

--- a/kingpin/schema.py
+++ b/kingpin/schema.py
@@ -79,4 +79,4 @@ def validate(config):
     try:
         return jsonschema.validate(config, SCHEMA_1_0)
     except jsonschema.exceptions.ValidationError as e:
-        raise exceptions.InvalidJSON(e)
+        raise exceptions.InvalidScript(e)

--- a/kingpin/test/test_schema.py
+++ b/kingpin/test/test_schema.py
@@ -27,5 +27,5 @@ class TestSchema(unittest.TestCase):
 
     def test_validate_with_invalid_json(self):
         json = {'this': 'is', 'invalid': 'ok'}
-        with self.assertRaises(exceptions.InvalidJSON):
+        with self.assertRaises(exceptions.InvalidScript):
             schema.validate(json)

--- a/kingpin/test/test_utils.py
+++ b/kingpin/test/test_utils.py
@@ -100,13 +100,29 @@ class TestUtils(unittest.TestCase):
         ret = utils.convert_script_to_dict(instance, {})
         self.assertEquals(type(ret), dict)
 
-    def test_convert_script_to_dict_junk_json(self):
+    def test_convert_script_to_dict_bad_name(self):
         instance = StringIO.StringIO()  # Empty buffer will fail demjson.
+        instance.__repr__ = lambda: 'Somefile.HAHA'
+
+        with self.assertRaises(exceptions.InvalidScriptName):
+            utils.convert_script_to_dict(instance, {})
+
+    def test_convert_script_to_dict_junk(self):
+        instance = StringIO.StringIO()
+        instance.__repr__ = lambda: 'Somefile.json'
+
         with self.assertRaises(exceptions.InvalidScript):
             utils.convert_script_to_dict(instance, {})
 
         with self.assertRaises(exceptions.InvalidScript):
             utils.convert_script_to_dict('junk data', {})
+
+        instance = StringIO.StringIO()
+        instance.__repr__ = lambda: 'Somefile.yaml'
+        instance.write('---bad-yaml')
+
+        with self.assertRaises(exceptions.InvalidScript):
+            utils.convert_script_to_dict(instance, {})
 
     def test_exception_logger(self):
         @utils.exception_logger

--- a/kingpin/test/test_utils.py
+++ b/kingpin/test/test_utils.py
@@ -76,12 +76,12 @@ class TestUtils(unittest.TestCase):
             strict=False)
         self.assertEquals(result, expect)
 
-    def test_convert_json_to_dict(self):
+    def test_convert_script_to_dict(self):
         # Should work with string path to a file
         dirname, filename = os.path.split(os.path.abspath(__file__))
         examples = '%s/../../examples' % dirname
         simple = '%s/simple.json' % examples
-        ret = utils.convert_json_to_dict(simple, {})
+        ret = utils.convert_script_to_dict(simple, {})
         self.assertEquals(type(ret), dict)
 
         # Should work with file instance also
@@ -89,17 +89,24 @@ class TestUtils(unittest.TestCase):
         examples = '%s/../../examples' % dirname
         simple = '%s/simple.json' % examples
         instance = open(simple)
-        ret = utils.convert_json_to_dict(instance, {})
+        ret = utils.convert_script_to_dict(instance, {})
         self.assertEquals(type(ret), dict)
 
-    def test_convert_json_to_dict_error(self):
+        # Should definitly support YAML as well
+        dirname, filename = os.path.split(os.path.abspath(__file__))
+        examples = '%s/../../examples' % dirname
+        simple = '%s/simple.yaml' % examples
+        instance = open(simple)
+        ret = utils.convert_script_to_dict(instance, {})
+        self.assertEquals(type(ret), dict)
+
+    def test_convert_script_to_dict_junk_json(self):
         instance = StringIO.StringIO()  # Empty buffer will fail demjson.
+        with self.assertRaises(exceptions.InvalidScript):
+            utils.convert_script_to_dict(instance, {})
 
-        with self.assertRaises(exceptions.InvalidJSON):
-            utils.convert_json_to_dict(instance, {})
-
-        with self.assertRaises(exceptions.InvalidJSON):
-            utils.convert_json_to_dict('junk data', {})
+        with self.assertRaises(exceptions.InvalidScript):
+            utils.convert_script_to_dict('junk data', {})
 
     def test_exception_logger(self):
         @utils.exception_logger

--- a/kingpin/utils.py
+++ b/kingpin/utils.py
@@ -185,8 +185,7 @@ def exception_logger(func):
             return func(*args, **kwargs)
         except Exception as e:
             log.debug('Exception caught in %s(%s, %s): %s' %
-                      (func, args, kwargs, e))
-            log.debug(traceback.format_exc())
+                      (func, args, kwargs, e), exc_info=1)
             raise
     return wrapper
 
@@ -341,19 +340,17 @@ def convert_script_to_dict(script_file, tokens):
             decoded = demjson.decode(parsed)
         elif suffix in ('yml', 'yaml'):
             decoded = yaml.safe_load(parsed)
+            if decoded is None:
+                raise exceptions.InvalidScript(
+                    'Invalid YAML in `%s`' % filename)
         else:
-            raise exceptions.InvalidScript('Invalid file extension: %s' %
-                                           suffix)
+            raise exceptions.InvalidScriptName(
+                'Invalid file extension: %s' % suffix)
     except demjson.JSONError as e:
         # demjson exceptions have `pretty_description()` method with
         # much more useful info.
         raise exceptions.InvalidScript('JSON in `%s` has an error: %s' % (
             filename, e.pretty_description()))
-    except yaml.scanner.ScannerError as e:
-        # demjson exceptions have `pretty_description()` method with
-        # much more useful info.
-        raise exceptions.InvalidScript('YAML in `%s` has an error: %s' % (
-            filename, e))
     return decoded
 
 

--- a/kingpin/utils.py
+++ b/kingpin/utils.py
@@ -28,6 +28,7 @@ import logging
 import os
 import re
 import sys
+import yaml
 import time
 import traceback
 
@@ -297,48 +298,62 @@ def populate_with_tokens(string, tokens, left_wrapper='%', right_wrapper='%',
     return string
 
 
-def convert_json_to_dict(json_file, tokens):
+def convert_script_to_dict(script_file, tokens):
     """Converts a JSON file to a config dict.
 
     Reads in a JSON file, swaps out any environment variables that
     have been used inside the JSON, and then returns a dictionary.
 
     Args:
-        json_file: Path to the JSON file to import, or file instance.
+        script_file: Path to the JSON/YAML file to import, or file instance.
         tokens: dictionary to pass to populate_with_tokens.
 
     Returns:
         <Dictonary of Config Data>
 
     Raises:
-        kingpin.exceptions.InvalidJSON
+        kingpin.exceptions.InvalidScript
     """
 
     filename = ''
     try:
-        if type(json_file) in (str, unicode):
-            filename = json_file
-            instance = open(json_file)
-        elif type(json_file) is file:
-            filename = json_file.name
-            instance = json_file
+        if type(script_file) in (str, unicode):
+            filename = script_file
+            instance = open(script_file)
+        elif type(script_file) is file:
+            filename = script_file.name
+            instance = script_file
         else:
-            filename = str(json_file)
-            instance = json_file
+            filename = str(script_file)
+            instance = script_file
     except IOError as e:
-        raise exceptions.InvalidJSON('Error reading json_file %s: %s' %
-                                     (json_file, e))
+        raise exceptions.InvalidScript('Error reading script %s: %s' %
+                                       (script_file, e))
 
     raw = instance.read()
     parsed = populate_with_tokens(raw, tokens)
 
+    # If the file ends with .json, use demjson to read it. If it ends with
+    # .yml/.yaml, use PyYAML. If neither, error.
+    suffix = filename.split('.')[-1].strip().lower()
     try:
-        decoded = demjson.decode(parsed)
+        if suffix == 'json':
+            decoded = demjson.decode(parsed)
+        elif suffix in ('yml', 'yaml'):
+            decoded = yaml.safe_load(parsed)
+        else:
+            raise exceptions.InvalidScript('Invalid file extension: %s' %
+                                           suffix)
     except demjson.JSONError as e:
         # demjson exceptions have `pretty_description()` method with
         # much more useful info.
-        raise exceptions.InvalidJSON('JSON in `%s` has an error: %s' % (
+        raise exceptions.InvalidScript('JSON in `%s` has an error: %s' % (
             filename, e.pretty_description()))
+    except yaml.scanner.ScannerError as e:
+        # demjson exceptions have `pretty_description()` method with
+        # much more useful info.
+        raise exceptions.InvalidScript('YAML in `%s` has an error: %s' % (
+            filename, e))
     return decoded
 
 

--- a/kingpin/utils.py
+++ b/kingpin/utils.py
@@ -30,7 +30,6 @@ import re
 import sys
 import yaml
 import time
-import traceback
 
 from tornado import gen
 from tornado import ioloop

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ simplejson
 jsonschema
 demjson
 datadiff
+PyYAML
 
 # Colorize the log output!
 rainbow_logging_handler


### PR DESCRIPTION
Supporting both YAML and JSON is pretty easy. Most of this commit is
just renaming of methods so they are more generic (script instead of
json for example). Still missing a test though for the
convert_script_to_dict() method when the YAML parser is executed and it
fails.

@siminm, could you take a stab at the final missing unit test on junk YAML?