### PR TITLE
Fix the Macro Integration tests after the YAML switch.

### DIFF
--- a/kingpin/actors/misc.py
+++ b/kingpin/actors/misc.py
@@ -181,7 +181,7 @@ class Macro(base.BaseActor):
             buf = StringIO.StringIO()
             # Set buffer representation for debug printing.
             buf.__repr__ = lambda: (
-                '<In-memory file from "%s">' % self.option('macro'))
+                'In-memory file from: %s' % self.option('macro'))
             buf.write(R.body)
             buf.seek(0)
             client.close()
@@ -216,7 +216,7 @@ class Macro(base.BaseActor):
             return utils.convert_script_to_dict(
                 script_file=script_file,
                 tokens=self.option('tokens'))
-        except kingpin_exceptions.InvalidScript as e:
+        except (kingpin_exceptions.InvalidScript, LookupError) as e:
             raise exceptions.UnrecoverableActorFailure(e)
 
     def _check_schema(self, config):


### PR DESCRIPTION
First, make sure that on an http-downloaded script, we set the __repr__
of that in such a way that it can be parsed like a file name. Second,
restore the behavior of the convert_script_to_dict class so that we
catch LookupErrors and wrap them in an UnrecoverableActorFailure.

Review: @siminm