### PR TITLE
Add Lifecycle Management support to the aws.s3.Bucket actor.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -289,7 +289,10 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/2.7', None),
+    'boto': ('http://boto.cloudhackers.com/en/latest/', None)
+}
 
 # Force the RTD theme for all builds
 import sphinx_rtd_theme

--- a/kingpin/actors/aws/test/integration_s3.py
+++ b/kingpin/actors/aws/test/integration_s3.py
@@ -45,7 +45,7 @@ class IntegrationS3(testing.AsyncTestCase):
 
     @attr('aws', 'integration')
     @testing.gen_test(timeout=60)
-    def integration_01a_create_bucket(self):
+    def integration_01_create_bucket(self):
         actor = s3.Bucket(
             options={
                 'name': self.bucket_name,
@@ -60,7 +60,7 @@ class IntegrationS3(testing.AsyncTestCase):
 
     @attr('aws', 'integration')
     @testing.gen_test(timeout=60)
-    def integration_01b_set_bucket_policy(self):
+    def integration_02a_set_bucket_policy(self):
         actor = s3.Bucket(
             options={
                 'name': self.bucket_name,
@@ -74,7 +74,7 @@ class IntegrationS3(testing.AsyncTestCase):
 
     @attr('aws', 'integration')
     @testing.gen_test(timeout=60)
-    def integration_01c_delete_bucket_policy(self):
+    def integration_02b_delete_bucket_policy(self):
         actor = s3.Bucket(
             options={
                 'name': self.bucket_name,
@@ -88,7 +88,7 @@ class IntegrationS3(testing.AsyncTestCase):
 
     @attr('aws', 'integration')
     @testing.gen_test(timeout=60)
-    def integration_01d_enable_versioning(self):
+    def integration_03a_enable_versioning(self):
         actor = s3.Bucket(
             options={
                 'name': self.bucket_name,
@@ -102,13 +102,73 @@ class IntegrationS3(testing.AsyncTestCase):
 
     @attr('aws', 'integration')
     @testing.gen_test(timeout=60)
-    def integration_01d_disable_versioning(self):
+    def integration_03b_disable_versioning(self):
         actor = s3.Bucket(
             options={
                 'name': self.bucket_name,
                 'region': self.region,
                 'state': 'present',
                 'versioning': False,
+            }
+        )
+        done = yield actor.execute()
+        self.assertEquals(done, None)
+
+    @attr('aws', 'integration')
+    @testing.gen_test(timeout=60)
+    def integration_04a_enable_lifecycle_management(self):
+        actor = s3.Bucket(
+            options={
+                'name': self.bucket_name,
+                'region': self.region,
+                'state': 'present',
+                'lifecycle': [{
+                    'id': 'test',
+                    'prefix': '/',
+                    'status': 'Enabled',
+                    'expiration': 30,
+                    'transition': {
+                        'days': 10,
+                        'storage_class': 'GLACIER'
+                    }
+                }]
+            }
+        )
+        done = yield actor.execute()
+        self.assertEquals(done, None)
+
+    @attr('aws', 'integration')
+    @testing.gen_test(timeout=60)
+    def integration_04b_update_lifecycle_management(self):
+        actor = s3.Bucket(
+            options={
+                'name': self.bucket_name,
+                'region': self.region,
+                'state': 'present',
+                'lifecycle': [{
+                    'id': 'test',
+                    'prefix': '/',
+                    'status': 'Enabled',
+                    'expiration': 180,
+                    'transition': {
+                        'days': 90,
+                        'storage_class': 'STANDARD_IA'
+                    }
+                }]
+            }
+        )
+        done = yield actor.execute()
+        self.assertEquals(done, None)
+
+    @attr('aws', 'integration')
+    @testing.gen_test(timeout=60)
+    def integration_04c_disable_lifecycle_management(self):
+        actor = s3.Bucket(
+            options={
+                'name': self.bucket_name,
+                'region': self.region,
+                'state': 'present',
+                'lifecycle': []
             }
         )
         done = yield actor.execute()

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ futures
 # Used to parse out the JSON and validate its format.
 simplejson
 jsonschema
+jsonpickle
 demjson
 datadiff
 PyYAML


### PR DESCRIPTION
This adds full management (configuring, deleting and updating) of the S3
bucket lifecycle policies. As many policies can be defined as needed,
and they are all schema-checked as much as possible to ensure fast
detection of invalid policies.