### PR TITLE
Create a new AlertSpecBase ensurable base actor for managing RightScale AlertSpecs

### DIFF
--- a/kingpin/actors/rightscale/alerts.py
+++ b/kingpin/actors/rightscale/alerts.py
@@ -23,7 +23,9 @@ from tornado import gen
 import requests
 
 from kingpin.actors import exceptions
+from kingpin.actors.utils import dry
 from kingpin.actors.rightscale import base
+from kingpin.constants import SchemaCompareBase
 from kingpin.constants import REQUIRED
 
 log = logging.getLogger(__name__)
@@ -370,3 +372,189 @@ class Destroy(AlertsBaseActor):
         # Wait for the deletes to finish
         if deletes:
             yield deletes
+
+
+class AlertSpecSchema(SchemaCompareBase):
+
+    """Provides JSON-Schema based verification of the supplied AlertSpec
+
+    The majority of the schema mirrors the RightScale API:
+      http://reference.rightscale.com/api1.5/resources/ResourceAlertSpecs.html#create
+    """
+
+    SCHEMA = {
+        'type': ['object'],
+        'required': [
+            'condition', 'duration', 'file', 'name', 'threshold', 'variable'
+        ],
+        'properties': {
+            'condition': {
+                'type': 'string',
+                'enum': ['>', '>=', '<', '<=', '==', '!=']
+            },
+            'description': {'type': 'string'},
+            'duration': {'type': 'integer'},
+            'escalation_name': {'type': 'string'},
+            'file': {'type': 'string'},
+            'name': {'type': 'string'},
+            'threshold': {'type': 'string'},
+            'variable': {'type': 'string'},
+            'vote_tag': {'type': 'string'},
+            'vote_type': {'enum': ['grow', 'shrink']}
+        }
+    }
+
+
+class AlertSpecBase(base.EnsurableRightScaleBaseActor):
+
+    """Extremely simple AlertSpec creation actor.
+
+    This actor isn't really meant to be instantiated on its own -- it provides
+    the base functionality though for creating, deleting and updating an
+    AlertSpec on a given RightScale resource. The resource can be either a
+    Server Array, Server Template, Instance or Deployment.
+
+    **Options**
+
+    :href:
+      The RightScale HREF for the resource you wish to apply the Alert Spec to.
+
+    :state:
+      (str) Either `present` or `absent`
+
+    :spec:
+      A dictionary that conforms to the :py:mod:`AlertSpecSchema`.
+
+    **Examples**
+
+    .. code-block:: json
+
+       { "actor": "rightscale.alerts.AlertSpecBase",
+         "options": {
+           "href": "/api/server_arrays/abcd1234",
+           "spec": {
+                "name": "Instance Stranded",
+                "description": "Alert if an instance enders a stranded",
+                "file": "RS/server-failure",
+                "variable": "state",
+                "condition": "==",
+                "threshold": "stranded",
+                "duration": 2,
+                "escalation_name": "critical"
+           }
+         }
+       }
+
+    """
+
+    all_options = {
+        'href': (str, None, 'RightScale Resource HREF to act on'),
+        'spec': (AlertSpecSchema, None, 'The actual Alert Spec definition itself.')
+    }
+    unmanaged_options = ['href']
+    desc = "AlertSpec: {spec[name]}"
+
+    @gen.coroutine
+    def _precache(self):
+        name = self.option('spec').get('name')
+        href = self.option('href')
+
+        # Generate a fully populated set of parameters by including the href
+        # that was supplied to us.
+        desired_spec = dict(self.option('spec'))
+        desired_spec['subject_href'] = href
+        self.desired_params = self._generate_rightscale_params(
+            'alert_spec', desired_spec)
+
+        # Search for the existing spec
+        log.debug('Searching for AlertSpec matching: %s' % name)
+        self.spec = yield self._client.find_by_name_and_keys(
+            self._client._client.alert_specs,
+            name=name, exact=True, subject_href=href)
+
+        if not self.spec:
+            log.debug('AlertSpec matching "%s" could not be found.' % name)
+            self.spec = None
+        else:
+            log.debug('Got AlertSpec: %s' % self.spec)
+
+    @gen.coroutine
+    def _get_state(self):
+        if self.spec:
+            raise gen.Return('present')
+        raise gen.Return('absent')
+
+    @gen.coroutine
+    def _set_state(self):
+        if self.option('state') == 'absent':
+            yield self._delete_spec()
+        else:
+            yield self._create_spec()
+
+    @gen.coroutine
+    def _get_spec(self):
+        if self.spec:
+            raise gen.Return(
+                self._strip_returned_spec_resource(self.spec))
+
+    @gen.coroutine
+    def _set_spec(self):
+        yield self._update_spec()
+
+    @gen.coroutine
+    @dry('Would have created the AlertSpec')
+    def _create_spec(self):
+        try:
+            self.spec = yield self._client.create_resource(
+                self._client._client.alert_specs, self.desired_params)
+        except requests.exceptions.HTTPError as e:
+            if e.response.status_code in (422, 400):
+                msg = ('Invalid parameters supplied to Alert Spec "%s": %s'
+                       % (self.option('href'), self.desired_params))
+                raise exceptions.RecoverableActorFailure(msg)
+            raise
+
+        self.log.info('Alert spec has been created')
+
+    @gen.coroutine
+    @dry('Would have updated the AlertSpec')
+    def _update_spec(self):
+        try:
+            self.spec = yield self._client.update(
+                self.spec, self.desired_params)
+        except requests.exceptions.HTTPError as e:
+            if e.response.status_code in (422, 400):
+                msg = ('Invalid parameters supplied to Alert Spec "%s": %s'
+                       % (self.spec.soul['name'], self.desired_params))
+                raise exceptions.RecoverableActorFailure(msg)
+            raise
+
+        self.log.info('Alert spec has been updated')
+
+    @gen.coroutine
+    @dry('Would have deleted the AlertSpec')
+    def _delete_spec(self):
+        yield self._client.destroy_resource(self.spec)
+        self.spec = None
+
+        self.log.info('Alert spec has been destroyed')
+
+    def _strip_returned_spec_resource(self, spec):
+        """Converts an AlertSpec resource into a comparable dict.
+
+        Walks through the AlertSpecSchema and creates a new dictionary object
+        with only the values from the AlertSpec that were supplied. This
+        creates a dict we can compare against the supplied data by the user.
+
+        args:
+            spec: A RightScale AlertSpec resource
+
+        returns:
+            <dictionary that matches the AlertSpecSchema>
+        """
+        new = {}
+        desired_keys = AlertSpecSchema.SCHEMA['properties'].keys()
+        for key in desired_keys:
+            if key in spec.soul:
+                new[key] = spec.soul[key]
+        return new

