### PR TITLE
Support deep nested token passing to macros and group actors

### DIFF
--- a/examples/misc.macro/inner.yaml
+++ b/examples/misc.macro/inner.yaml
@@ -1,0 +1,6 @@
+---
+
+actor: misc.Macro
+desc: Calling sleeper ... going to be %DESC%
+options:
+  macro: examples/misc.macro/sleeper.yaml

--- a/examples/misc.macro/outer.yaml
+++ b/examples/misc.macro/outer.yaml
@@ -1,0 +1,8 @@
+---
+
+actor: misc.Macro
+options:
+  macro: examples/misc.macro/inner.yaml
+  tokens:
+    SLEEP: 0.1
+    DESC: Sleeping for a while

--- a/examples/misc.macro/outer_group.yaml
+++ b/examples/misc.macro/outer_group.yaml
@@ -1,0 +1,10 @@
+---
+
+actor: group.Sync
+options:
+  acts:
+    - actor: misc.Macro
+      options:
+        macro:  examples/misc.macro/outer_macro.yaml
+        tokens:
+          FOO: weee

--- a/examples/misc.macro/outer_macro.yaml
+++ b/examples/misc.macro/outer_macro.yaml
@@ -1,8 +1,8 @@
 ---
 
 actor: misc.Macro
+desc: I need the %FOO% token
 options:
   macro: examples/misc.macro/inner.yaml
   tokens:
-    SLEEP: 0.1
     DESC: Sleeping for a while

--- a/examples/misc.macro/sleeper.yaml
+++ b/examples/misc.macro/sleeper.yaml
@@ -1,0 +1,6 @@
+---
+
+actor: misc.Sleep
+desc: %DESC%
+options:
+  sleep: %SLEEP%

