### PR TITLE
Add .coveragerc file to show missing lines.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[report]
+show_missing = True


### PR DESCRIPTION
The newest version of coverage has show_missing set to false.

See: http://stackoverflow.com/questions/37733194/