--- a/kingpin/actors/rightscale/alerts.py
+++ b/kingpin/actors/rightscale/alerts.py
@@ -423,7 +423,8 @@ class AlertSpecBase(base.EnsurableRightScaleBaseActor):
       (str) Either `present` or `absent`
 
     :spec:
-      A dictionary that conforms to the :py:mod:`AlertSpecSchema`.
+      A dictionary that conforms to the
+      :py:mod:`~kingpin.actors.rightscale.alerts.AlertSpecSchema`.
 
     **Examples**
 
@@ -453,6 +454,10 @@ class AlertSpecBase(base.EnsurableRightScaleBaseActor):
     }
     unmanaged_options = ['href']
     desc = "AlertSpec: {spec[name]}"
+
+    def __init__(self, *args, **kwargs):
+        super(AlertSpecBase, self).__init__(*args, **kwargs)
+        self.changed = False
 
     @gen.coroutine
     def _precache(self):
@@ -491,6 +496,8 @@ class AlertSpecBase(base.EnsurableRightScaleBaseActor):
         else:
             yield self._create_spec()
 
+        self.changed = True
+
     @gen.coroutine
     def _get_spec(self):
         if self.spec:
@@ -500,6 +507,7 @@ class AlertSpecBase(base.EnsurableRightScaleBaseActor):
     @gen.coroutine
     def _set_spec(self):
         yield self._update_spec()
+        self.changed = True
 
     @gen.coroutine
     @dry('Would have created the AlertSpec')
@@ -558,3 +566,8 @@ class AlertSpecBase(base.EnsurableRightScaleBaseActor):
             if key in spec.soul:
                 new[key] = spec.soul[key]
         return new
+
+    @gen.coroutine
+    def _execute(self):
+        yield super(AlertSpecBase, self)._execute()
+        raise gen.Return(self.changed)