--- a/kingpin/actors/base.py
+++ b/kingpin/actors/base.py
@@ -106,8 +106,17 @@ class BaseActor(object):
     strict_init_context = True
 
     def __init__(self, desc=None, options={}, dry=False, warn_on_failure=False,
-                 condition=True, init_context={}, timeout=None):
+                 condition=True, init_context={}, timeout=None, *args,
+                 **kwargs):
         """Initializes the Actor.
+
+        Note about *args/**kwargs:
+          In rare cases, it may be that an Actor that subclasses BaseActor will
+          need to be able to privately pass or accept internal options that the
+          user never sees. An example of this is the group.Sync/Async and
+          misc.Macro actors which pass an 'init_tokens' dictionary around to
+          help with %TOKEN% parsing. In these cases, we want to silently accept
+          the passed in values, but we don't do anything with them ourselves.
 
         Args:
             desc: (Str) description of the action being executed.

--- a/kingpin/actors/test/test_group.py
+++ b/kingpin/actors/test/test_group.py
@@ -139,6 +139,25 @@ class TestBaseGroupActor(TestGroupActorBaseClass):
             mock.call(context={'init': 'stuff', 'key': 'tadaa'})
         ])
 
+    def test_build_actions_with_context_file_str(self):
+        acts = [dict(self.actor_returns)]
+
+        with mock.patch.object(group.BaseGroupActor,
+                               '_build_action_group') as action_builder:
+            action_builder.return_value = acts
+            group.BaseGroupActor(
+                'ContextFile Actor',
+                {'acts': acts,
+                 'contexts': 'examples/test/context.json'},
+                init_tokens={'TOKEN_VALUE': 'tadaa'},
+                init_context={'init': 'stuff'})
+
+        self.assertEquals(2, len(action_builder.mock_calls))
+        action_builder.assert_has_calls([
+            mock.call(context={'init': 'stuff', 'key': 'value1'}),
+            mock.call(context={'init': 'stuff', 'key': 'tadaa'})
+        ])
+
     def test_build_actions_with_contexts(self):
         acts = [dict(self.actor_returns),
                 dict(self.actor_returns),

--- a/kingpin/actors/test/test_misc.py
+++ b/kingpin/actors/test/test_misc.py
@@ -39,6 +39,13 @@ class TestMacro(testing.AsyncTestCase):
             self.assertEquals(schema_validate.call_count, 1)
             self.assertEquals(actor.initial_actor, get_actor())
 
+    def test_init_nested_tokens(self):
+        actor = misc.Macro(
+            options={'macro': 'examples/misc.macro/outer.yaml'})
+        self.assertEquals(actor, True)
+
+        self.assertTrue(False)
+
     def test_init_remote(self):
         misc.Macro._get_config_from_script = mock.Mock()
         misc.Macro._check_schema = mock.Mock()

--- a/kingpin/actors/test/test_misc.py
+++ b/kingpin/actors/test/test_misc.py
@@ -33,21 +33,52 @@ class TestMacro(testing.AsyncTestCase):
             }
 
             actor = misc.Macro('Unit Test', {'macro': 'test.json',
-                                             'tokens': {}})
+                                             'tokens': {}},
+                               init_tokens={})
 
             j2d.assert_called_with(script_file='unit-test-macro', tokens={})
             self.assertEquals(schema_validate.call_count, 1)
             self.assertEquals(actor.initial_actor, get_actor())
 
     def test_init_nested_tokens(self):
-        actor = misc.Macro(
-            options={'macro': 'examples/misc.macro/outer.yaml'})
-        self.assertEquals(actor, True)
+        # Quick test to ensure that a series of nested groups and macro actors
+        # will pass supplied tokens all the way down to their sub actors.
 
-        self.assertTrue(False)
+        # Generate a single outer actor. This actor will create many internal
+        # actors.
+        init_tokens = {'SLEEP': 0}
+        actor = misc.Macro(
+            options={'macro': 'examples/misc.macro/outer_group.yaml'},
+            init_tokens=init_tokens)
+
+        # Ensure that the initial misc.Macro actor, and the initial actor it
+        # created (from outer_group.yaml) both have the appropriate init
+        # tokens. This helps ensure that we used .copy() properly a well as the
+        # fact that the tokens were passed down appropriately.
+        self.assertEquals(actor._init_tokens, init_tokens)
+        self.assertEquals(actor.initial_actor._init_tokens, init_tokens)
+
+        # Ensure that the nested misc.Macro actor from outer_macro.yaml got
+        # init_tokens, AND the 'FOO' token from outer_group.yaml's own
+        # definition.
+        self.assertEquals(actor.initial_actor._actions[0]._init_tokens,
+                          {'SLEEP': 0, 'FOO': 'weee'})
+
+        # Next ensure that the mostly nested examples/misc.macro/inner.yaml
+        # actor got the SLEEP, FOO, and DESC tokens.
+        self.assertEquals(
+            actor.initial_actor._actions[0].initial_actor._init_tokens,
+            {'SLEEP': 0, 'FOO': 'weee', 'DESC': 'Sleeping for a while'})
+
+        # Finally, ensure the super nested
+        s = actor.initial_actor._actions[0].initial_actor.initial_actor
+        self.assertEquals(
+            s._init_tokens,
+            {'SLEEP': 0, 'FOO': 'weee', 'DESC': 'Sleeping for a while'})
 
     def test_init_remote(self):
         misc.Macro._get_config_from_script = mock.Mock()
+        misc.Macro._get_config_from_script.return_value = {}
         misc.Macro._check_schema = mock.Mock()
         with mock.patch('kingpin.actors.utils.get_actor'):
             with mock.patch.object(httpclient.HTTPClient, 'fetch'):
@@ -57,6 +88,7 @@ class TestMacro(testing.AsyncTestCase):
     def test_init_dry(self):
         misc.Macro._check_macro = mock.Mock()
         misc.Macro._get_config_from_script = mock.Mock()
+        misc.Macro._get_config_from_script.return_value = {}
         misc.Macro._check_schema = mock.Mock()
 
         with mock.patch('kingpin.utils.convert_script_to_dict') as j2d, \
@@ -121,6 +153,7 @@ class TestMacro(testing.AsyncTestCase):
         misc.Macro._check_macro = mock.Mock()
         misc.Macro._get_macro = mock.Mock()
         misc.Macro._get_config_from_script = mock.Mock()
+        misc.Macro._get_config_from_script.return_value = {}
         misc.Macro._check_schema = mock.Mock()
 
         with mock.patch('kingpin.actors.utils.get_actor') as get_actor:

--- a/kingpin/actors/utils.py
+++ b/kingpin/actors/utils.py
@@ -58,7 +58,15 @@ def get_actor(config, dry):
     # not a valid kwarg for an Actor object.
     actor_string = config.pop('actor')
 
-    log.debug('Building Actor "%s" with args: %s' % (actor_string, config))
+    # Create a copy of the config dict, but strip out the tokens. They likely
+    # contain credentials! This is used purely for this debug message below.
+    #
+    # Known actors that do this are misc.Macro, group.Sync, group.Async
+    clean_config = config.copy()
+    clean_config['init_tokens'] = '<hidden>'
+
+    log.debug('Building Actor "%s" with args: %s' %
+              (actor_string, clean_config))
     ActorClass = get_actor_class(actor_string)
     return ActorClass(dry=dry, **config)
 

--- a/kingpin/actors/utils.py
+++ b/kingpin/actors/utils.py
@@ -76,7 +76,7 @@ def get_actor_class(actor):
 
     # Try to load our local actors up first. Assume that the
     # 'kingpin.actors.' prefix was not included in the name.
-    for prefix in ['', 'kingpin.actors.', 'actors.']:
+    for prefix in ['kingpin.actors.', '', 'actors.']:
         full_actor = prefix + actor
         try:
             return utils.str_to_class(full_actor)

--- a/kingpin/bin/deploy.py
+++ b/kingpin/bin/deploy.py
@@ -79,8 +79,6 @@ def kingpin_fail(message):
 
 
 def get_main_actor(dry):
-    env_tokens = dict(os.environ)
-
     # Cannot specify a script file an an actor at the same time.
     if args.script and args.actor:
         kingpin_fail('You may only specify --actor or --script, not both!')
@@ -102,9 +100,7 @@ def get_main_actor(dry):
             '%s You must specify --script or provide it as first argument.'
             % e)
 
-    return Macro(desc='Kingpin',
-                 options={'macro': script, 'tokens': env_tokens},
-                 dry=dry)
+    return Macro(desc='Kingpin', options={'macro': script}, dry=dry)
 
 
 @gen.coroutine


### PR DESCRIPTION
This patch implements a "token passing" system for the Group and Macro actors. These special actor types can pass in the "tokens" they were initialized with to each subsequent actor, allowing that actor to have the same access as the first one. This allows for a deeply nested Macro or Group actor to leverage a variable that was available at code launch time, but not necessarily passed to it.

Though this change is not backwards-incompatible -- its definitely a large change in the way we think about drawing up large and complex JSON/YAML scripts.

Closes #362.

