### PR TITLE
Make the 'init_tokens' available to all actors.

### DIFF
--- a/kingpin/actors/aws/base.py
+++ b/kingpin/actors/aws/base.py
@@ -34,7 +34,6 @@ _Note, these can be skipped only if you have a .aws/credentials file in place._
 
 import json
 import logging
-import os
 import urllib
 import re
 
@@ -293,7 +292,7 @@ class AWSBaseActor(base.BaseActor):
 
         try:
             p_doc = utils.convert_script_to_dict(script_file=policy,
-                                                 tokens=os.environ)
+                                                 tokens=self._init_tokens)
         except kingpin_exceptions.InvalidScript as e:
             raise exceptions.UnrecoverableActorFailure('Error parsing %s: %s' %
                                                        (policy, e))

--- a/kingpin/actors/base.py
+++ b/kingpin/actors/base.py
@@ -106,17 +106,9 @@ class BaseActor(object):
     strict_init_context = True
 
     def __init__(self, desc=None, options={}, dry=False, warn_on_failure=False,
-                 condition=True, init_context={}, timeout=None, *args,
-                 **kwargs):
+                 condition=True, init_context={}, init_tokens={},
+                 timeout=None):
         """Initializes the Actor.
-
-        Note about *args/**kwargs:
-          In rare cases, it may be that an Actor that subclasses BaseActor will
-          need to be able to privately pass or accept internal options that the
-          user never sees. An example of this is the group.Sync/Async and
-          misc.Macro actors which pass an 'init_tokens' dictionary around to
-          help with %TOKEN% parsing. In these cases, we want to silently accept
-          the passed in values, but we don't do anything with them ourselves.
 
         Args:
             desc: (Str) description of the action being executed.
@@ -129,6 +121,9 @@ class BaseActor(object):
             init_context: (Dict) Key/Value pairs used at instantiation
                 time to replace {KEY} strings in the actor definition.
                 This is usually driven by the group.Sync/Async actors.
+            init_tokens: (Dict) Key/Value pairs passed into the actor that can
+            be used for token replacement. Typically this is os.environ() plus
+            some custom tokens. Set generally by the misc.Macro actor.
             timeout: (Str/Int/Float) Timeout in seconds for the actor.
         """
         self._type = '%s.%s' % (self.__module__, self.__class__.__name__)
@@ -138,6 +133,7 @@ class BaseActor(object):
         self._warn_on_failure = warn_on_failure
         self._condition = condition
         self._init_context = init_context
+        self._init_tokens = init_tokens
 
         self._timeout = timeout
         if timeout is None:

--- a/kingpin/actors/group.py
+++ b/kingpin/actors/group.py
@@ -80,17 +80,8 @@ class BaseGroupActor(base.BaseActor):
 
           See `Token-replacement <basicuse.html#token-replacement>` for more
           info.
-
-        args:
-          init_tokens: <privately used, see note above>
         """
         super(BaseGroupActor, self).__init__(*args, **kwargs)
-
-        # Store the init_tokens tokens that were passed into us at
-        # instantiation time -- these would only come from a misc.Macro or
-        # group.Sync/Async actor. These will be passed to all sub-actors in the
-        # _build_actions() method.
-        self._init_tokens = kwargs.get('init_tokens', {})
 
         # DEPRECATE IN v0.5.0
         if type(self.option('contexts')) == dict:

--- a/kingpin/actors/misc.py
+++ b/kingpin/actors/misc.py
@@ -27,7 +27,6 @@ dedicated packages. Things like sleep timers, loggers, etc.
   headers/cookies/etc. are exposed*
 """
 
-import os
 import StringIO
 import json
 import logging
@@ -134,13 +133,9 @@ class Macro(base.BaseActor):
     def __init__(self, *args, **kwargs):
         """Pre-parse the script file and compile actors.
 
-        *Note about init_tokens:*
-          See group.BaseActor for more information.
-
-        args:
-            init_tokens: <privately used, see note above>
+        Note, we override the default init_tokens={} from the base class and
+        default it to a _copy_ of the os.environ dict.
         """
-
         super(Macro, self).__init__(*args, **kwargs)
 
         # Temporary check that macro is a local file.
@@ -152,7 +147,6 @@ class Macro(base.BaseActor):
         # and merge them with the explicitly defined tokens in the actor
         # definition itself. Give priority to the explicitly defined tokens on
         # any conflicts.
-        self._init_tokens = kwargs.get('init_tokens', os.environ.copy())
         self._init_tokens.update(self.option('tokens'))
 
         # Copy the tmp file / download a remote macro

--- a/kingpin/bin/deploy.py
+++ b/kingpin/bin/deploy.py
@@ -79,6 +79,8 @@ def kingpin_fail(message):
 
 
 def get_main_actor(dry):
+    env_tokens = dict(os.environ)
+
     # Cannot specify a script file an an actor at the same time.
     if args.script and args.actor:
         kingpin_fail('You may only specify --actor or --script, not both!')
@@ -100,7 +102,9 @@ def get_main_actor(dry):
             '%s You must specify --script or provide it as first argument.'
             % e)
 
-    return Macro(desc='Kingpin', options={'macro': script}, dry=dry)
+    return Macro(desc='Kingpin',
+                 options={'macro': script, 'tokens': env_tokens},
+                 dry=dry)
 
 
 @gen.coroutine

--- a/kingpin/version.py
+++ b/kingpin/version.py
@@ -13,4 +13,4 @@
 # Copyright 2014 Nextdoor.com, Inc
 
 
-__version__ = '0.3.1a'
+__version__ = '0.3.1b'


### PR DESCRIPTION
The self._init_tokens are actually useful for all actors -- for example,
the AWS actors should be able to use them  when parsing cloudformation and
inline policies.