### PR TITLE
Convert aws.cloudformation.Create to use Boto3

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -291,7 +291,8 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': ('https://docs.python.org/2.7', None),
-    'boto': ('http://boto.cloudhackers.com/en/latest/', None)
+    'boto': ('http://boto.cloudhackers.com/en/latest/', None),
+    'boto3': ('http://boto3.readthedocs.io/en/latest/', None)
 }
 
 # Force the RTD theme for all builds

--- a/examples/test/aws.cloudformation/cf.unittest.json
+++ b/examples/test/aws.cloudformation/cf.unittest.json
@@ -1,1 +1,1 @@
-#BLANK
+{ "blank": "json" }

--- a/kingpin/actors/aws/base.py
+++ b/kingpin/actors/aws/base.py
@@ -51,6 +51,7 @@ import boto.ec2.elb
 import boto.iam
 import boto.sqs
 import boto.s3
+import boto3
 
 from kingpin import utils
 from kingpin import exceptions as kingpin_exceptions
@@ -155,8 +156,9 @@ class AWSBaseActor(base.BaseActor):
             region,
             aws_access_key_id=key,
             aws_secret_access_key=secret)
-        self.cf_conn = boto.cloudformation.connect_to_region(
-            region,
+        self.cf3_conn = boto3.client(
+            'cloudformation',
+            region_name=region,
             aws_access_key_id=key,
             aws_secret_access_key=secret)
         self.sqs_conn = boto.sqs.connect_to_region(

--- a/kingpin/actors/aws/cloudformation.py
+++ b/kingpin/actors/aws/cloudformation.py
@@ -27,9 +27,10 @@ from tornado import ioloop
 
 from kingpin import utils
 from kingpin.actors import exceptions
+from kingpin.actors.utils import dry
 from kingpin.actors.aws import base
-from kingpin.constants import SchemaCompareBase
-from kingpin.constants import REQUIRED
+from kingpin.constants import SchemaCompareBase, StringCompareBase
+from kingpin.constants import REQUIRED, STATE
 
 log = logging.getLogger(__name__)
 
@@ -46,6 +47,11 @@ EXECUTOR = concurrent.futures.ThreadPoolExecutor(10)
 class CloudFormationError(exceptions.RecoverableActorFailure):
 
     """Raised on any generic CloudFormation error."""
+
+
+class StackFailed(exceptions.RecoverableActorFailure):
+
+    """Raised any time a Stack fails to be created or updated."""
 
 
 class InvalidTemplate(exceptions.UnrecoverableActorFailure):
@@ -65,7 +71,11 @@ class StackNotFound(exceptions.RecoverableActorFailure):
 
 class ParametersConfig(SchemaCompareBase):
 
-    """Simple validation that the Parameters are pure Key/Value formatted"""
+    """Validates the Parameters option.
+
+    A valid `parameters` option is a dictionary with simple Key/Value pairs of
+    strings. No nested dicts, arrays or other objects.
+    """
 
     SCHEMA = {
         'type': ['object', 'null'],
@@ -81,11 +91,43 @@ class ParametersConfig(SchemaCompareBase):
     valid = '{ "key", "value", "key2", "value2" }'
 
 
+class CapabilitiesConfig(SchemaCompareBase):
+
+    """Validates the Capabilities option.
+
+    The only `capability` option available currently is `CAPABILITY_IAM` -- but
+    to support forwards compatibility, you must supply this as as a list.
+    """
+
+    SCHEMA = {
+        'type': ['array', 'null'],
+        'uniqueItems': True,
+        'items': {
+            'type': 'string',
+            'enum': ['CAPABILITY_IAM']
+        }
+    }
+    valid = '[ "CAPABILITY_IAM" ]'
+
+
+class OnFailureConfig(StringCompareBase):
+
+    """Validates the On Failure option.
+
+    The `on_failure` option can take one of the following settings:
+      `DO_NOTHING`, `ROLLBACK`, `DELETE`
+
+    This option is applied at stack _creation_ time!
+    """
+
+    valid = ('DO_NOTHING', 'ROLLBACK', 'DELETE')
+
+
 # CloudFormation has over a dozen different 'stack states'... but for the
 # purposes of these actors, we really only care about a few logical states.
 # Here we map the raw states into logical states.
 COMPLETE = ('CREATE_COMPLETE', 'UPDATE_COMPLETE')
-DELETED = ('DELETE_COMPLETE', 'ROLLBACK_COMPLETE')
+DELETED = ('DELETE_COMPLETE', )
 IN_PROGRESS = (
     'CREATE_IN_PROGRESS', 'DELETE_IN_PROGRESS',
     'ROLLBACK_IN_PROGRESS', 'UPDATE_COMPLETE_CLEANUP_IN_PROGRESS',
@@ -93,7 +135,7 @@ IN_PROGRESS = (
     'UPDATE_ROLLBACK_IN_PROGRESS')
 FAILED = (
     'CREATE_FAILED', 'DELETE_FAILED', 'ROLLBACK_FAILED',
-    'UPDATE_ROLLBACK_FAILED')
+    'UPDATE_ROLLBACK_FAILED', 'ROLLBACK_COMPLETE')
 
 
 class CloudFormationBaseActor(base.AWSBaseActor):
@@ -110,6 +152,66 @@ class CloudFormationBaseActor(base.AWSBaseActor):
     all_options = {
         'region': (str, REQUIRED, 'AWS region (or zone) name, like us-west-2')
     }
+
+    def _get_template_body(self, template):
+        """Reads in a local template file and returns the contents.
+
+        If the template string supplied is a local file resource (has no
+        URI prefix), then this method will return the contents of the file.
+        Otherwise, returns None.
+
+        Args:
+            template: String with a reference to a template location.
+
+        Returns:
+            One tuple of:
+              (Contents of template file, None)
+              (None, URL of template)
+
+        Raises:
+            InvalidTemplate
+        """
+        if template is None:
+            return (None, None)
+
+        remote_types = ('http://', 'https://')
+
+        if template.startswith(remote_types):
+            return (None, template)
+
+        try:
+            return (json.dumps(self._parse_policy_json(template)), None)
+        except exceptions.UnrecoverableActorFailure as e:
+            raise InvalidTemplate(e)
+
+    @gen.coroutine
+    def _validate_template(self, body=None, url=None):
+        """Validates the CloudFormation template.
+
+        args:
+          body: The body of the template
+          url: A URL pointing to a template
+
+        Raises:
+            InvalidTemplate
+            exceptions.InvalidCredentials
+        """
+
+        if body is not None:
+            cfg = {'TemplateBody': body}
+            self.log.info('Validating template with AWS...')
+            try:
+                yield self.thread(self.cf3_conn.validate_template, **cfg)
+            except ClientError as e:
+                raise InvalidTemplate(e.message)
+
+        if url is not None:
+            cfg = {'TemplateURL': url}
+            self.log.info('Validating template (%s) with AWS...' % url)
+            try:
+                yield self.thread(self.cf3_conn.validate_template, **cfg)
+            except ClientError as e:
+                raise InvalidTemplate(e.message)
 
     def _create_parameters(self, parameters, use_previous_value=False):
         """Converts a simple Key/Value dict into Amazon CF Parameters.
@@ -145,45 +247,32 @@ class CloudFormationBaseActor(base.AWSBaseActor):
         return sorted_params
 
     @gen.coroutine
-    def _get_stacks(self):
-        """Gets a list of existing CloudFormation stacks.
-
-        Gets a list of all of the stacks currently in the account, that are not
-        in the status 'DELETE_COMPLETE'.
-
-        Returns:
-            A list of Boto S3 Stack Dicts
-        """
-        # Get the list of all possible stack statuses from the Boto module,
-        # then pull out the few that indicate a stack is no longer in
-        # existence.
-        self.log.debug('Getting list of stacks from Amazon..')
-        statuses = COMPLETE + IN_PROGRESS + FAILED
-        stacks = yield self.thread(self.cf3_conn.list_stacks,
-                                   StackStatusFilter=statuses)
-        raise gen.Return(stacks['StackSummaries'])
-
-    @gen.coroutine
     def _get_stack(self, stack):
         """Returns a cloudformation.Stack object of the requested stack.
 
+        If a "stack name" is supplied, Amazon returns only stacks that are
+        "live" -- it does not return deleted stacks. If a "stack id" is used,
+        Amazon will return the deleted stack as well.
+
         Args:
-            stack: String name
+            stack: Stack name or stack ID
 
         Returns
             <Stack Dict> or <None>
         """
-        stacks = yield self._get_stacks()
-        self.log.debug('Checking whether stack exists')
-        new_list = [s for s in stacks if s['StackName'] == stack]
+        try:
+            stacks = yield self.thread(self.cf3_conn.describe_stacks,
+                                       StackName=stack)
+        except ClientError as e:
+            if 'does not exist' in e.message:
+                raise gen.Return(None)
 
-        if len(new_list) > 0:
-            raise gen.Return(new_list[0])
+            raise CloudFormationError(e)
 
-        raise gen.Return(None)
+        raise gen.Return(stacks['Stacks'][0])
 
     @gen.coroutine
-    def _wait_until_state(self, desired_states, sleep=15):
+    def _wait_until_state(self, stack_name, desired_states, sleep=15):
         """Indefinite loop until a stack has finished creating/deleting.
 
         Whether the stack has failed, suceeded or been rolled back... this
@@ -191,6 +280,7 @@ class CloudFormationBaseActor(base.AWSBaseActor):
         failure (rollback/failed) then an exception is raised.
 
         Args:
+            stack_name: The stack name or stack ID to watch
             desired_states: (tuple/list) States that indicate a successful
                             operation.
             sleep: (int) Time in seconds between stack status checks
@@ -199,13 +289,11 @@ class CloudFormationBaseActor(base.AWSBaseActor):
             StackNotFound: If the stack doesn't exist.
         """
         while True:
-            stack = yield self._get_stack(self.option('name'))
+            stack = yield self._get_stack(stack_name)
 
             if not stack:
                 msg = 'Stack "%s" not found.' % self.option('name')
                 raise StackNotFound(msg)
-
-            self.log.debug('Got stack status: %s' % stack['StackStatus'])
 
             # First, lets see if the stack is still in progress (either
             # creation, deletion, or rollback .. doesn't really matter)
@@ -217,14 +305,121 @@ class CloudFormationBaseActor(base.AWSBaseActor):
 
             # If the stack is in the desired state, then return
             if stack['StackStatus'] in desired_states:
-                self.log.info('Stack execution completed, final state: %s' %
-                              stack['StackStatus'])
+                self.log.info('Stack state: %s' % stack['StackStatus'])
                 raise gen.Return()
 
             # Lastly, if we get here, then something is very wrong and we got
             # some funky status back. Throw an exception.
             msg = 'Unxpected stack state received (%s)' % stack['StackStatus']
-            raise CloudFormationError(msg)
+            raise StackFailed(msg)
+
+    @gen.coroutine
+    def _get_stack_events(self, stack):
+        """Returns a list of human-readable CF Events.
+
+        Searches for all of the Stack events for a given CF Stack and returns
+        them in a human-readable list of strings.
+
+        http://docs.aws.amazon.com/AWSCloudFormation/latest/
+        APIReference/API_DescribeStackEvents.html
+
+        args:
+            stack: Stack ID or Stack name
+
+        returns:
+            [<list of human readable strings>]
+        """
+        try:
+            raw = yield self.thread(
+                self.cf3_conn.describe_stack_events, StackName=stack)
+        except ClientError:
+            raise gen.Return([])
+
+        # Reverse the list, and iterate through the data
+        events = []
+        for event in raw['StackEvents'][::-1]:
+            # Not every event has a "reason" ... for those, we add a blank reason
+            # value just to make string formatting easier below.
+            if 'ResourceStatusReason' not in event:
+                event['ResourceStatusReason'] = ''
+
+            log_string_fmt = (
+                '{ResourceType} {LogicalResourceId} '
+                '({ResourceStatus}): {ResourceStatusReason}'
+            )
+
+            events.append(log_string_fmt.format(**event))
+
+        raise gen.Return(events)
+
+    @gen.coroutine
+    @dry('Would have deleted stack {stack}')
+    def _delete_stack(self, stack):
+        """Executes the stack deletion."""
+
+        exists = yield self._get_stack(stack)
+        if not exists:
+            raise StackNotFound('Stack does not exist!')
+
+        self.log.info('Deleting stack')
+        try:
+            ret = yield self.thread(
+                self.cf3_conn.delete_stack, StackName=stack)
+        except ClientError as e:
+            raise CloudFormationError(e.message)
+
+        req_id = ret['ResponseMetadata']['RequestId']
+        self.log.info('Stack delete requested: %s' % req_id)
+
+        # Now wait until the stack creation has finished
+        try:
+            yield self._wait_until_state(exists['StackId'], DELETED)
+        except StackNotFound:
+            # Pass here because a stack not found exception is totally
+            # reasonable since we're deleting the stack. Sometimes Amazon
+            # actually deletes the stack immediately, and othertimes it lists
+            # the stack as a 'deleted' state, but we still get that state back.
+            # Either case is fine.
+            pass
+
+    @gen.coroutine
+    @dry('Would have created stack {stack}')
+    def _create_stack(self, stack):
+        """Executes the stack creation."""
+        # Create the stack, and get its ID.
+        self.log.info('Creating stack %s' % stack)
+
+        if self._template_body:
+            cfg = {'TemplateBody': self._template_body}
+        else:
+            cfg = {'TemplateURL': self._template_url}
+
+        try:
+            stack = yield self.thread(
+                self.cf3_conn.create_stack,
+                StackName=stack,
+                Parameters=self._parameters,
+                OnFailure=self.option('on_failure'),
+                TimeoutInMinutes=self.option('timeout_in_minutes'),
+                Capabilities=self.option('capabilities'),
+                **cfg)
+        except ClientError as e:
+            raise CloudFormationError(e.message)
+
+        # Now wait until the stack creation has finished. If the creation
+        # fails, get the logs from Amazon for the user.
+        try:
+            yield self._wait_until_state(stack['StackId'], COMPLETE)
+        except StackFailed as e:
+            events = yield self._get_stack_events(stack['StackId'])
+            for e in events:
+                self.log.error(e)
+            msg = 'Stack creation failed: %s' % events
+            raise StackFailed(msg)
+
+        self.log.info('Stack created: %s' % stack['StackId'])
+
+        raise gen.Return(stack['StackId'])
 
 
 class Create(CloudFormationBaseActor):
@@ -236,14 +431,18 @@ class Create(CloudFormationBaseActor):
 
     **Options**
 
+    :name:
+      The name of the queue to create
+
     :capabilities:
       A list of CF capabilities to add to the stack.
 
-    :disable_rollback:
-      Set to True to disable rollback of the stack if creation failed.
+    :on_failure:
+     (:py:class:`OnFailureConfig`)
 
-    :name:
-      The name of the queue to create
+     One of the following strings: `DO_NOTHING`, `ROLLBACK`, `DELETE`
+
+     Default: `DELETE`
 
     :parameters:
       A dictionary of key/value pairs used to fill in the parameters for the
@@ -269,7 +468,6 @@ class Create(CloudFormationBaseActor):
          "actor": "aws.cloudformation.Create",
          "options": {
            "capabilities": [ "CAPABILITY_IAM" ],
-           "disable_rollback": true,
            "name": "%CF_NAME%",
            "parameters": {
              "test_param": "%TEST_PARAM_NAME%",
@@ -290,9 +488,8 @@ class Create(CloudFormationBaseActor):
         'capabilities': (list, [],
                          'The list of capabilities that you want to allow '
                          'in the stack'),
-        'disable_rollback': (bool, False,
-                             'Set to `True` to disable rollback of the stack '
-                             'if stack creation failed.'),
+        'on_failure': (OnFailureConfig, 'DELETE',
+                       'Action to take if the stack fails to be created'),
         'name': (str, REQUIRED, 'Name of the stack'),
         'parameters': (ParametersConfig, {}, 'Parameters passed into the CF '
                                              'template execution'),
@@ -319,90 +516,13 @@ class Create(CloudFormationBaseActor):
         (self._template_body, self._template_url) = self._get_template_body(
             self.option('template'))
 
-    def _get_template_body(self, template):
-        """Reads in a local template file and returns the contents.
-
-        If the template string supplied is a local file resource (has no
-        URI prefix), then this method will return the contents of the file.
-        Otherwise, returns None.
-
-        Args:
-            template: String with a reference to a template location.
-
-        Returns:
-            One tuple of:
-              (Contents of template file, None)
-              (None, URL of template)
-
-        Raises:
-            InvalidTemplate
-        """
-        remote_types = ('http://', 'https://')
-
-        if template.startswith(remote_types):
-            self.log.error('GOT HERE')
-            return (None, template)
-
-        try:
-            return (json.dumps(self._parse_policy_json(template)), None)
-        except exceptions.UnrecoverableActorFailure as e:
-            raise InvalidTemplate(e)
-
-    @gen.coroutine
-    def _validate_template(self):
-        """Validates the CloudFormation template.
-
-        Raises:
-            InvalidTemplate
-            exceptions.InvalidCredentials
-        """
-        if self._template_body is not None:
-            self.log.info('Validating template with AWS...')
-        else:
-            self.log.info('Validating template (%s) with AWS...' %
-                          self._template_url)
-
-        if self._template_body:
-            cfg = {'TemplateBody': self._template_body}
-        else:
-            cfg = {'TemplateURL': self._template_url}
-
-        try:
-            yield self.thread(self.cf3_conn.validate_template, **cfg)
-        except ClientError as e:
-            raise InvalidTemplate(e.message)
-
-    @gen.coroutine
-    def _create_stack(self):
-        """Executes the stack creation."""
-        # Create the stack, and get its ID.
-        self.log.info('Creating stack %s' % self.option('name'))
-
-        if self._template_body:
-            cfg = {'TemplateBody': self._template_body}
-        else:
-            cfg = {'TemplateURL': self._template_url}
-
-        try:
-            stack = yield self.thread(
-                self.cf3_conn.create_stack,
-                StackName=self.option('name'),
-                Parameters=self._parameters,
-                DisableRollback=self.option('disable_rollback'),
-                TimeoutInMinutes=self.option('timeout_in_minutes'),
-                Capabilities=self.option('capabilities'),
-                **cfg)
-        except ClientError as e:
-            raise CloudFormationError(e.message)
-
-        self.log.info('Stack created: %s' % stack['StackId'])
-        raise gen.Return(stack['StackId'])
-
     @gen.coroutine
     def _execute(self):
         stack_name = self.option('name')
 
-        yield self._validate_template()
+        yield self._validate_template(
+            self._template_body,
+            self._template_url)
 
         # If a stack already exists, we cannot re-create it. Raise a
         # recoverable exception and let the end user decide whether this is bad
@@ -418,10 +538,7 @@ class Create(CloudFormationBaseActor):
             raise gen.Return()
 
         # Create the stack
-        yield self._create_stack()
-
-        # Now wait until the stack creation has finished
-        yield self._wait_until_state(COMPLETE)
+        yield self._create_stack(stack=stack_name)
 
         raise gen.Return()
 
@@ -463,47 +580,178 @@ class Delete(CloudFormationBaseActor):
     desc = "Deleting CloudFormation Stack {name}"
 
     @gen.coroutine
-    def _delete_stack(self):
-        """Executes the stack deletion."""
-        # Create the stack, and get its ID.
-        self.log.info('Deleting stack')
-        try:
-            ret = yield self.thread(
-                self.cf3_conn.delete_stack, StackName=self.option('name'))
-        except ClientError as e:
-            raise CloudFormationError(e.message)
+    def _execute(self):
+        stack_name = self.option('name')
+        yield self._delete_stack(stack=stack_name)
 
-        req_id = ret['ResponseMetadata']['RequestId']
-        self.log.info('Stack delete requested: %s' % req_id)
-        raise gen.Return(req_id)
+
+class Stack(CloudFormationBaseActor):
+
+    """Manages the state of a CloudFormation stack.
+
+    This actor can manage the following aspects of a CloudFormation stack in
+    Amazon:
+
+      * Ensure that the Stack is present or absent.
+      * Manage the CF Capabilities
+
+    **Options**
+
+    :name:
+      The name of the queue to create
+
+    :state:
+      (str) Present or Absent. Default: "present"
+
+    :capabilities:
+      (:py:class:`CapabilitiesConfig`, None)
+
+      A list of CF capabilities to add to the stack.
+
+    :disable_rollback:
+      Set to True to disable rollback of the stack if creation failed.
+
+    :on_failure:
+     (:py:class:`OnFailureConfig`, None)
+
+     One of the following strings: `DO_NOTHING`, `ROLLBACK`, `DELETE`
+
+     Default: `DELETE`
+
+    :parameters:
+      (:py:class:`ParametersConfig`, None)
+
+      A dictionary of key/value pairs used to fill in the parameters for the
+      CloudFormation template.
+
+    :region:
+      AWS region (or zone) string, like 'us-west-2'
+
+    :template:
+      String of path to CloudFormation template. Can either be in the form of a
+      local file path (ie, `./my_template.json`) or a URI (ie
+      `https://my_site.com/cf.json`).
+
+    :timeout_in_minutes:
+      The amount of time that can pass before the stack status becomes
+      CREATE_FAILED.
+
+    **Examples**
+
+    .. code-block:: json
+
+       { "actor": "aws.cloudformation.Create",
+         "state": "present",
+         "options": {
+           "capabilities": [ "CAPABILITY_IAM" ],
+           "on_failure": "DELETE",
+           "name": "%CF_NAME%",
+           "parameters": {
+             "test_param": "%TEST_PARAM_NAME%",
+           },
+           "region": "us-west-1",
+           "template": "/examples/cloudformation_test.json",
+           "timeout_in_minutes": 45,
+         }
+       }
+
+    **Dry Mode**
+
+    Validates the template, verifies that an existing stack with that name does
+    not exist. Does not create the stack.
+    """
+
+    all_options = {
+        'name': (str, REQUIRED, 'Name of the stack'),
+        'state': (STATE, 'present',
+                  'Desired state of the bucket: present/absent'),
+        'capabilities': (CapabilitiesConfig, [],
+                         'The list of capabilities that you want to allow '
+                         'in the stack'),
+        'disable_rollback': (bool, False,
+                             'Set to `True` to disable rollback of the stack '
+                             'if stack creation failed.'),
+        'on_failure': (OnFailureConfig, 'DELETE',
+                       'Action to take if the stack fails to be created'),
+        'parameters': (ParametersConfig, {}, 'Parameters passed into the CF '
+                                             'template execution'),
+        'region': (str, REQUIRED, 'AWS region (or zone) name, like us-west-2'),
+        'template': (str, REQUIRED,
+                     'Path to the AWS CloudFormation File. http(s)://, '
+                     'file:///, absolute or relative file paths.'),
+        'timeout_in_minutes': (int, 60,
+                               'The amount of time that can pass before the '
+                               'stack status becomes CREATE_FAILED'),
+    }
+
+    desc = 'CloudFormation Stack {name}'
+
+    def __init__(self, *args, **kwargs):
+        """Initialize our object variables."""
+        super(Stack, self).__init__(*args, **kwargs)
+
+        # Convert our supplied parameters into a properly formatted dict
+        self._parameters = self._create_parameters(self.option('parameters'))
+
+        # Check if the supplied CF template is a local file. If it is, read it
+        # into memory.
+        (self._template_body, self._template_url) = self._get_template_body(
+            self.option('template'))
+
+    @gen.coroutine
+    def _update_stack(self, stack):
+        self.log.info('Verifying that stack is in desired state')
+
+        # Upon a stack creation, there are two states the stack can be left in
+        # that are both un-fixable -- CREATE_FAILED and ROLLBACK_COMPLETE. In
+        # both of these cases, the only possible option is to destroy the stack
+        # and re-create it, you cannot fix a broken stack.
+        if stack['StackStatus'] in ('CREATE_FAILED', 'ROLLBACK_COMPLETE'):
+            self.log.warning(
+                'Stack found in a failed state: %s' % stack['StackStatus'])
+            yield self._delete_stack(stack=stack['StackId'])
+            yield self._create_stack(stack=stack['StackName'])
+            raise gen.Return()
+
+    @gen.coroutine
+    def _ensure_stack(self):
+        state = self.option('state')
+        stack_name = self.option('name')
+
+        self.log.info('Ensuring that CF Stack %s is %s' %
+                      (stack_name, state))
+
+        # Figure out if the stack already exists or not. In this case, we
+        # ignore DELETED stacks because they don't apply or block you from
+        # creating a new stack.
+        stack = yield self._get_stack(stack_name)
+
+        # Before we figure out what to do, lets make sure the stack isn't in a
+        # mutating state.
+        if stack:
+            yield self._wait_until_state(stack['StackId'],
+                                         (COMPLETE + FAILED + DELETED))
+
+        # Determine the current state of the stack vs the desired state
+        if state == 'absent' and stack is None:
+            self.log.debug('Stack does not exist')
+        elif state == 'absent' and stack:
+            yield self._delete_stack(stack=stack_name)
+        elif state == 'present' and stack is None:
+            stack = yield self._create_stack(stack=stack_name)
+        elif state == 'present' and stack:
+            stack = yield self._update_stack(stack)
+
+        raise gen.Return(stack)
 
     @gen.coroutine
     def _execute(self):
-        stack_name = self.option('name')
+        # Before we do anything, validate that the supplied template body or
+        # url is valid. If its not, an exception is raised.
+        yield self._validate_template(
+            self._template_body,
+            self._template_url)
 
-        # If the stack doesn't exist, let the user know.
-        exists = yield self._get_stack(stack_name)
-        if not exists:
-            raise StackNotFound('Stack does not exist!')
-
-        # If we're in dry mode, exit at this point. We can't do anything
-        # further to validate that the creation process will work.
-        if self._dry:
-            self.log.info('Skipping CloudFormation Stack deletion.')
-            raise gen.Return()
-
-        # Delete
-        yield self._delete_stack()
-
-        # Now wait until the stack creation has finished
-        try:
-            yield self._wait_until_state(DELETED)
-        except StackNotFound:
-            # Pass here because a stack not found exception is totally
-            # reasonable since we're deleting the stack. Sometimes Amazon
-            # actually deletes the stack immediately, and othertimes it lists
-            # the stack as a 'deleted' state, but we still get that state back.
-            # Either case is fine.
-            pass
-
-        raise gen.Return()
+        # This main method triggers the creation, deletion or update of the
+        # stack as necessary.
+        yield self._ensure_stack()

--- a/kingpin/actors/aws/test/integration_cloudformation.py
+++ b/kingpin/actors/aws/test/integration_cloudformation.py
@@ -86,13 +86,126 @@ class IntegrationCreate(testing.AsyncTestCase):
         done = yield actor.execute()
         self.assertEquals(done, None)
 
-    @attr('aws', 'integration')
-    @testing.gen_test(timeout=60)
-    def integration_04_delete_missing_stack_should_fail(self):
-        actor = cloudformation.Delete(
-            'Delete Stack',
-            {'region': self.region,
-             'name': self.bucket_name})
 
-        with self.assertRaises(cloudformation.StackNotFound):
-            yield actor.execute()
+class IntegrationStack(testing.AsyncTestCase):
+
+    """High Level CloudFormation Stack Testing.
+
+    These tests will check two things:
+    * Create a super-simple CloudFormation stack
+    * Update the stack
+    * Delete that same stack
+
+    Requirements:
+        Your AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must have access to
+        create CF stacks. The stack we create is extremely simple, and should
+        impact none of your AWS resources. The stack creates a simple S3
+        bucket, so your credentials must have access to create that buckets.
+
+    Note, these tests must be run in-order. The order is defined by
+    their definition order in this file. Nose follows this order according
+    to its documentation:
+
+        http://nose.readthedocs.org/en/latest/writing_tests.html
+    """
+
+    integration = True
+
+    region = 'us-east-1'
+    bucket_name = 'kingpin-stack-%s' % UUID
+
+    @attr('aws', 'integration')
+    @testing.gen_test(timeout=600)
+    def integration_01a_ensure_stack(self):
+        actor = cloudformation.Stack(
+            options={
+                'region': self.region,
+                'state': 'present',
+                'name': self.bucket_name,
+                'template':
+                    'examples/test/aws.cloudformation/cf.integration.json',
+                'parameters': {
+                    'BucketName': self.bucket_name}})
+
+        done = yield actor.execute()
+        self.assertEquals(done, None)
+
+    @attr('aws', 'integration')
+    @testing.gen_test(timeout=600)
+    def integration_01b_ensure_stack_still_there(self):
+        actor = cloudformation.Stack(
+            options={
+                'region': self.region,
+                'state': 'present',
+                'name': self.bucket_name,
+                'template':
+                    'examples/test/aws.cloudformation/cf.integration.json',
+                'parameters': {
+                    'BucketName': self.bucket_name}})
+
+        done = yield actor.execute()
+        self.assertEquals(done, None)
+
+    @attr('aws', 'integration')
+    @testing.gen_test(timeout=600)
+    def integration_02a_update_bucket_name(self):
+        actor = cloudformation.Stack(
+            options={
+                'region': self.region,
+                'state': 'present',
+                'name': self.bucket_name,
+                'template':
+                    'examples/test/aws.cloudformation/cf.integration.json',
+                'parameters': {
+                    'BucketName': '%s-updated' % self.bucket_name}})
+
+        done = yield actor.execute()
+        self.assertEquals(done, None)
+
+    @attr('aws', 'integration')
+    @testing.gen_test(timeout=600)
+    def integration_02a_update_bucket_name_second_time_should_work(self):
+        actor = cloudformation.Stack(
+            options={
+                'region': self.region,
+                'state': 'present',
+                'name': self.bucket_name,
+                'template':
+                    'examples/test/aws.cloudformation/cf.integration.json',
+                'parameters': {
+                    'BucketName': '%s-updated' % self.bucket_name}})
+
+        done = yield actor.execute()
+        self.assertEquals(done, None)
+
+    @attr('aws', 'integration')
+    @testing.gen_test(timeout=600)
+    def integration_03a_delete_stack(self):
+        actor = cloudformation.Stack(
+            options={
+                'region': self.region,
+                'state': 'absent',
+                'name': self.bucket_name,
+                'template':
+                    'examples/test/aws.cloudformation/cf.integration.json',
+                'parameters': {
+                    'BucketName': '%s-updated' % self.bucket_name}})
+
+        done = yield actor.execute()
+        self.assertEquals(done, None)
+
+    @attr('aws', 'integration')
+    @testing.gen_test(timeout=600)
+    def integration_03b_ensure_stack_absent(self):
+        actor = cloudformation.Stack(
+            options={
+                'region': self.region,
+                'state': 'absent',
+                'name': self.bucket_name,
+                'template':
+                    'examples/test/aws.cloudformation/cf.integration.json',
+                'parameters': {
+                    'BucketName': '%s-updated' % self.bucket_name}})
+
+        done = yield actor.execute()
+        self.assertEquals(done, None)

--- a/kingpin/actors/aws/test/test_cloudformation.py
+++ b/kingpin/actors/aws/test/test_cloudformation.py
@@ -24,6 +24,24 @@ def create_fake_stack(name, status):
     return fake_stack
 
 
+def create_fake_stack_event(name, resource, status, reason=None):
+    fake_event = {
+        'EventId': '264322b0-2426-11e6-aaa1-500c28b32ed2',
+        'LogicalResourceId': resource,
+        'PhysicalResourceId': 'arn:aws:cf:us-east-1:x:stack/%s/abc' % name,
+        'ResourceStatus': status,
+        'ResourceType': 'AWS::CloudFormation::Stack',
+        'StackId': 'arn:aws:cf:us-east-1:xxx:stack/%s/xyz' % name,
+        'StackName': name,
+        'Timestamp': datetime.datetime.now(),
+    }
+
+    if reason:
+        fake_event['ResourceStatusReason'] = reason
+
+    return fake_event
+
+
 class TestCloudFormationBaseActor(testing.AsyncTestCase):
 
     def setUp(self):
@@ -32,6 +50,67 @@ class TestCloudFormationBaseActor(testing.AsyncTestCase):
         settings.AWS_SECRET_ACCESS_KEY = 'unit-test'
         settings.RETRYING_SETTINGS = {'stop_max_attempt_number': 1}
         reload(cloudformation)
+
+        self.actor = cloudformation.CloudFormationBaseActor(
+            'unittest', {'region': 'us-east-1'})
+        self.actor.cf3_conn = mock.MagicMock(name='cf3_conn')
+
+    def test_get_template_body(self):
+        file = 'examples/test/aws.cloudformation/cf.unittest.json'
+        url = 'http://foobar.json'
+
+        # Should work...
+        ret = self.actor._get_template_body(file)
+        expected = ('{"blank": "json"}', None)
+        self.assertEquals(ret, expected)
+
+        # Should return None
+        ret = self.actor._get_template_body(None)
+        expected = (None, None)
+        self.assertEquals(ret, expected)
+
+        # Should return None
+        ret = self.actor._get_template_body(url)
+        expected = (None, 'http://foobar.json')
+        self.assertEquals(ret, expected)
+
+        # Should raise exception
+        with self.assertRaises(cloudformation.InvalidTemplate):
+            self.actor._get_template_body('missing')
+
+    @testing.gen_test
+    def test_validate_template_body(self):
+        yield self.actor._validate_template(body='test body')
+        self.actor.cf3_conn.validate_template.assert_called_with(
+            TemplateBody='test body')
+
+    @testing.gen_test
+    def test_validate_template_url(self):
+        yield self.actor._validate_template(url='http://foobar.json')
+        self.actor.cf3_conn.validate_template.assert_called_with(
+            TemplateURL='http://foobar.json')
+
+    @testing.gen_test
+    def test_validate_template_raises_boto_error(self):
+        fake_exc = {
+            'ResponseMetadata': {
+                'HTTPStatusCode': 400,
+                'RequestId': 'dfc1a12c-22c1-11e6-80b1-8fd4cf167f54'
+            },
+            'Error': {
+                'Message': 'Template format error: JSON not well-formed',
+                'Code': 'ValidationError',
+                'Type': 'Sender'
+            }
+        }
+
+        self.actor.cf3_conn.validate_template.side_effect = ClientError(
+            fake_exc, 'FakeOperation')
+        with self.assertRaises(cloudformation.InvalidTemplate):
+            yield self.actor._validate_template(url='junk')
+
+        with self.assertRaises(cloudformation.InvalidTemplate):
+            yield self.actor._validate_template(body='junk')
 
     def test_create_parameters(self):
         params = {
@@ -55,78 +134,172 @@ class TestCloudFormationBaseActor(testing.AsyncTestCase):
         self.assertEquals(ret, expected)
 
     @testing.gen_test
-    def test_get_stacks(self):
-        actor = cloudformation.CloudFormationBaseActor(
-            'unittest', {'region': 'us-east-1'})
-        actor.cf3_conn.list_stacks = mock.MagicMock()
-        actor.cf3_conn.list_stacks.return_value = {
-            'StackSummaries': [
-                create_fake_stack('s1', 'UPDATE_COMPLETE'),
-                create_fake_stack('s2', 'UPDATE_COMPLETE'),
-                create_fake_stack('s3', 'UPDATE_COMPLETE')
-            ]
-        }
-        ret = yield actor._get_stacks()
-        self.assertEquals(
-            ['s1', 's2', 's3'],
-            [ret[0]['StackName'],
-             ret[1]['StackName'],
-             ret[2]['StackName']])
-
-    @testing.gen_test
     def test_get_stack(self):
-        actor = cloudformation.CloudFormationBaseActor(
-            'unittest', {'region': 'us-east-1'})
-        actor.cf3_conn.list_stacks = mock.MagicMock()
-        actor.cf3_conn.list_stacks.return_value = {
-            'StackSummaries': [
-                create_fake_stack('s1', 'UPDATE_COMPLETE'),
-                create_fake_stack('s2', 'UPDATE_COMPLETE'),
-                create_fake_stack('s3', 'UPDATE_COMPLETE')
-            ]
-        }
+        self.actor.cf3_conn.describe_stacks.return_value = {
+            'Stacks': [create_fake_stack('s1', 'UPDATE_COMPLETE')]}
 
-        ret = yield actor._get_stack('s1')
+        ret = yield self.actor._get_stack('s1')
         self.assertEquals(ret['StackName'], 's1')
 
-        ret = yield actor._get_stack('s5')
+    @testing.gen_test
+    def test_get_stack_not_found(self):
+        fake_exc = {
+            'ResponseMetadata': {
+                'HTTPStatusCode': 400,
+                'RequestId': 'dfc1a12c-22c1-11e6-80b1-8fd4cf167f54'
+            },
+            'Error': {
+                'Message': 'Stack with id s1 does not exist',
+                'Code': 'ExecutionFailure',
+                'Type': 'Sender'
+            }
+        }
+        self.actor.cf3_conn.describe_stacks.side_effect = ClientError(
+            fake_exc, 'Failure')
+
+        ret = yield self.actor._get_stack('s1')
         self.assertEquals(ret, None)
 
     @testing.gen_test
-    def test_wait_until_state(self):
+    def test_get_stack_exc(self):
+        fake_exc = {
+            'ResponseMetadata': {
+                'HTTPStatusCode': 400,
+                'RequestId': 'dfc1a12c-22c1-11e6-80b1-8fd4cf167f54'
+            },
+            'Error': {
+                'Message': 'Some other error',
+                'Code': 'ExecutionFailure',
+                'Type': 'Sender'
+            }
+        }
+        self.actor.cf3_conn.describe_stacks.side_effect = ClientError(
+            fake_exc, 'Failure')
 
+        with self.assertRaises(cloudformation.CloudFormationError):
+            yield self.actor._get_stack('s1')
+
+    @testing.gen_test
+    def test_wait_until_state_complete(self):
         create_in_progress = create_fake_stack('test', 'CREATE_IN_PROGRESS')
         create_complete = create_fake_stack('test', 'CREATE_COMPLETE')
 
-        actor = cloudformation.CloudFormationBaseActor(
-            'unittest', {'region': 'us-east-1'})
-        actor._get_stack = mock.MagicMock()
-
         # Make _get_stack() yield back 2 in-progress states, then yield a
         # successfull execution.
-        actor._get_stack.side_effect = [
+        self.actor._get_stack = mock.MagicMock(name='FakeStack')
+        self.actor._get_stack.side_effect = [
             tornado_value(create_in_progress),
             tornado_value(create_in_progress),
             tornado_value(create_complete)
         ]
-        ret = yield actor._wait_until_state(cloudformation.COMPLETE, sleep=0.1)
-        self.assertEquals(ret, None)
+        yield self.actor._wait_until_state(
+            'test', cloudformation.COMPLETE, sleep=0.01)
+        self.actor._get_stack.assert_has_calls(
+            [mock.call('test'), mock.call('test'), mock.call('test')])
+
+    @testing.gen_test
+    def test_wait_until_state_stack_failed(self):
+        create_in_progress = create_fake_stack('test', 'CREATE_IN_PROGRESS')
+        create_complete = create_fake_stack('test', 'CREATE_COMPLETE')
 
         # Make sure a cloudformationerror is raised if we ask for a deleted
         # state rather than a created one.
-        actor._get_stack.side_effect = [
+        self.actor._get_stack = mock.MagicMock(name='FakeStack')
+        self.actor._get_stack.side_effect = [
             tornado_value(create_in_progress),
             tornado_value(create_in_progress),
             tornado_value(create_complete)
         ]
-        with self.assertRaises(cloudformation.CloudFormationError):
-            yield actor._wait_until_state(cloudformation.DELETED, sleep=0.1)
+        with self.assertRaises(cloudformation.StackFailed):
+            yield self.actor._wait_until_state(
+                'test', cloudformation.DELETED, sleep=0.1)
 
+    @testing.gen_test
+    def test_wait_until_state_stack_not_found(self):
         # Lastly, test that if wait_until_state returns no actor, we bail
         # appropriately.
-        actor._get_stack.side_effect = [tornado_value(None)]
+        self.actor._get_stack = mock.MagicMock(name='FakeStack')
+        self.actor._get_stack.return_value = tornado_value(None)
         with self.assertRaises(cloudformation.StackNotFound):
-            yield actor._wait_until_state(cloudformation.COMPLETE, sleep=0.1)
+            yield self.actor._wait_until_state(
+                'test', cloudformation.COMPLETE, sleep=0.1)
+
+    @testing.gen_test
+    def test_get_stack_events(self):
+        fake_events = {
+            'StackEvents': [
+                create_fake_stack_event('test', 'test', 'DELETE_COMPLETE'),
+                create_fake_stack_event('test', 's3', 'DELETE_COMPLETE'),
+                create_fake_stack_event('test', 's3', 'DELETE_IN_PROGRESS'),
+                create_fake_stack_event('test', 's3', 'CREATE_FAILED', 'bad'),
+                create_fake_stack_event('test', 's3', 'CREATE_IN_PROGRESS'),
+                create_fake_stack_event('test', 'test', 'CREATE_IN_PROGRESS')
+            ]
+        }
+        expected = [
+            'AWS::CloudFormation::Stack test (CREATE_IN_PROGRESS): ',
+            'AWS::CloudFormation::Stack s3 (CREATE_IN_PROGRESS): ',
+            'AWS::CloudFormation::Stack s3 (CREATE_FAILED): bad',
+            'AWS::CloudFormation::Stack s3 (DELETE_IN_PROGRESS): ',
+            'AWS::CloudFormation::Stack s3 (DELETE_COMPLETE): ',
+            'AWS::CloudFormation::Stack test (DELETE_COMPLETE): '
+        ]
+        self.actor.cf3_conn.describe_stack_events.return_value = fake_events
+        ret = yield self.actor._get_stack_events('test')
+
+        self.assertEquals(ret, expected)
+
+    @testing.gen_test
+    def test_get_stack_events_exc(self):
+        fake_exc = {
+            'ResponseMetadata': {
+                'HTTPStatusCode': 400,
+                'RequestId': 'dfc1a12c-22c1-11e6-80b1-8fd4cf167f54'
+            },
+            'Error': {
+                'Message': 'Some other error',
+                'Code': 'ExecutionFailure',
+                'Type': 'Sender'
+            }
+        }
+        self.actor.cf3_conn.describe_stack_events.side_effect = ClientError(
+            fake_exc, 'Failure')
+        ret = yield self.actor._get_stack_events('test')
+        self.assertEquals(ret, [])
+
+    @testing.gen_test
+    def test_delete_stack(self):
+        self.actor.cf3_conn.delete_stack.return_value = {
+            'ResponseMetadata': {'RequestId': 'req-id-1'}
+        }
+        self.actor._wait_until_state = mock.MagicMock(name='_wait_until_state')
+        self.actor._wait_until_state.side_effect = cloudformation.StackNotFound()
+
+        yield self.actor._delete_stack(stack='stack')
+
+        self.assertTrue(self.actor.cf3_conn.delete_stack.called)
+        self.assertTrue(self.actor._wait_until_state.called)
+
+    @testing.gen_test
+    def test_delete_stack_raises_boto_error(self):
+        self.actor.cf3_conn.delete_stack = mock.MagicMock(name='delete_stack_mock')
+
+        fake_exc = {
+            'ResponseMetadata': {
+                'HTTPStatusCode': 400,
+                'RequestId': 'dfc1a12c-22c1-11e6-80b1-8fd4cf167f54'
+            },
+            'Error': {
+                'Message': 'Something failed',
+                'Code': 'ExecutionFailure',
+                'Type': 'Sender'
+            }
+        }
+
+        self.actor.cf3_conn.delete_stack.side_effect = ClientError(
+            fake_exc, 'Error')
+        with self.assertRaises(cloudformation.CloudFormationError):
+            yield self.actor._delete_stack(stack='stack')
 
 
 class TestCreate(testing.AsyncTestCase):
@@ -138,83 +311,6 @@ class TestCreate(testing.AsyncTestCase):
         settings.RETRYING_SETTINGS = {'stop_max_attempt_number': 1}
         reload(cloudformation)
 
-    def test_get_template_body(self):
-        # Should work...
-        actor = cloudformation.Create(
-            'Unit Test Action',
-            {'name': 'unit-test-cf',
-             'region': 'us-west-2',
-             'template': 'examples/test/aws.cloudformation/cf.unittest.json'})
-        self.assertNotEquals(actor._template_body, '#BLANK\r\n')
-        self.assertEquals(actor._template_url, None)
-
-        # Should return None
-        actor = cloudformation.Create(
-            'Unit Test Action',
-            {'name': 'unit-test-cf',
-             'region': 'us-west-2',
-             'template': 'http://foobar.json'})
-        self.assertEquals(actor._template_body, None)
-        self.assertEquals(actor._template_url, 'http://foobar.json')
-
-        # Should raise exception
-        with self.assertRaises(cloudformation.InvalidTemplate):
-            actor = cloudformation.Create(
-                'Unit Test Action',
-                {'name': 'unit-test-cf',
-                 'region': 'us-west-2',
-                 'template': 'missing'})
-
-    @testing.gen_test
-    def test_validate_template_body(self):
-        actor = cloudformation.Create(
-            'Unit Test Action',
-            {'name': 'unit-test-cf',
-             'region': 'us-west-2',
-             'template': 'examples/test/aws.cloudformation/cf.unittest.json'})
-        actor.cf3_conn.validate_template = mock.MagicMock()
-        yield actor._validate_template()
-        actor.cf3_conn.validate_template.assert_called_with(
-            TemplateBody='{"blank": "json"}')
-
-    @testing.gen_test
-    def test_validate_template_url(self):
-        actor = cloudformation.Create(
-            'Unit Test Action',
-            {'name': 'unit-test-cf',
-             'region': 'us-west-2',
-             'template': 'http://foobar.json'})
-        actor.cf3_conn.validate_template = mock.MagicMock()
-        yield actor._validate_template()
-        actor.cf3_conn.validate_template.assert_called_with(
-            TemplateURL='http://foobar.json')
-
-    @testing.gen_test
-    def test_validate_template_raises_boto_error(self):
-        actor = cloudformation.Create(
-            'Unit Test Action',
-            {'name': 'unit-test-cf',
-             'region': 'us-west-2',
-             'template': 'http://foobar.json'})
-
-        fake_exc = {
-            'ResponseMetadata': {
-                'HTTPStatusCode': 400,
-                'RequestId': 'dfc1a12c-22c1-11e6-80b1-8fd4cf167f54'
-            },
-            'Error': {
-                'Message': 'Template format error: JSON not well-formed',
-                'Code': 'ValidationError',
-                'Type': 'Sender'
-            }
-        }
-
-        actor.cf3_conn.validate_template = mock.MagicMock()
-        actor.cf3_conn.validate_template.side_effect = ClientError(
-            fake_exc, 'FakeOperation')
-        with self.assertRaises(cloudformation.InvalidTemplate):
-            yield actor._validate_template()
-
     @testing.gen_test
     def test_create_stack_file(self):
         actor = cloudformation.Create(
@@ -223,9 +319,11 @@ class TestCreate(testing.AsyncTestCase):
              'region': 'us-west-2',
              'template':
                  'examples/test/aws.cloudformation/cf.integration.json'})
+        actor._wait_until_state = mock.MagicMock(name='_wait_until_state')
+        actor._wait_until_state.side_effect = [tornado_value(None)]
         actor.cf3_conn.create_stack = mock.MagicMock(name='create_stack_mock')
         actor.cf3_conn.create_stack.return_value = {'StackId': 'arn:123'}
-        ret = yield actor._create_stack()
+        ret = yield actor._create_stack(stack='test')
         self.assertEquals(ret, 'arn:123')
 
     @testing.gen_test
@@ -235,9 +333,11 @@ class TestCreate(testing.AsyncTestCase):
             {'name': 'unit-test-cf',
              'region': 'us-west-2',
              'template': 'https://www.test.com'})
+        actor._wait_until_state = mock.MagicMock(name='_wait_until_state')
+        actor._wait_until_state.side_effect = [tornado_value(None)]
         actor.cf3_conn.create_stack = mock.MagicMock(name='create_stack_mock')
         actor.cf3_conn.create_stack.return_value = {'StackId': 'arn:123'}
-        ret = yield actor._create_stack()
+        ret = yield actor._create_stack(stack='unit-test-cf')
         self.assertEquals(ret, 'arn:123')
 
     @testing.gen_test
@@ -248,7 +348,7 @@ class TestCreate(testing.AsyncTestCase):
              'region': 'us-west-2',
              'template':
                  'examples/test/aws.cloudformation/cf.integration.json'})
-        actor.cf3_conn.create_stack = mock.MagicMock()
+        actor.cf3_conn.create_stack = mock.MagicMock(name='create_stack_mock')
 
         fake_exc = {
             'ResponseMetadata': {
@@ -265,7 +365,28 @@ class TestCreate(testing.AsyncTestCase):
         actor.cf3_conn.create_stack.side_effect = ClientError(
             fake_exc, 'Failure')
         with self.assertRaises(cloudformation.CloudFormationError):
-            yield actor._create_stack()
+            yield actor._create_stack(stack='test')
+
+    @testing.gen_test
+    def test_create_stack_wait_until_raises_boto_error(self):
+        actor = cloudformation.Create(
+            'Unit Test Action',
+            {'name': 'unit-test-cf',
+             'region': 'us-west-2',
+             'template':
+                 'examples/test/aws.cloudformation/cf.integration.json'})
+        actor.cf3_conn.create_stack = mock.MagicMock(name='create_stack_mock')
+        actor.cf3_conn.create_stack.return_value = {'StackId': 'arn:123'}
+
+        actor._wait_until_state = mock.MagicMock(name='_wait_until_state')
+        actor._wait_until_state.side_effect = cloudformation.StackFailed()
+
+        actor._get_stack_events = mock.MagicMock(name='_get_stack_events')
+        actor._get_stack_events.return_value = tornado_value(
+            ['Log Message'])
+
+        with self.assertRaises(cloudformation.StackFailed):
+            yield actor._create_stack(stack='test')
 
     @testing.gen_test
     def test_execute(self):
@@ -276,17 +397,17 @@ class TestCreate(testing.AsyncTestCase):
              'template':
                  'examples/test/aws.cloudformation/cf.integration.json'})
 
-        actor._validate_template = mock.MagicMock()
-        actor._validate_template.side_effect = [tornado_value(True)]
+        actor._validate_template = mock.MagicMock(name='_validate_template')
+        actor._validate_template.return_value = tornado_value(True)
 
-        actor._get_stack = mock.MagicMock()
-        actor._get_stack.side_effect = [tornado_value(None)]
+        actor._get_stack = mock.MagicMock(name='_get_stack')
+        actor._get_stack.return_value = tornado_value(None)
 
-        actor._create_stack = mock.MagicMock()
-        actor._create_stack.side_effect = [tornado_value(None)]
+        actor._create_stack = mock.MagicMock(name='_create_stack')
+        actor._create_stack.return_value = tornado_value(None)
 
-        actor._wait_until_state = mock.MagicMock()
-        actor._wait_until_state.side_effect = [tornado_value(None)]
+        actor._wait_until_state = mock.MagicMock(name='_wait_until_state')
+        actor._wait_until_state.return_value = tornado_value(None)
         yield actor._execute()
 
     @testing.gen_test
@@ -298,11 +419,11 @@ class TestCreate(testing.AsyncTestCase):
              'template':
                  'examples/test/aws.cloudformation/cf.integration.json'})
 
-        actor._validate_template = mock.MagicMock()
-        actor._validate_template.side_effect = [tornado_value(True)]
+        actor._validate_template = mock.MagicMock(name='_validate_template')
+        actor._validate_template.return_value = tornado_value(True)
 
-        actor._get_stack = mock.MagicMock()
-        actor._get_stack.side_effect = [tornado_value(True)]
+        actor._get_stack = mock.MagicMock(name='_get_stack')
+        actor._get_stack.return_value = tornado_value(True)
 
         with self.assertRaises(cloudformation.StackAlreadyExists):
             yield actor._execute()
@@ -317,11 +438,11 @@ class TestCreate(testing.AsyncTestCase):
                  'examples/test/aws.cloudformation/cf.integration.json'},
             dry=True)
 
-        actor._validate_template = mock.MagicMock()
-        actor._validate_template.side_effect = [tornado_value(True)]
+        actor._validate_template = mock.MagicMock(name='_validate_template')
+        actor._validate_template.return_value = tornado_value(True)
 
-        actor._get_stack = mock.MagicMock()
-        actor._get_stack.side_effect = [tornado_value(None)]
+        actor._get_stack = mock.MagicMock(name='_get_stack')
+        actor._get_stack.return_value = tornado_value(None)
 
         yield actor._execute()
 
@@ -336,54 +457,16 @@ class TestDelete(testing.AsyncTestCase):
         reload(cloudformation)
 
     @testing.gen_test
-    def test_delete_stack(self):
-        actor = cloudformation.Delete(
-            'Unit Test Action',
-            {'name': 'unit-test-cf',
-             'region': 'us-west-2'})
-        actor.cf3_conn.delete_stack = mock.MagicMock(name='delete_stack_mock')
-        actor.cf3_conn.delete_stack.return_value = {
-            'ResponseMetadata': {'RequestId': 'req-id-1'}
-        }
-        ret = yield actor._delete_stack()
-        self.assertEquals(ret, 'req-id-1')
-
-    @testing.gen_test
-    def test_delete_stack_raises_boto_error(self):
-        actor = cloudformation.Delete(
-            'Unit Test Action',
-            {'name': 'unit-test-cf',
-             'region': 'us-west-2'})
-        actor.cf3_conn.delete_stack = mock.MagicMock()
-
-        fake_exc = {
-            'ResponseMetadata': {
-                'HTTPStatusCode': 400,
-                'RequestId': 'dfc1a12c-22c1-11e6-80b1-8fd4cf167f54'
-            },
-            'Error': {
-                'Message': 'Something failed',
-                'Code': 'ExecutionFailure',
-                'Type': 'Sender'
-            }
-        }
-
-        actor.cf3_conn.delete_stack.side_effect = ClientError(
-            fake_exc, 'Error')
-        with self.assertRaises(cloudformation.CloudFormationError):
-            yield actor._delete_stack()
-
-    @testing.gen_test
     def test_execute(self):
         actor = cloudformation.Delete(
             'Unit Test Action',
             {'name': 'unit-test-cf',
              'region': 'us-west-2'})
-        actor._get_stack = mock.MagicMock()
-        actor._get_stack.side_effect = [tornado_value(True)]
-        actor._delete_stack = mock.MagicMock()
-        actor._delete_stack.side_effect = [tornado_value(None)]
-        actor._wait_until_state = mock.MagicMock()
+        actor._get_stack = mock.MagicMock(name='_get_stack')
+        actor._get_stack.return_value = tornado_value(True)
+        actor._delete_stack = mock.MagicMock(name='_delete_stack')
+        actor._delete_stack.return_value = tornado_value(None)
+        actor._wait_until_state = mock.MagicMock(name='_wait_until_state')
         actor._wait_until_state.side_effect = cloudformation.StackNotFound()
         yield actor._execute()
 
@@ -393,8 +476,8 @@ class TestDelete(testing.AsyncTestCase):
             'Unit Test Action',
             {'name': 'unit-test-cf',
              'region': 'us-west-2'}, dry=True)
-        actor._get_stack = mock.MagicMock()
-        actor._get_stack.side_effect = [tornado_value(True)]
+        actor._get_stack = mock.MagicMock(name='_get_stack')
+        actor._get_stack.return_value = tornado_value(True)
         yield actor._execute()
 
     @testing.gen_test
@@ -403,7 +486,108 @@ class TestDelete(testing.AsyncTestCase):
             'Unit Test Action',
             {'name': 'unit-test-cf',
              'region': 'us-west-2'})
-        actor._get_stack = mock.MagicMock()
-        actor._get_stack.side_effect = [tornado_value(None)]
+        actor._get_stack = mock.MagicMock(name='_get_stack')
+        actor._get_stack.return_value = tornado_value(None)
         with self.assertRaises(cloudformation.StackNotFound):
             yield actor._execute()
+
+
+class TestStack(testing.AsyncTestCase):
+
+    def setUp(self):
+        super(TestStack, self).setUp()
+        settings.AWS_ACCESS_KEY_ID = 'unit-test'
+        settings.AWS_SECRET_ACCESS_KEY = 'unit-test'
+        settings.RETRYING_SETTINGS = {'stop_max_attempt_number': 1}
+        reload(cloudformation)
+
+        self.actor = cloudformation.Stack(
+            options={
+                'name': 'unit-test-cf',
+                'state': 'present',
+                'region': 'us-west-2',
+                'template': 'examples/test/aws.cloudformation/cf.unittest.json'
+            })
+        self.actor.cf3_conn = mock.MagicMock(name='cf3_conn')
+
+    @testing.gen_test
+    def test_update_stack(self):
+        fake_stack = create_fake_stack('fake', 'CREATE_FAILED')
+        self.actor._get_stack = mock.MagicMock(name='_get_stack')
+        self.actor._get_stack.return_value = tornado_value(fake_stack)
+        self.actor._delete_stack = mock.MagicMock(name='_delete_stack')
+        self.actor._delete_stack.return_value = tornado_value(fake_stack)
+        self.actor._create_stack = mock.MagicMock(name='_create_stack')
+        self.actor._create_stack.return_value = tornado_value(fake_stack)
+
+        yield self.actor._update_stack(fake_stack)
+
+        self.actor._delete_stack.assert_called_with(
+            stack='arn:aws:cloudformation:us-east-1:xxxx:stack/fake/xyz')
+        self.actor._create_stack.assert_called_with(
+            stack='fake')
+
+    @testing.gen_test
+    def test_ensure_stack_is_absent_and_wants_absent(self):
+        self.actor._options['state'] = 'absent'
+        self.actor._get_stack = mock.MagicMock(name='_get_stack')
+        self.actor._get_stack.return_value = tornado_value(None)
+        self.actor._delete_stack = mock.MagicMock(name='_delete_stack')
+        self.actor._delete_stack.return_value = tornado_value(None)
+        self.actor._create_stack = mock.MagicMock(name='_create_stack')
+        self.actor._create_stack.return_value = tornado_value(None)
+
+        yield self.actor._ensure_stack()
+
+        self.assertFalse(self.actor._create_stack.called)
+        self.assertFalse(self.actor._delete_stack.called)
+
+    @testing.gen_test
+    def test_ensure_stack_is_present_and_wants_absent(self):
+        self.actor._options['state'] = 'absent'
+        fake_stack = create_fake_stack('unit-test-cf', 'CREATE_COMPLETE')
+        self.actor._get_stack = mock.MagicMock(name='_get_stack')
+        self.actor._get_stack.return_value = tornado_value(fake_stack)
+        self.actor._delete_stack = mock.MagicMock(name='_delete_stack')
+        self.actor._delete_stack.return_value = tornado_value(None)
+        self.actor._create_stack = mock.MagicMock(name='_create_stack')
+        self.actor._create_stack.return_value = tornado_value(None)
+
+        yield self.actor._ensure_stack()
+
+        self.assertTrue(self.actor._delete_stack.called)
+        self.assertFalse(self.actor._create_stack.called)
+
+    @testing.gen_test
+    def test_ensure_stack_is_absent_and_wants_present(self):
+        self.actor._options['state'] = 'present'
+        self.actor._get_stack = mock.MagicMock(name='_get_stack')
+        self.actor._get_stack.return_value = tornado_value(None)
+        self.actor._delete_stack = mock.MagicMock(name='_delete_stack')
+        self.actor._delete_stack.return_value = tornado_value(None)
+        self.actor._create_stack = mock.MagicMock(name='_create_stack')
+        self.actor._create_stack.return_value = tornado_value(None)
+
+        yield self.actor._ensure_stack()
+
+        self.assertFalse(self.actor._delete_stack.called)
+        self.assertTrue(self.actor._create_stack.called)
+
+    @testing.gen_test
+    def test_ensure_stack_is_present_and_wants_update_create_failed(self):
+        self.actor._options['state'] = 'present'
+        fake_stack = create_fake_stack('fake', 'CREATE_FAILED')
+        self.actor._get_stack = mock.MagicMock(name='_get_stack')
+        self.actor._get_stack.return_value = tornado_value(fake_stack)
+        self.actor._delete_stack = mock.MagicMock(name='_delete_stack')
+        self.actor._delete_stack.return_value = tornado_value(None)
+        self.actor._create_stack = mock.MagicMock(name='_create_stack')
+        self.actor._create_stack.return_value = tornado_value(None)
+        self.actor._update_stack = mock.MagicMock(name='_update_stack')
+        self.actor._update_stack.return_value = tornado_value(None)
+
+        yield self.actor._ensure_stack()
+
+        self.assertFalse(self.actor._delete_stack.called)
+        self.assertFalse(self.actor._create_stack.called)
+        self.assertTrue(self.actor._update_stack.called)

--- a/kingpin/bin/deploy.py
+++ b/kingpin/bin/deploy.py
@@ -37,6 +37,7 @@ __author__ = 'Matt Wise (matt@nextdoor.com)'
 # We handle all the exceptions ourselves, so additional log statements from
 # BOTO are not needed.
 logging.getLogger('boto').setLevel(logging.CRITICAL)
+logging.getLogger('botocore').setLevel(logging.CRITICAL)
 
 # Initial option handler to set up the basic application environment.
 parser = argparse.ArgumentParser(description='Kingpin v%s' % __version__)
@@ -92,6 +93,7 @@ def get_main_actor(dry):
 
         return ActorClass(options=options,
                           dry=dry,
+                          init_tokens=env_tokens,
                           **parameters)
 
     # Actor not specified. Process JSON file.

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,3 +33,6 @@ mock==1.0.1
 
 # kingpin.actors.aws
 boto>=2.32.1
+
+# kingpin.actors.aws.cloudformation
+boto3>=1.3.1

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,8 @@ class UnitTestCommand(Command):
     description = 'Run unit tests'
     user_options = []
     args = [PACKAGE,
+            '--cover-erase',
+            '--cover-min-percentage=100',
             '--with-coverage',
             '--cover-package=%s' % PACKAGE,
             '-v']


### PR DESCRIPTION
This is step 1 ... use Boto3 rather than Boto. Boto3 will be required
for us to interact with CF Change Sets.