### PR TITLE
Pin coverage to version 4.0.

### DIFF
--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -2,7 +2,7 @@ nose
 mock==1.0.1
 pep8
 pyflakes
-coverage
+coverage==4.0
 Sphinx==1.4
 sphinx_rtd_theme
 functools32


### PR DESCRIPTION
The newest version of coverage has show_missing set to false.

See: http://stackoverflow.com/questions/37733194/

We can fix with this, or by adding a .coveragerc file.