### PR TITLE
Bugfix -- handling a single alertspec on a template was broken

### DIFF
--- a/kingpin/actors/rightscale/alerts.py
+++ b/kingpin/actors/rightscale/alerts.py
@@ -678,6 +678,8 @@ class AlertSpecsBase(base.EnsurableRightScaleBaseActor):
         all_resource_specs = yield self._client.find_by_name_and_keys(
             self._client._client.alert_specs, exact=True,
             subject_href=self.option('href'))
+        if not isinstance(all_resource_specs, list):
+            all_resource_specs = [all_resource_specs]
 
         # Now quickly compare this list to the list of desired specs. For each
         # one thats found that doesn't match, create a new AlertSpecBase actor

--- a/kingpin/actors/rightscale/server_array.py
+++ b/kingpin/actors/rightscale/server_array.py
@@ -377,13 +377,10 @@ class Update(ServerArrayBaseActor):
                       (array.soul['name'], self._params))
         try:
             yield self._client.update(array, self._params)
+        except api.RightScaleError as e:
+            raise exceptions.RecoverableActorFailure(e)
         except requests.exceptions.HTTPError as e:
-            if e.response.status_code in (422, 400):
-                msg = ('Invalid parameters supplied to patch array "%s"' %
-                       self.option('array'))
-                raise exceptions.RecoverableActorFailure(msg)
-
-            raise exceptions.ActorException(e)
+            raise exceptions.UnrecoverableActorFailure(e)
 
         raise gen.Return()
 
@@ -558,12 +555,10 @@ class UpdateNextInstance(ServerArrayBaseActor):
 
         try:
             yield self._client.update(instance, rs_params)
+        except api.RightScaleError as e:
+            raise exceptions.RecoverableActorFailure(e)
         except requests.exceptions.HTTPError as e:
-            if e.response.status_code in (422, 400):
-                msg = ('Invalid parameters supplied to patch array "%s"' %
-                       self.option('array'))
-                raise exceptions.RecoverableActorFailure(msg)
-            raise
+            raise exceptions.UnrecoverableActorFailure(e)
 
         raise gen.Return()
 

--- a/kingpin/actors/rightscale/test/test_alerts.py
+++ b/kingpin/actors/rightscale/test/test_alerts.py
@@ -514,6 +514,23 @@ class TestAlertSpecsBase(testing.AsyncTestCase):
         self.assertTrue(self.actor.alert_actors[1]._precache.called)
 
     @testing.gen_test
+    def test_precache_only_one_returned(self):
+        wanted_fake_spec = mock.MagicMock(name='wanted_fake_spec')
+        wanted_fake_spec.soul = {
+            'name': 'high load alarm'
+        }
+        self.client_mock.find_by_name_and_keys.side_effect = [
+            helper.tornado_value(wanted_fake_spec)
+        ]
+        with mock.patch.object(alerts, "AlertSpecBase") as a_mock:
+            a_mock()._precache.side_effect = [helper.tornado_value(None)]
+            yield self.actor._precache()
+
+        self.assertEquals(1, len(self.actor.alert_actors))
+
+        self.assertTrue(self.actor.alert_actors[0]._precache.called)
+
+    @testing.gen_test
     def test_get_state(self):
         ret = yield self.actor._get_state()
         self.assertEquals(None, ret)

--- a/kingpin/actors/rightscale/test/test_api.py
+++ b/kingpin/actors/rightscale/test/test_api.py
@@ -37,6 +37,16 @@ class TestRightScale(testing.AsyncTestCase):
         def raises_exc():
             raise requests.exceptions.HTTPError(response=response)
 
+        with self.assertRaises(api.RightScaleError):
+            raises_exc()
+
+    def test_exception_logger_with_no_text(self):
+        response = mock.MagicMock(name='fake_response', spec=[])
+
+        @api.rightscale_error_logger
+        def raises_exc():
+            raise requests.exceptions.HTTPError(response=response)
+
         with self.assertRaises(requests.exceptions.HTTPError):
             raises_exc()
 