--- a/kingpin/actors/rightscale/alerts.py
+++ b/kingpin/actors/rightscale/alerts.py
@@ -405,6 +405,20 @@ class AlertSpecSchema(SchemaCompareBase):
     }
 
 
+class AlertSpecsSchema(SchemaCompareBase):
+
+    """Provides JSON-Schema verification that the supplied input was a list
+    of AlertSpecSchemas."""
+
+    SCHEMA = {
+        'type': ['array', 'null'],
+        'uniqueItems': True,
+        'items': {
+            'anyOf': [AlertSpecSchema.SCHEMA]
+        }
+    }
+
+
 class AlertSpecBase(base.EnsurableRightScaleBaseActor):
 
     """Extremely simple AlertSpec creation actor.
@@ -450,7 +464,8 @@ class AlertSpecBase(base.EnsurableRightScaleBaseActor):
 
     all_options = {
         'href': (str, None, 'RightScale Resource HREF to act on'),
-        'spec': (AlertSpecSchema, None, 'The actual Alert Spec definition itself.')
+        'spec': (AlertSpecSchema, None,
+                 'The actual Alert Spec definition itself.')
     }
     unmanaged_options = ['href']
     desc = "AlertSpec: {spec[name]}"
@@ -471,21 +486,35 @@ class AlertSpecBase(base.EnsurableRightScaleBaseActor):
         self.desired_params = self._generate_rightscale_params(
             'alert_spec', desired_spec)
 
-        # Search for the existing spec
+        # Search for the existing spec. Even though we do an 'exact' search
+        # here, this is kind of misleading. We are searching on multiple keys
+        # (name, subject_href) and the find_by_name_and_keys() code isn't smart
+        # enough to return a true perfect match on all the keys supplied.
+        # Therefore, this MAY return a list with multiple results.
         log.debug('Searching for AlertSpec matching: %s' % name)
-        self.spec = yield self._client.find_by_name_and_keys(
-            self._client._client.alert_specs,
-            name=name, exact=True, subject_href=href)
+        self.existing_spec = yield self._client.find_by_name_and_keys(
+            self._client._client.alert_specs, exact=True,
+            name=name, subject_href=href)
 
-        if not self.spec:
+        # Handle the multiple-result scenario. Since exact=True above, we
+        # should never get a list back with a single item, so we'll only focus
+        # on the issue of getting back multiple items. Search through the list
+        # of items for an _exact_ match on the name.
+        if (isinstance(self.existing_spec, list) and
+                len(self.existing_spec) > 1):
+            self.existing_spec = [
+                s for s in self.existing_spec if
+                s.soul['name'] == self.option('spec')['name']][0]
+
+        if not self.existing_spec:
             log.debug('AlertSpec matching "%s" could not be found.' % name)
-            self.spec = None
+            self.existing_spec = None
         else:
-            log.debug('Got AlertSpec: %s' % self.spec)
+            log.debug('Got AlertSpec: %s' % self.existing_spec)
 
     @gen.coroutine
     def _get_state(self):
-        if self.spec:
+        if self.existing_spec:
             raise gen.Return('present')
         raise gen.Return('absent')
 
@@ -500,9 +529,9 @@ class AlertSpecBase(base.EnsurableRightScaleBaseActor):
 
     @gen.coroutine
     def _get_spec(self):
-        if self.spec:
+        if self.existing_spec:
             raise gen.Return(
-                self._strip_returned_spec_resource(self.spec))
+                self._strip_returned_spec_resource(self.existing_spec))
 
     @gen.coroutine
     def _set_spec(self):
@@ -513,7 +542,7 @@ class AlertSpecBase(base.EnsurableRightScaleBaseActor):
     @dry('Would have created the AlertSpec')
     def _create_spec(self):
         try:
-            self.spec = yield self._client.create_resource(
+            self.existing_spec = yield self._client.create_resource(
                 self._client._client.alert_specs, self.desired_params)
         except requests.exceptions.HTTPError as e:
             if e.response.status_code in (422, 400):
@@ -528,12 +557,13 @@ class AlertSpecBase(base.EnsurableRightScaleBaseActor):
     @dry('Would have updated the AlertSpec')
     def _update_spec(self):
         try:
-            self.spec = yield self._client.update(
-                self.spec, self.desired_params)
+            self.existing_spec = yield self._client.update(
+                self.existing_spec, self.desired_params)
         except requests.exceptions.HTTPError as e:
             if e.response.status_code in (422, 400):
                 msg = ('Invalid parameters supplied to Alert Spec "%s": %s'
-                       % (self.spec.soul['name'], self.desired_params))
+                       % (self.existing_spec.soul['name'],
+                          self.desired_params))
                 raise exceptions.RecoverableActorFailure(msg)
             raise
 
@@ -542,8 +572,8 @@ class AlertSpecBase(base.EnsurableRightScaleBaseActor):
     @gen.coroutine
     @dry('Would have deleted the AlertSpec')
     def _delete_spec(self):
-        yield self._client.destroy_resource(self.spec)
-        self.spec = None
+        yield self._client.destroy_resource(self.existing_spec)
+        self.existing_spec = None
 
         self.log.info('Alert spec has been destroyed')
 
@@ -567,7 +597,183 @@ class AlertSpecBase(base.EnsurableRightScaleBaseActor):
                 new[key] = spec.soul[key]
         return new
 
+
+class AlertSpecsBase(base.EnsurableRightScaleBaseActor):
+
+    """Extremely simple AlertSpec management actor.
+
+    This actor isn't really meant to be instantiated on its own -- it provides
+    the base functionality though for creating, deleting and updating an
+    AlertSpec on a given RightScale resource. The subtle difference here is
+    that this actor manages the entire list of AlertSpecs on a given resource,
+    rather than just a single spec.
+
+    **Options**
+
+    :href:
+      The RightScale HREF for the resource you wish to apply the Alert Spec to.
+
+    :state:
+      (str) Either `present` or `absent`
+
+    :spec:
+      A dictionary that conforms to the
+      :py:mod:`~kingpin.actors.rightscale.alerts.AlertSpecSchema`.
+
+    **Examples**
+
+    .. code-block:: json
+
+       { "actor": "rightscale.alerts.AlertSpecsBase",
+         "options": {
+           "href": "/api/server_arrays/abcd1234",
+           "specs": [
+                { "name": "Instance Stranded",
+                  "description": "Alert if an instance enders a stranded",
+                  "file": "RS/server-failure",
+                  "variable": "state",
+                  "condition": "==",
+                  "threshold": "stranded",
+                  "duration": 2,
+                  "escalation_name": "critical"
+                }
+            ]
+         }
+       }
+
+    """
+
+    all_options = {
+        'href': (str, None, 'RightScale Resource HREF to act on'),
+        'specs': (AlertSpecsSchema, None, 'A list of AlertSpec dicts'),
+    }
+    unmanaged_options = ['href']
+    desc = "AlertSpecs: {href}"
+
+    def __init__(self, *args, **kwargs):
+        super(AlertSpecsBase, self).__init__(*args, **kwargs)
+        self.changed = False
+
+        self.alert_actors = []
+        for spec in self.option('specs'):
+            a = AlertSpecBase(
+                desc=('AlertSpecs: %s "%s"' % (
+                      self.option('href'), spec['name'])),
+                options={
+                    'href': self.option('href'),
+                    'state': self.option('state'),
+                    'spec': spec
+                },
+                dry=self._dry)
+
+            # Replace the new child actors RightScale client with our own --
+            # this way we only have to log in once rather than
+            # once-per-alert-spec.
+            a._client = self._client
+            self.alert_actors.append(a)
+
     @gen.coroutine
-    def _execute(self):
-        yield super(AlertSpecBase, self)._execute()
-        raise gen.Return(self.changed)
+    def _precache(self):
+        # Get a list of all of the AlertSpecs associated with the resource.
+        all_resource_specs = yield self._client.find_by_name_and_keys(
+            self._client._client.alert_specs, exact=True,
+            subject_href=self.option('href'))
+
+        # Now quickly compare this list to the list of desired specs. For each
+        # one thats found that doesn't match, create a new AlertSpecBase actor
+        # that will purge this AlertSpec.
+        desired_spec_names = [s['name'] for s in self.option('specs')]
+
+        for spec in all_resource_specs:
+            if spec.soul['name'] in desired_spec_names:
+                continue
+
+            # Create a AlertSpec actor where state is absent
+            self.alert_actors.append(
+                AlertSpecBase(
+                    desc=('AlertSpecs: %s "%s"' % (
+                          self.option('href'), spec.soul['name'])),
+                    options={
+                        'href': self.option('href'),
+                        'state': 'absent',
+                        'spec': {
+                            'name': spec.soul['name'],
+
+                            # The rest of these options don't matter, but need
+                            # to be here in order to pass the Schema
+                            # verification.
+                            'condition': '==',
+                            'duration': 0,
+                            'file': 'bogus',
+                            'threshold': 'NaN',
+                            'variable': 'state'
+                        }
+                    },
+                    dry=self._dry))
+
+        # Now create all of the AlertSpec actors that we want to use to manage
+        # the defined alert specs.
+        tasks = []
+        for actor in self.alert_actors:
+            # Do all the heavy lifting by throwing these _precache() calls onto
+            # a task list and then yield the whole list at once. This makes the
+            # rest of the get/set comparison calls super fast.
+            tasks.append(actor._precache())
+        yield tasks
+
+    @gen.coroutine
+    def _get_state(self):
+        raise gen.Return()
+
+    @gen.coroutine
+    def _compare_state(self):
+        equals = True
+
+        # For every actor we've created, make sure the state matches the
+        # desired state. If they aren't, set our equals to False and let
+        # set_state() get called.
+        for actor in self.alert_actors:
+            # Note, this is super fast because the AlertSpecBase._precache()
+            # actor did all of the actual API calls ahead of time. This returns
+            # instantly.
+            is_equal = yield actor._compare_state()
+            if not is_equal:
+                equals = False
+
+        raise gen.Return(equals)
+
+    @gen.coroutine
+    def _set_state(self):
+        tasks = []
+        for actor in self.alert_actors:
+            is_equal = yield actor._compare_state()
+            if not is_equal:
+                tasks.append(actor._set_state())
+                self.changed = True
+        yield tasks
+
+    @gen.coroutine
+    def _get_specs(self):
+        specs = []
+        for actor in self.alert_actors:
+            # Note, this is super fast because the AlertSpecBase._precache()
+            # actor did all of the actual API calls ahead of time. This returns
+            # instantly.
+            specs.append((yield actor._get_spec()))
+        raise gen.Return(specs)
+
+    @gen.coroutine
+    def _set_specs(self):
+        tasks = []
+        for actor in self.alert_actors:
+            # Note, this is super fast because the AlertSpecBase._precache()
+            # actor did all of the actual API calls ahead of time. This returns
+            # instantly.
+            equals = yield actor._compare_spec()
+            if not equals:
+                # Note, we don't call _set_spec() here intentionally because
+                # that doesn't have the logic to skip setting the spec if we
+                # want it absent.
+                tasks.append(actor._execute())
+                self.changed = True
+        yield tasks

--- a/kingpin/actors/rightscale/test/integration_mci_and_st.py
+++ b/kingpin/actors/rightscale/test/integration_mci_and_st.py
@@ -40,6 +40,16 @@ class IntegrationMCIandST(testing.AsyncTestCase):
             'images': [{'mci': self.name}],
             'tags': [
                 'boneman:test=true'
+            ],
+            'alerts': [
+                {'name': 'Instance Stranded',
+                 'description': 'Alert if an instance enders a stranded',
+                 'file': 'RS/server-failure',
+                 'variable': 'state',
+                 'condition': '==',
+                 'threshold': 'stranded',
+                 'duration': 2,
+                 'escalation_name': 'critical'}
             ]
         }
 
@@ -104,6 +114,14 @@ class IntegrationMCIandST(testing.AsyncTestCase):
     @attr('rightscale', 'integration')
     @testing.gen_test(timeout=60)
     def integration_05b_create_st(self):
+        actor = server_template.ServerTemplate(
+            options=self.template)
+        yield actor.execute()
+
+    @attr('rightscale', 'integration')
+    @testing.gen_test(timeout=60)
+    def integration_05c_update_st(self):
+        self.template['alerts'][0]['threshold'] = 5
         actor = server_template.ServerTemplate(
             options=self.template)
         yield actor.execute()

--- a/kingpin/actors/rightscale/test/test_alerts.py
+++ b/kingpin/actors/rightscale/test/test_alerts.py
@@ -251,10 +251,10 @@ class TestDestroyActor(testing.AsyncTestCase):
         self.assertEquals(0, destroy_mock._call_count)
 
 
-class TestAlert(testing.AsyncTestCase):
+class TestAlertSpecBase(testing.AsyncTestCase):
 
     def setUp(self, *args, **kwargs):
-        super(TestAlert, self).setUp()
+        super(TestAlertSpecBase, self).setUp()
         base.TOKEN = 'unittest'
 
         self._spec = {
@@ -273,9 +273,7 @@ class TestAlert(testing.AsyncTestCase):
         # Create the actor
         self.actor = alerts.AlertSpecBase(
             options={
-                'array': 'test array',
-                'template': 'test template',
-                'deployment': 'test deployment',
+                'href': '/api/template/abcd',
                 'spec': self._spec,
             }
         )
@@ -290,7 +288,19 @@ class TestAlert(testing.AsyncTestCase):
         self.client_mock.find_by_name_and_keys.side_effect = [
             helper.tornado_value(fake_spec)]
         yield self.actor._precache()
-        self.assertEquals(self.actor.spec, fake_spec)
+        self.assertEquals(self.actor.existing_spec, fake_spec)
+
+    @testing.gen_test
+    def test_precache_too_many_matching(self):
+        fake_spec = mock.MagicMock(name='fake_spec')
+        fake_spec.soul = {'name': 'high load alarm'}
+        self.client_mock.find_by_name_and_keys.side_effect = [
+            helper.tornado_value([
+                fake_spec, fake_spec
+            ])
+        ]
+        yield self.actor._precache()
+        self.assertEquals(self.actor.existing_spec, fake_spec)
 
     @testing.gen_test
     def test_precache_missing(self):
@@ -298,15 +308,15 @@ class TestAlert(testing.AsyncTestCase):
         self.client_mock.find_by_name_and_keys.side_effect = [
             helper.tornado_value(fake_spec)]
         yield self.actor._precache()
-        self.assertEquals(self.actor.spec, fake_spec)
+        self.assertEquals(self.actor.existing_spec, fake_spec)
 
     @testing.gen_test
     def test_get_state(self):
-        self.actor.spec = mock.MagicMock()
+        self.actor.existing_spec = mock.MagicMock()
         ret = yield self.actor._get_state()
         self.assertEquals(ret, 'present')
 
-        self.actor.spec = None
+        self.actor.existing_spec = None
         ret = yield self.actor._get_state()
         self.assertEquals(ret, 'absent')
 
@@ -327,8 +337,8 @@ class TestAlert(testing.AsyncTestCase):
 
     @testing.gen_test
     def test_get_spec(self):
-        self.actor.spec = mock.MagicMock()
-        self.actor.spec.soul = {
+        self.actor.existing_spec = mock.MagicMock()
+        self.actor.existing_spec.soul = {
             'created_at': 'some_time',
             'updated_at': 'some_other_time',
             'name': 'high load alarm',
@@ -361,7 +371,7 @@ class TestAlert(testing.AsyncTestCase):
             helper.tornado_value(fake_spec)
         ]
         yield self.actor._create_spec()
-        self.assertEquals(self.actor.spec, fake_spec)
+        self.assertEquals(self.actor.existing_spec, fake_spec)
 
     @testing.gen_test
     def test_create_spec_422(self):
@@ -396,18 +406,18 @@ class TestAlert(testing.AsyncTestCase):
     @testing.gen_test
     def test_update_spec(self):
         fake_spec = mock.MagicMock()
-        self.actor.spec = mock.MagicMock()
+        self.actor.existing_spec = mock.MagicMock()
         self.actor.desired_params = {}
         self.client_mock.update.side_effect = [
             helper.tornado_value(fake_spec)
         ]
         yield self.actor._update_spec()
-        self.assertEquals(self.actor.spec, fake_spec)
+        self.assertEquals(self.actor.existing_spec, fake_spec)
 
     @testing.gen_test
     def test_update_spec_422(self):
         self.actor.desired_params = {}
-        self.actor.spec = mock.MagicMock()
+        self.actor.existing_spec = mock.MagicMock()
 
         # Mock the update_resource() call so we don't really try to do work
         msg = '422: Unprocessible entity'
@@ -423,7 +433,7 @@ class TestAlert(testing.AsyncTestCase):
     @testing.gen_test
     def test_update_spec_500(self):
         self.actor.desired_params = {}
-        self.actor.spec = mock.MagicMock()
+        self.actor.existing_spec = mock.MagicMock()
 
         # Mock the update_resource() call so we don't really try to do work
         msg = '500: Server Error'
@@ -438,9 +448,109 @@ class TestAlert(testing.AsyncTestCase):
 
     @testing.gen_test
     def test_delete_spec(self):
-        self.actor.spec = mock.MagicMock()
+        self.actor.existing_spec = mock.MagicMock()
         self.client_mock.destroy_resource.side_effect = [
             helper.tornado_value(None)
         ]
         yield self.actor._delete_spec()
-        self.assertEquals(self.actor.spec, None)
+        self.assertEquals(self.actor.existing_spec, None)
+
+
+class TestAlertSpecsBase(testing.AsyncTestCase):
+
+    def setUp(self, *args, **kwargs):
+        super(TestAlertSpecsBase, self).setUp()
+        base.TOKEN = 'unittest'
+
+        self._spec = {
+            'name': 'high load alarm',
+            'description': 'My test alert',
+            'escalation_name': 'critical',
+            'file': 'cpu-0/cpu-idle',
+            'variable': 'value',
+            'condition': '>=',
+            'duration': 5,
+            'threshold': '0.3',
+            'vote_tag': 'array_1',
+            'vote_type': 'grow'
+        }
+
+        # Create the actor. Mock out any calls to create an AlertSpecBase
+        # object and instead return fake object instead.
+        with mock.patch.object(alerts, "AlertSpecBase") as a_mock:
+            a_mock()._precache.side_effect = [helper.tornado_value(None)]
+
+            self.actor = alerts.AlertSpecsBase(
+                options={
+                    'href': '/api/template/abcd',
+                    'specs': [self._spec],
+                }
+            )
+
+        # Patch the actor so that we use the client mock
+        self.client_mock = mock.MagicMock()
+        self.actor._client = self.client_mock
+
+    @testing.gen_test
+    def test_precache(self):
+        unwanted_fake_spec = mock.MagicMock(name='unwanted_fake_spec')
+        unwanted_fake_spec.soul = {
+            'name': 'unwanted spec that should be deleted'
+        }
+        wanted_fake_spec = mock.MagicMock(name='wanted_fake_spec')
+        wanted_fake_spec.soul = {
+            'name': 'high load alarm'
+        }
+        self.client_mock.find_by_name_and_keys.side_effect = [
+            helper.tornado_value([unwanted_fake_spec, wanted_fake_spec])
+        ]
+        with mock.patch.object(alerts, "AlertSpecBase") as a_mock:
+            a_mock()._precache.side_effect = [helper.tornado_value(None)]
+            yield self.actor._precache()
+
+        self.assertEquals(2, len(self.actor.alert_actors))
+
+        self.assertTrue(self.actor.alert_actors[0]._precache.called)
+        self.assertTrue(self.actor.alert_actors[1]._precache.called)
+
+    @testing.gen_test
+    def test_get_state(self):
+        ret = yield self.actor._get_state()
+        self.assertEquals(None, ret)
+
+    @testing.gen_test
+    def test_compare_state(self):
+        self.actor.alert_actors[0]._compare_state.side_effect = [
+            helper.tornado_value(False)]
+
+        ret = yield self.actor._compare_state()
+        self.assertEquals(False, ret)
+
+    @testing.gen_test
+    def test_set_state(self):
+        test_actor = self.actor.alert_actors[0]
+        test_actor._compare_state.side_effect = [helper.tornado_value(False)]
+        test_actor._set_state.side_effect = [helper.tornado_value(None)]
+
+        yield self.actor._set_state()
+
+        self.assertTrue(test_actor._set_state.called)
+        self.assertTrue(self.actor.changed)
+
+    @testing.gen_test
+    def test_get_specs(self):
+        self.actor.alert_actors[0]._get_spec.side_effect = [
+            helper.tornado_value(1)]
+        ret = yield self.actor._get_specs()
+        self.assertEquals([1], ret)
+
+    @testing.gen_test
+    def test_set_specs(self):
+        test_actor = self.actor.alert_actors[0]
+        test_actor._compare_spec.side_effect = [helper.tornado_value(False)]
+        test_actor._execute.side_effect = [helper.tornado_value(None)]
+
+        yield self.actor._set_specs()
+
+        self.assertTrue(test_actor._execute.called)
+        self.assertTrue(self.actor.changed)


### PR DESCRIPTION
No integration tests yet .. since this actor doesn't do any subject href discovery, its hard to test it as is. It will get integration tests when we create actors that subclass from this.