### PR TITLE
Bugfix -- Ensure the appropriate kwargs are used for the dry decorator.

### DIFF
--- a/kingpin/actors/aws/s3.py
+++ b/kingpin/actors/aws/s3.py
@@ -720,7 +720,8 @@ class Bucket(S3BaseActor):
         # Next simple check -- if we're pushing a new config, and the old
         # config is empty (there was none), then just go and push it.
         if existing is None:
-            yield self._configure_lifecycle(bucket, self.lifecycle)
+            yield self._configure_lifecycle(bucket=bucket,
+                                            lifecycle=self.lifecycle)
             raise gen.Return()
 
         # Now sort through the existing Lifecycle configuration and the one
@@ -733,7 +734,8 @@ class Bucket(S3BaseActor):
             self.log.info('Lifecycle configurations do not match. Updating.')
             for line in diff.split('\n'):
                 self.log.info('Diff: %s' % line)
-            yield self._configure_lifecycle(bucket, self.lifecycle)
+            yield self._configure_lifecycle(bucket=bucket,
+                                            lifecycle=self.lifecycle)
 
     @gen.coroutine
     @dry('Would have deleted the existing lifecycle configuration')

--- a/kingpin/actors/aws/test/test_sqs.py
+++ b/kingpin/actors/aws/test/test_sqs.py
@@ -95,10 +95,10 @@ class TestDeleteSQSQueueActor(SQSTestCase):
                            {'name': 'unit-test-queue',
                             'region': 'us-west-2'})
         q = mock.Mock()
-        q.name = 'unit-test-queue'
+        q .name = 'unit-test-queue'
         self.sqs_conn().delete_queue.return_value = False
         with self.assertRaises(sqs.QueueDeletionFailed):
-            yield actor._delete_queue(q)
+            yield actor._delete_queue(queue=q)
 
     @testing.gen_test
     def test_execute(self):

--- a/kingpin/actors/utils.py
+++ b/kingpin/actors/utils.py
@@ -53,14 +53,21 @@ def dry(dry_message):
         variables you'd like can be substituted as long as they're passed to
         the method being wrapped.
     """
-    log.debug('Creating _skip_on_dry decorator with "%s"' % dry_message)
+    # TODO: Bring these back when we have log.trace
+    # log.debug('Creating _skip_on_dry decorator with "%s"' % dry_message)
 
     def _skip_on_dry(f):
-        log.debug('Decorating function "%s" with _skip_on_dry' % f)
+        # TODO: Bring these back when we have log.trace
+        # log.debug('Decorating function "%s" with _skip_on_dry' % f)
 
         def wrapper(self, *args, **kwargs):
+            # _Always_ compile the message we'd use in the event of a Dry run.
+            # This ensures that our test cases catch any time invalid **kwargs
+            # are passed in.
+            msg = dry_message.format(*args, **kwargs)
+
             if self._dry:
-                self.log.warning(dry_message.format(*args, **kwargs))
+                self.log.warning(msg)
                 raise gen.Return()
             ret = yield gen.coroutine(f)(self, *args, **kwargs)
             raise gen.Return(ret)


### PR DESCRIPTION
This fix has two parts -- one, I fix the bad calls where we were passing in
*args rather than *kwargs. Second, I moved the .format() call in the
@dry decorator so that its _always_ executed, and will fail any test case
where we execute that codepath incorrectly.