--- a/kingpin/actors/rightscale/test/test_server_array.py
+++ b/kingpin/actors/rightscale/test/test_server_array.py
@@ -199,26 +199,7 @@ class TestUpdateActor(testing.AsyncTestCase):
         error = requests.exceptions.HTTPError(msg, response=mocked_response)
         self.client_mock.update.side_effect = error
 
-        with self.assertRaises(exceptions.ActorException):
-            yield self.actor._execute()
-
-        self.client_mock.update.assert_called_once_with(
-            mocked_array, [('server_array[name]', 'newunitarray')])
-
-    @testing.gen_test
-    def test_execute_400_error(self):
-        mocked_array = mock.MagicMock(name='unittestarray')
-
-        self.actor._check_array_inputs = mock_tornado(True)
-        self.actor._find_server_arrays = mock_tornado(mocked_array)
-
-        msg = '400 Client Error: Bad Request'
-        mocked_response = mock.MagicMock(name='response')
-        mocked_response.status_code = 400
-        error = requests.exceptions.HTTPError(msg, response=mocked_response)
-        self.client_mock.update.side_effect = error
-
-        with self.assertRaises(exceptions.RecoverableActorFailure):
+        with self.assertRaises(exceptions.UnrecoverableActorFailure):
             yield self.actor._execute()
 
         self.client_mock.update.assert_called_once_with(
@@ -231,10 +212,7 @@ class TestUpdateActor(testing.AsyncTestCase):
         self.actor._check_array_inputs = mock_tornado(True)
         self.actor._find_server_arrays = mock_tornado(mocked_array)
 
-        msg = '422 Client Error: Unprocessable Entity'
-        mocked_response = mock.MagicMock(name='response')
-        mocked_response.status_code = 422
-        error = requests.exceptions.HTTPError(msg, response=mocked_response)
+        error = api.RightScaleError('error doing thing')
         self.client_mock.update.side_effect = error
 
         with self.assertRaises(exceptions.RecoverableActorFailure):
@@ -341,29 +319,7 @@ class TestUpdateNextInstanceActor(testing.AsyncTestCase):
         self.actor._find_def_image_href = mock_tornado('fake_href')
         self.actor._client.show.side_effect = mock_tornado(mocked_instance)
 
-        msg = '400 Client Error: Bad Request'
-        mocked_response = mock.MagicMock(name='response')
-        mocked_response.status_code = 400
-        error = requests.exceptions.HTTPError(msg, response=mocked_response)
-        self.client_mock.update.side_effect = error
-
-        with self.assertRaises(exceptions.RecoverableActorFailure):
-            yield self.actor._update_params(mocked_array)
-
-    @testing.gen_test
-    def test_update_params_422_error(self):
-        # Mock out our array object, and the next_instance. Then mock out the
-        # api.show() method to return the mocked instance. Verify that the
-        # right calls were made to the API though.
-        mocked_array = mock.MagicMock(name='unittestarray')
-        mocked_instance = mock.MagicMock(name='nextinstance')
-        self.actor._find_def_image_href = mock_tornado('fake_href')
-        self.actor._client.show.side_effect = mock_tornado(mocked_instance)
-
-        msg = '422 Client Error: Unprocessable Entity'
-        mocked_response = mock.MagicMock(name='response')
-        mocked_response.status_code = 422
-        error = requests.exceptions.HTTPError(msg, response=mocked_response)
+        error = api.RightScaleError('error')
         self.client_mock.update.side_effect = error
 
         with self.assertRaises(exceptions.RecoverableActorFailure):
@@ -385,7 +341,7 @@ class TestUpdateNextInstanceActor(testing.AsyncTestCase):
         error = requests.exceptions.HTTPError(msg, response=mocked_response)
         self.client_mock.update.side_effect = error
 
-        with self.assertRaises(requests.exceptions.HTTPError):
+        with self.assertRaises(exceptions.UnrecoverableActorFailure):
             yield self.actor._update_params(mocked_array)
 
     @testing.gen_test


### PR DESCRIPTION
This also includes some cleanup to our RightScale error text handling to
make it more obvious when we have clean rightscale error text coming
back to us.