### PR TITLE
Example test that shows how nested tokens don't work.

### DIFF
--- a/examples/misc.macro/inner.yaml
+++ b/examples/misc.macro/inner.yaml
@@ -1,0 +1,6 @@
+---
+
+actor: misc.Macro
+desc: Calling sleeper ... going to be %DESC%
+options:
+  macro: examples/misc.macro/sleeper.yaml

--- a/examples/misc.macro/outer.yaml
+++ b/examples/misc.macro/outer.yaml
@@ -1,0 +1,8 @@
+---
+
+actor: misc.Macro
+options:
+  macro: examples/misc.macro/inner.yaml
+  tokens:
+    SLEEP: 0.1
+    DESC: Sleeping for a while

--- a/examples/misc.macro/sleeper.yaml
+++ b/examples/misc.macro/sleeper.yaml
@@ -1,0 +1,6 @@
+---
+
+actor: misc.Sleep
+desc: %DESC%
+options:
+  sleep: %SLEEP%

--- a/kingpin/actors/test/test_misc.py
+++ b/kingpin/actors/test/test_misc.py
@@ -39,6 +39,13 @@ class TestMacro(testing.AsyncTestCase):
             self.assertEquals(schema_validate.call_count, 1)
             self.assertEquals(actor.initial_actor, get_actor())
 
+    def test_init_nested_tokens(self):
+        actor = misc.Macro(
+            options={'macro': 'examples/misc.macro/outer.yaml'})
+        self.assertEquals(actor, True)
+
+        self.assertTrue(False)
+
     def test_init_remote(self):
         misc.Macro._get_config_from_script = mock.Mock()
         misc.Macro._check_schema = mock.Mock()

--- a/kingpin/actors/utils.py
+++ b/kingpin/actors/utils.py
@@ -76,7 +76,7 @@ def get_actor_class(actor):
 
     # Try to load our local actors up first. Assume that the
     # 'kingpin.actors.' prefix was not included in the name.
-    for prefix in ['', 'kingpin.actors.', 'actors.']:
+    for prefix in ['kingpin.actors.', '', 'actors.']:
         full_actor = prefix + actor
         try:
             return utils.str_to_class(full_actor)


### PR DESCRIPTION
This is normal expected behavior right now -- first writing the test
though to show the behavior. Second, we can look at addressing the
behavior.

@siminm -- I think its time that we solve this in some way. This is a
reasonable test that shows how someone might want to use nested tokens, and
yet we explicitly prohibit this. I know that we made a decision to not support
this back in the day, but lets revisit this.

I'm first going to work on code to make nested tokens work. Once we have it
working, we can talk about how to go about implementing it so that its not
backwards breaking, and its clear to the user how it works.