### PR TITLE
Convert the aws.s3.Bucket actor to use Boto3

### DIFF
--- a/kingpin/actors/aws/base.py
+++ b/kingpin/actors/aws/base.py
@@ -41,7 +41,6 @@ import re
 
 from boto import exception as boto_exception
 from boto import utils as boto_utils
-from boto.s3.connection import OrdinaryCallingFormat
 from boto3 import exceptions as boto3_exceptions
 from retrying import retry
 from tornado import concurrent
@@ -51,7 +50,6 @@ import boto.cloudformation
 import boto.ec2
 import boto.ec2.elb
 import boto.iam
-import boto.s3
 import boto.sqs
 import boto3
 
@@ -172,11 +170,11 @@ class AWSBaseActor(base.BaseActor):
             region,
             aws_access_key_id=key,
             aws_secret_access_key=secret)
-        self.s3_conn = boto.s3.connect_to_region(
-            region,
+        self.s3_conn = boto3.client(
+            's3',
+            region_name=region,
             aws_access_key_id=key,
-            aws_secret_access_key=secret,
-            calling_format=OrdinaryCallingFormat())
+            aws_secret_access_key=secret)
 
     @concurrent.run_on_executor
     @retry(**aws_settings.RETRYING_SETTINGS)
@@ -334,3 +332,8 @@ class AWSBaseActor(base.BaseActor):
         dict2 = pprint.pformat(dict2).splitlines()
 
         return '\n'.join(difflib.unified_diff(dict1, dict2, n=2))
+
+
+class EnsurableAWSBaseActor(AWSBaseActor, base.EnsurableBaseActor):
+
+    """Ensurable version of the AWS Base Actor"""

--- a/kingpin/actors/aws/test/test_s3.py
+++ b/kingpin/actors/aws/test/test_s3.py
@@ -1,15 +1,12 @@
 import logging
 
-from boto.exception import S3ResponseError
-from boto.s3 import lifecycle
+from botocore.exceptions import ClientError
 from tornado import testing
 import mock
 
 from kingpin.actors import exceptions
-from kingpin.actors.aws import base as aws_base
 from kingpin.actors.aws import s3 as s3_actor
 from kingpin.actors.aws import settings
-from kingpin.actors.test.helper import tornado_value
 
 log = logging.getLogger(__name__)
 
@@ -34,7 +31,7 @@ class TestBucket(testing.AsyncTestCase):
                     'status': 'Enabled',
                     'expiration': "30",
                     'transition': {
-                        'days': "45",
+                        'days': 45,
                         'storage_class': 'GLACIER',
                     }
                 }],
@@ -55,10 +52,6 @@ class TestBucket(testing.AsyncTestCase):
                         'invalid_data': 'bad_field'
                     }})
 
-    def test_generate_lifecycle_empty_returns_none(self):
-        ret = self.actor._generate_lifecycle([])
-        self.assertEquals(ret, None)
-
     def test_generate_lifecycle_missing_expiration(self):
         bad_config = [
             {'id': 'test', 'prefix': '/', 'state': 'Enabled'}
@@ -73,431 +66,381 @@ class TestBucket(testing.AsyncTestCase):
 
         # Verify that the rule was created with the basic options
         r = self.actor.lifecycle[0]
-        self.assertEquals(r.id, 'test')
-        self.assertEquals(r.prefix, '/test')
-        self.assertEquals(r.status, 'Enabled')
+        self.assertEquals(r['ID'], 'test')
+        self.assertEquals(r['Prefix'], '/test')
+        self.assertEquals(r['Status'], 'Enabled')
 
         # Validate that the string "30" was turned into an Expiration object
-        self.assertEquals(r.expiration.days, 30)
+        self.assertEquals(r['Expiration']['Days'], 30)
 
         # Validate that the transition config was built properly too
-        self.assertEquals(r.transition.days, 45)
+        self.assertEquals(r['Transition']['Days'], 45)
+
+    def test_snake_to_camel(self):
+        snake = {
+            'i_should_be_taller': {
+                'me_too_man': [
+                    'not_me'
+                ]
+            }
+        }
+
+        self.assertEquals(
+            self.actor._snake_to_camel(snake),
+            {'IShouldBeTaller': {'MeTooMan': ['not_me']}}
+        )
 
     @testing.gen_test
-    def test_get_bucket_exists(self):
-        fake_bucket = mock.MagicMock()
-        self.actor.s3_conn.get_bucket.return_value = fake_bucket
-        ret = yield self.actor._get_bucket()
-        self.assertEquals(fake_bucket, ret)
+    def test_precache(self):
+        self.actor.s3_conn.list_buckets.return_value = {
+            'Buckets': [
+                {'Name': 'wrong_bucket'},
+                {'Name': 'test'}
+            ]
+        }
+
+        yield self.actor._precache()
+        self.assertTrue(self.actor._bucket_exists)
 
     @testing.gen_test
-    def test_get_bucket_301(self):
-        self.actor.s3_conn.get_bucket.side_effect = S3ResponseError(
-            301, 'Wrong region buddy')
-        with self.assertRaises(exceptions.RecoverableActorFailure):
-            yield self.actor._get_bucket()
+    def test_get_state_absent(self):
+        ret = yield self.actor._get_state()
+        self.assertEquals('absent', ret)
 
     @testing.gen_test
-    def test_get_bucket_404(self):
-        self.actor.s3_conn.get_bucket.side_effect = S3ResponseError(
-            404, 'Not here')
-        ret = yield self.actor._get_bucket()
-        self.assertEquals(None, ret)
+    def test_get_state_present(self):
+        self.actor._bucket_exists = True
+        ret = yield self.actor._get_state()
+        self.assertEquals('present', ret)
 
     @testing.gen_test
-    def test_get_bucket_500(self):
-        self.actor.s3_conn.get_bucket.side_effect = S3ResponseError(
-            500, 'Something else happened')
-        with self.assertRaises(exceptions.RecoverableActorFailure):
-            yield self.actor._get_bucket()
-
-    @testing.gen_test
-    def test_ensure_bucket_is_present_and_wants_present(self):
-        self.actor._options['state'] = 'present'
-        self.actor._get_bucket = mock.MagicMock()
-        self.actor._get_bucket.side_effect = [tornado_value(True)]
-        self.actor._create_bucket = mock.MagicMock()
-        self.actor._create_bucket.side_effect = [tornado_value(None)]
-        self.actor._delete_bucket = mock.MagicMock()
-        self.actor._delete_bucket.side_effect = [tornado_value(None)]
-
-        ret = yield self.actor._ensure_bucket()
-        self.assertEquals(True, ret)
-        self.assertFalse(self.actor._create_bucket.called)
-        self.assertFalse(self.actor._delete_bucket.called)
-
-    @testing.gen_test
-    def test_ensure_bucket_is_present_and_wants_absent(self):
+    def test_set_state_absent(self):
         self.actor._options['state'] = 'absent'
-        self.actor._get_bucket = mock.MagicMock()
-        self.actor._get_bucket.side_effect = [tornado_value(True)]
-        self.actor._create_bucket = mock.MagicMock()
-        self.actor._create_bucket.side_effect = [tornado_value(None)]
-        self.actor._verify_can_delete_bucket = mock.MagicMock()
-        self.actor._verify_can_delete_bucket.side_effect = [
-            tornado_value(None)]
-        self.actor._delete_bucket = mock.MagicMock()
-        self.actor._delete_bucket.side_effect = [tornado_value(None)]
-
-        ret = yield self.actor._ensure_bucket()
-        self.assertEquals(None, ret)
-        self.assertFalse(self.actor._create_bucket.called)
-        self.actor._verify_can_delete_bucket.assert_called_with(bucket=True)
-        self.actor._delete_bucket.assert_called_with(bucket=True)
+        yield self.actor._set_state()
+        self.actor.s3_conn.delete_bucket.assert_has_calls([
+            mock.call(Bucket='test')])
 
     @testing.gen_test
-    def test_ensure_bucket_is_absent_and_wants_present(self):
+    def test_set_state_present(self):
         self.actor._options['state'] = 'present'
-        self.actor._get_bucket = mock.MagicMock()
-        self.actor._get_bucket.side_effect = [tornado_value(None)]
-        self.actor._create_bucket = mock.MagicMock()
-        self.actor._create_bucket.side_effect = [tornado_value(True)]
-        self.actor._delete_bucket = mock.MagicMock()
-        self.actor._delete_bucket.side_effect = [tornado_value(None)]
-
-        ret = yield self.actor._ensure_bucket()
-        self.assertEquals(True, ret)
-        self.assertTrue(self.actor._create_bucket.called)
-        self.assertFalse(self.actor._delete_bucket.called)
-
-    @testing.gen_test
-    def test_ensure_bucket_is_absent_and_wants_absent(self):
-        self.actor._options['state'] = 'absent'
-        self.actor._get_bucket = mock.MagicMock()
-        self.actor._get_bucket.side_effect = [tornado_value(None)]
-        self.actor._create_bucket = mock.MagicMock()
-        self.actor._create_bucket.side_effect = [tornado_value(None)]
-        self.actor._delete_bucket = mock.MagicMock()
-        self.actor._delete_bucket.side_effect = [tornado_value(None)]
-
-        ret = yield self.actor._ensure_bucket()
-        self.assertEquals(None, ret)
-        self.assertFalse(self.actor._create_bucket.called)
-        self.assertFalse(self.actor._delete_bucket.called)
-
-    @testing.gen_test
-    def test_create_bucket_dry(self):
-        self.actor._dry = True
-        self.actor.s3_conn.create_bucket = mock.MagicMock()
-        self.actor.s3_conn.create_bucket.return_value = True
-        ret = yield self.actor._create_bucket()
-        self.assertTrue(isinstance(ret, mock.MagicMock))
-        self.assertFalse(self.actor.s3_conn.create_bucket.called)
+        yield self.actor._set_state()
+        self.actor.s3_conn.create_bucket.assert_has_calls([
+            mock.call(Bucket='test')])
 
     @testing.gen_test
     def test_create_bucket(self):
-        self.actor.s3_conn.create_bucket = mock.MagicMock()
-        self.actor.s3_conn.create_bucket.return_value = True
-        ret = yield self.actor._create_bucket()
-        self.assertEquals(True, ret)
-        self.actor.s3_conn.create_bucket.assert_called_with(
-            'test')
+        yield self.actor._create_bucket()
+        self.actor.s3_conn.create_bucket.assert_called_with(Bucket='test')
 
     @testing.gen_test
     def test_create_bucket_new_region(self):
-        self.actor.s3_conn.create_bucket = mock.MagicMock()
-        self.actor.s3_conn.create_bucket.return_value = True
         self.actor._options['region'] = 'us-west-1'
-        ret = yield self.actor._create_bucket()
-        self.assertEquals(True, ret)
+        yield self.actor._create_bucket()
         self.actor.s3_conn.create_bucket.assert_called_with(
-            'test', location='us-west-1')
+            Bucket='test',
+            CreateBucketConfiguration={'LocationConstraint': 'us-west-1'})
 
     @testing.gen_test
     def test_verify_can_delete_bucket(self):
-        fake_bucket = mock.MagicMock()
-        fake_bucket.get_all_keys.return_value = [1, 2, 3]
+        self.actor.s3_conn.list_objects.return_value = {
+            'Contents': [1, 2, 3]
+        }
         with self.assertRaises(exceptions.RecoverableActorFailure):
-            yield self.actor._verify_can_delete_bucket(fake_bucket)
+            yield self.actor._verify_can_delete_bucket()
+
+    @testing.gen_test
+    def test_verify_can_delete_bucket_true(self):
+        self.actor.s3_conn.list_objects.return_value = {}
+        yield self.actor._verify_can_delete_bucket()
 
     @testing.gen_test
     def test_delete_bucket(self):
-        fake_bucket = mock.MagicMock()
-        fake_bucket.side_effect = [tornado_value(None)]
-        yield self.actor._delete_bucket(bucket=fake_bucket)
-        self.assertTrue(fake_bucket.delete.called)
+        yield self.actor._delete_bucket()
+        self.actor.s3_conn.delete_bucket.assert_has_calls(
+            [mock.call(Bucket='test')])
 
     @testing.gen_test
     def test_delete_bucket_409(self):
-        fake_bucket = mock.MagicMock()
-        fake_bucket.side_effect = [tornado_value(None)]
-        fake_bucket.delete.side_effect = S3ResponseError(409, 'Files in it!')
+        self.actor.s3_conn.delete_bucket.side_effect = ClientError(
+            {'Error': {}}, 'Error')
         with self.assertRaises(exceptions.RecoverableActorFailure):
-            yield self.actor._delete_bucket(bucket=fake_bucket)
+            yield self.actor._delete_bucket()
 
     @testing.gen_test
-    def test_ensure_policy_is_500(self):
-        fake_bucket = mock.MagicMock()
-        fake_bucket.get_policy.side_effect = S3ResponseError(500, 'None')
-        with self.assertRaises(exceptions.RecoverableActorFailure):
-            yield self.actor._ensure_policy(fake_bucket)
+    def test_get_policy(self):
+        self.actor.s3_conn.get_bucket_policy.return_value = {'Policy': '{}'}
+        ret = yield self.actor._get_policy()
+        self.assertEquals({}, ret)
 
     @testing.gen_test
-    def test_ensure_policy_is_404_and_wants_absent(self):
-        fake_bucket = mock.MagicMock()
-        fake_bucket.get_policy.side_effect = S3ResponseError(404, 'None')
+    def test_get_policy_empty(self):
+        self.actor.s3_conn.get_bucket_policy.side_effect = ClientError(
+            {'Error': {}}, 'NoSuchBucketPolicy')
+        ret = yield self.actor._get_policy()
+        self.assertEquals('', ret)
+
+    @testing.gen_test
+    def test_get_policy_exc(self):
+        self.actor.s3_conn.get_bucket_policy.side_effect = ClientError(
+            {'Error': {}}, 'SomeOtherError')
+        with self.assertRaises(ClientError):
+            yield self.actor._get_policy()
+
+    @testing.gen_test
+    def test_compare_policy(self):
+        self.actor.policy = {'test': 'policy'}
+        self.actor.s3_conn.get_bucket_policy.return_value = {
+            'Policy': '{"test": "policy"}'
+        }
+        ret = yield self.actor._compare_policy()
+        self.assertTrue(ret)
+
+    @testing.gen_test
+    def test_compare_policy_false(self):
+        self.actor.policy = {'test': 'bah'}
+        self.actor.s3_conn.get_bucket_policy.return_value = {
+            'Policy': '{"test": "policy"}'
+        }
+        ret = yield self.actor._compare_policy()
+        self.assertFalse(ret)
+
+    @testing.gen_test
+    def test_compare_policy_not_managing(self):
+        self.actor.policy = None
+        self.actor.s3_conn.get_bucket_policy.return_value = {
+            'Policy': '{"test": "policy"}'
+        }
+        ret = yield self.actor._compare_policy()
+        self.assertTrue(ret)
+
+    @testing.gen_test
+    def test_set_policy(self):
+        self.actor.policy = {}
+        yield self.actor._set_policy()
+        self.actor.s3_conn.put_bucket_policy.assert_has_calls([
+            mock.call(Bucket='test', Policy='{}')])
+
+    @testing.gen_test
+    def test_set_policy_malformed_policy(self):
+        self.actor.policy = {}
+        self.actor.s3_conn.put_bucket_policy.side_effect = ClientError(
+            {'Error': {}}, 'MalformedPolicy')
+        with self.assertRaises(exceptions.RecoverableActorFailure):
+            yield self.actor._set_policy()
+
+        self.actor.s3_conn.put_bucket_policy.assert_has_calls([
+            mock.call(Bucket='test', Policy='{}')])
+
+    @testing.gen_test
+    def test_set_policy_client_error(self):
+        self.actor.policy = {}
+        self.actor.s3_conn.put_bucket_policy.side_effect = ClientError(
+            {'Error': {}}, 'Some Other Error')
+        with self.assertRaises(exceptions.RecoverableActorFailure):
+            yield self.actor._set_policy()
+
+        self.actor.s3_conn.put_bucket_policy.assert_has_calls([
+            mock.call(Bucket='test', Policy='{}')])
+
+    @testing.gen_test
+    def test_set_policy_delete(self):
         self.actor.policy = ''
-        yield self.actor._ensure_policy(fake_bucket)
+        yield self.actor._set_policy()
+        self.actor.s3_conn.delete_bucket_policy.assert_has_calls([
+            mock.call(Bucket='test')])
 
     @testing.gen_test
-    def test_ensure_policy_is_present_and_wants_absent(self):
-        fake_bucket = mock.MagicMock()
-        fake_bucket.get_policy.return_value = '{"fake_pol": 1}'
-        self.actor.policy = ''
-        yield self.actor._ensure_policy(fake_bucket)
-        self.assertTrue(fake_bucket.delete_policy.called)
+    def test_get_logging(self):
+        self.actor._bucket_exists = True
+        self.actor.s3_conn.get_bucket_logging.return_value = {
+            'LoggingEnabled': {
+                'TargetBucket': 'Target-Bucket',
+                'TargetPrefix': 'Target-Prefix'
+            }
+        }
+
+        ret = yield self.actor._get_logging()
+        self.assertEquals(
+            ret,
+            {'target': 'Target-Bucket', 'prefix': 'Target-Prefix'})
 
     @testing.gen_test
-    def test_ensure_policy_is_present_and_wants_absent_500(self):
-        fake_bucket = mock.MagicMock()
-        fake_bucket.get_policy.return_value = '{"fake_pol": 1}'
-        fake_bucket.delete_policy.side_effect = S3ResponseError(500, 'None')
-        self.actor.policy = ''
-        with self.assertRaises(exceptions.RecoverableActorFailure):
-            yield self.actor._ensure_policy(fake_bucket)
+    def test_get_logging_disabled(self):
+        self.actor._bucket_exists = True
+        self.actor.s3_conn.get_bucket_logging.return_value = {}
+        ret = yield self.actor._get_logging()
+        self.assertEquals(ret, {'target': '', 'prefix': ''})
 
     @testing.gen_test
-    def test_ensure_policy_is_present_and_wants_same(self):
-        fake_bucket = mock.MagicMock()
-        fake_bucket.get_policy.return_value = '{"fake_pol": 1}'
-        self.actor.policy = {"fake_pol": 1}
-        yield self.actor._ensure_policy(fake_bucket)
-        self.assertFalse(fake_bucket.set_policy.called)
+    def test_get_logging_no_bucket(self):
+        self.actor._bucket_exists = False
+        ret = yield self.actor._get_logging()
+        self.assertEquals(ret, None)
 
     @testing.gen_test
-    def test_ensure_policy_is_present_and_wants_different(self):
-        fake_bucket = mock.MagicMock()
-        fake_bucket.get_policy.return_value = '{"fake_pol": 1}'
-        yield self.actor._ensure_policy(fake_bucket)
-        self.assertTrue(fake_bucket.set_policy.called)
+    def test_set_logging_not_desired(self):
+        self.actor._options['logging'] = None
+        yield self.actor._set_logging()
+        self.assertFalse(self.actor.s3_conn.put_bucket_logging.called)
 
     @testing.gen_test
-    def test_ensure_policy_is_present_and_wants_different_malformed(self):
-        malformed_exc = S3ResponseError(400, 'Bad')
-        malformed_exc.error_code = 'MalformedPolicy'
-        fake_bucket = mock.MagicMock()
-        fake_bucket.get_policy.return_value = '{"fake_pol": 1}'
-        fake_bucket.set_policy.side_effect = malformed_exc
-        with self.assertRaises(aws_base.InvalidPolicy):
-            yield self.actor._ensure_policy(fake_bucket)
+    def test_set_logging_disabled(self):
+        self.actor._options['logging'] = {'target': '', 'prefix': ''}
+        yield self.actor._set_logging()
+        self.actor.s3_conn.put_bucket_logging.assert_has_calls([
+            mock.call(Bucket='test', BucketLoggingStatus={})])
 
     @testing.gen_test
-    def test_ensure_policy_is_present_and_wants_different_500(self):
-        fake_bucket = mock.MagicMock()
-        fake_bucket.get_policy.return_value = '{"fake_pol": 1}'
-        fake_bucket.set_policy.side_effect = S3ResponseError(500, 'Fail')
-        with self.assertRaises(exceptions.RecoverableActorFailure):
-            yield self.actor._ensure_policy(fake_bucket)
+    def test_set_logging(self):
+        self.actor._options['logging'] = {'target': 'tgt', 'prefix': 'pfx'}
+        yield self.actor._set_logging()
+        self.actor.s3_conn.put_bucket_logging.assert_has_calls([
+            mock.call(
+                Bucket='test',
+                BucketLoggingStatus={'LoggingEnabled': {
+                    'TargetPrefix': 'pfx', 'TargetBucket': 'tgt'}}
+            )])
 
     @testing.gen_test
-    def test_ensure_logging_is_present_and_wants_absent(self):
-        self.actor._options['logging'] = {'target': ''}
-        fake_logging_status = mock.MagicMock()
-        fake_logging_status.target = 'some_bucket'
-        fake_logging_status.prefix = None
-        fake_bucket = mock.MagicMock()
-        fake_bucket.get_logging_status.return_value = fake_logging_status
-        yield self.actor._ensure_logging(fake_bucket)
-        self.assertTrue(fake_bucket.get_logging_status.called)
-        self.assertTrue(fake_bucket.disable_logging.called)
-        self.assertFalse(fake_bucket.enable_logging.called)
-
-    @testing.gen_test
-    def test_ensure_logging_is_absent_and_wants_absent(self):
-        self.actor._options['logging'] = {'target': ''}
-        fake_logging_status = mock.MagicMock()
-        fake_logging_status.target = None
-        fake_logging_status.prefix = None
-        fake_bucket = mock.MagicMock()
-        fake_bucket.get_logging_status.return_value = fake_logging_status
-        yield self.actor._ensure_logging(fake_bucket)
-        self.assertTrue(fake_bucket.get_logging_status.called)
-        self.assertFalse(fake_bucket.disable_logging.called)
-        self.assertFalse(fake_bucket.enable_logging.called)
-
-    @testing.gen_test
-    def test_ensure_logging_is_absent_and_wants_present(self):
-        fake_logging_status = mock.MagicMock()
-        fake_logging_status.target = None
-        fake_logging_status.prefix = None
-        fake_bucket = mock.MagicMock()
-        fake_bucket.get_logging_status.return_value = fake_logging_status
-        yield self.actor._ensure_logging(fake_bucket)
-        self.assertTrue(fake_bucket.get_logging_status.called)
-        self.assertFalse(fake_bucket.disable_logging.called)
-        fake_bucket.enable_logging.assert_has_calls(
-            [mock.call('test_target', '/prefix')])
-
-    @testing.gen_test
-    def test_ensure_logging_is_present_and_matches(self):
-        fake_logging_status = mock.MagicMock()
-        fake_logging_status.target = 'test_target'
-        fake_logging_status.prefix = '/prefix'
-        fake_bucket = mock.MagicMock()
-        fake_bucket.get_logging_status.return_value = fake_logging_status
-        yield self.actor._ensure_logging(fake_bucket)
-        self.assertTrue(fake_bucket.get_logging_status.called)
-        self.assertFalse(fake_bucket.disable_logging.called)
-        self.assertFalse(fake_bucket.enable_logging.called)
-
-    @testing.gen_test
-    def test_ensure_logging_is_absent_and_wants_present_400(self):
-        fake_logging_status = mock.MagicMock()
-        fake_logging_status.target = 'some_new_target'
-        fake_logging_status.prefix = '/prefix'
-        fake_bucket = mock.MagicMock()
-        fake_bucket.get_logging_status.return_value = fake_logging_status
-        invalid_target_exc = S3ResponseError(500, 'Damn')
-        invalid_target_exc.error_code = 'InvalidTargetBucketForLogging'
-        fake_bucket.enable_logging.side_effect = invalid_target_exc
+    def test_set_logging_client_error(self):
+        self.actor.s3_conn.put_bucket_logging.side_effect = ClientError(
+            {'Error': {}}, 'Some error')
         with self.assertRaises(s3_actor.InvalidBucketConfig):
-            yield self.actor._ensure_logging(fake_bucket)
+            yield self.actor._set_logging()
 
     @testing.gen_test
-    def test_ensure_logging_is_absent_and_wants_present_500(self):
-        fake_logging_status = mock.MagicMock()
-        fake_logging_status.target = 'some_new_target'
-        fake_logging_status.prefix = '/prefix'
-        fake_bucket = mock.MagicMock()
-        fake_bucket.get_logging_status.return_value = fake_logging_status
-        fake_bucket.enable_logging.side_effect = S3ResponseError(500, 'Damn')
-        with self.assertRaises(exceptions.RecoverableActorFailure):
-            yield self.actor._ensure_logging(fake_bucket)
+    def test_get_versioning(self):
+        self.actor.s3_conn.get_bucket_versioning.return_value = {
+            'Status': 'Enabled'}
+        ret = yield self.actor._get_versioning()
+        self.assertTrue(ret)
 
     @testing.gen_test
-    def test_ensure_versioning_is_absent_and_wants_disabled(self):
-        self.actor._options['versioning'] = False
-        versioning = {}
-        fake_bucket = mock.MagicMock()
-        fake_bucket.get_versioning_status.return_value = versioning
-        yield self.actor._ensure_versioning(fake_bucket)
-        self.assertFalse(fake_bucket.configure_versioning.called)
+    def test_get_versioning_suspended(self):
+        self.actor.s3_conn.get_bucket_versioning.return_value = {
+            'Status': 'Suspended'}
+        ret = yield self.actor._get_versioning()
+        self.assertFalse(ret)
 
     @testing.gen_test
-    def test_ensure_versioning_is_suspended_and_wants_enabled(self):
-        self.actor._options['versioning'] = False
-        versioning = {'MfaDelete': 'Disabled', 'Versioning': 'Suspended'}
-        fake_bucket = mock.MagicMock()
-        fake_bucket.get_versioning_status.return_value = versioning
-        yield self.actor._ensure_versioning(fake_bucket)
-        self.assertFalse(fake_bucket.configure_versioning.called)
-
-    @testing.gen_test
-    def test_ensure_versioning_is_enabled_and_wants_suspended(self):
-        self.actor._options['versioning'] = False
-        versioning = {'MfaDelete': 'Disabled', 'Versioning': 'Enabled'}
-        fake_bucket = mock.MagicMock()
-        fake_bucket.get_versioning_status.return_value = versioning
-        yield self.actor._ensure_versioning(fake_bucket)
-        self.assertTrue(fake_bucket.configure_versioning.called)
-
-    @testing.gen_test
-    def test_ensure_versioning_is_enabled_and_wants_enabled(self):
+    def test_set_versioning(self):
         self.actor._options['versioning'] = True
-        versioning = {'MfaDelete': 'Disabled', 'Versioning': 'Enabled'}
-        fake_bucket = mock.MagicMock()
-        fake_bucket.get_versioning_status.return_value = versioning
-        yield self.actor._ensure_versioning(fake_bucket)
-        self.assertFalse(fake_bucket.configure_versioning.called)
+        yield self.actor._set_versioning()
+        self.actor.s3_conn.put_bucket_versioning.assert_has_calls([
+            mock.call(
+                Bucket='test',
+                VersioningConfiguration={'Status': 'Enabled'})])
 
     @testing.gen_test
-    def test_ensure_versioning_is_absent_and_wants_enabled(self):
-        self.actor._options['versioning'] = True
-        versioning = {}
-        fake_bucket = mock.MagicMock()
-        fake_bucket.get_versioning_status.return_value = versioning
-        yield self.actor._ensure_versioning(fake_bucket)
-        self.assertTrue(fake_bucket.configure_versioning.called)
+    def test_set_versioning_suspended(self):
+        self.actor._options['versioning'] = False
+        yield self.actor._set_versioning()
+        self.actor.s3_conn.put_bucket_versioning.assert_has_calls([
+            mock.call(
+                Bucket='test',
+                VersioningConfiguration={'Status': 'Suspended'})])
 
     @testing.gen_test
-    def test_ensure_lifecycle_raises_exc(self):
+    def test_set_versioning_none(self):
+        self.actor._options['versioning'] = None
+        yield self.actor._set_versioning()
+        self.assertFalse(self.actor.s3_conn.put_bucket_versioning.called)
+
+    @testing.gen_test
+    def test_get_lifecycle(self):
+        self.actor.s3_conn.get_bucket_lifecycle.return_value = {
+            'Rules': []}
+        ret = yield self.actor._get_lifecycle()
+        self.assertEquals(ret, [])
+
+    @testing.gen_test
+    def test_get_lifecycle_empty(self):
+        self.actor.s3_conn.get_bucket_lifecycle.side_effect = ClientError(
+            {'Error': {}}, 'NoSuchLifecycleConfiguration')
+        ret = yield self.actor._get_lifecycle()
+        self.assertEquals(ret, [])
+
+    @testing.gen_test
+    def test_compare_lifecycle(self):
+        self.actor.lifecycle = [{'test': 'test'}]
+        self.actor.s3_conn.get_bucket_lifecycle.return_value = {
+            'Rules': [{'test': 'test'}]}
+        ret = yield self.actor._compare_lifecycle()
+        self.assertTrue(ret)
+
+    @testing.gen_test
+    def test_compare_lifecycle_none(self):
         self.actor.lifecycle = None
-        fake_bucket = mock.MagicMock()
-        exc = S3ResponseError(500, 'Empty')
-        fake_bucket.get_lifecycle_config.side_effect = exc
-        with self.assertRaises(exceptions.RecoverableActorFailure):
-            yield self.actor._ensure_lifecycle(fake_bucket)
+        ret = yield self.actor._compare_lifecycle()
+        self.assertTrue(ret)
 
     @testing.gen_test
-    def test_ensure_lifecycle_is_absent_and_wants_absent(self):
-        self.actor.lifecycle = None
-        fake_bucket = mock.MagicMock()
-        exc = S3ResponseError(404, 'Empty')
-        fake_bucket.get_lifecycle_config.side_effect = exc
-        yield self.actor._ensure_lifecycle(fake_bucket)
-        self.assertFalse(fake_bucket.configure_lifecycle.called)
-        self.assertFalse(fake_bucket.delete_lifecycle_configuration.called)
+    def test_compare_lifecycle_diff(self):
+        self.actor.lifecycle = [{'test1': 'test'}]
+        self.actor.s3_conn.get_bucket_lifecycle.return_value = {
+            'Rules': [{'test': 'test'}]}
+        ret = yield self.actor._compare_lifecycle()
+        self.assertFalse(ret)
 
     @testing.gen_test
-    def test_ensure_lifecycle_is_present_and_wants_absent(self):
-        self.actor.lifecycle = None
-        fake_bucket = mock.MagicMock()
-        fake_bucket.get_lifecycle_config.return_value = lifecycle.Lifecycle()
-        yield self.actor._ensure_lifecycle(fake_bucket)
-        self.assertFalse(fake_bucket.configure_lifecycle.called)
-        self.assertTrue(fake_bucket.delete_lifecycle_configuration.called)
+    def test_set_lifecycle_delete(self):
+        self.actor.lifecycle = []
+        yield self.actor._set_lifecycle()
+        self.actor.s3_conn.delete_bucket_lifecycle.assert_has_calls([
+            mock.call(Bucket='test')])
 
     @testing.gen_test
-    def test_ensure_lifecycle_is_absent_and_wants_present(self):
-        fake_bucket = mock.MagicMock()
-        exc = S3ResponseError(404, 'Empty')
-        fake_bucket.get_lifecycle_config.side_effect = exc
-        yield self.actor._ensure_lifecycle(fake_bucket)
-        self.assertTrue(fake_bucket.configure_lifecycle.called)
-        self.assertFalse(fake_bucket.delete_lifecycle_configuration.called)
+    def test_set_lifecycle(self):
+        self.actor.lifecycle = [{'test': 'test'}]
+        yield self.actor._set_lifecycle()
+        self.actor.s3_conn.put_bucket_lifecycle.assert_has_calls([
+            mock.call(
+                Bucket='test',
+                LifecycleConfiguration={'Rules': [{'test': 'test'}]})])
 
     @testing.gen_test
-    def test_ensure_lifecycle_is_present_and_wants_different(self):
-        fake_bucket = mock.MagicMock()
-        fake_bucket.get_lifecycle_config.return_value = lifecycle.Lifecycle()
-        yield self.actor._ensure_lifecycle(fake_bucket)
-        self.assertTrue(fake_bucket.configure_lifecycle.called)
-        self.assertFalse(fake_bucket.delete_lifecycle_configuration.called)
-
-    @testing.gen_test
-    def test_delete_lifecycle(self):
-        fake_bucket = mock.MagicMock()
-        yield self.actor._delete_lifecycle(fake_bucket)
-        self.assertTrue(fake_bucket.delete_lifecycle_configuration.called)
-
-    @testing.gen_test
-    def test_configure_lifecycle(self):
-        fake_bucket = mock.MagicMock()
-        yield self.actor._configure_lifecycle(bucket=fake_bucket,
-                                              lifecycle=self.actor.lifecycle)
-        self.assertTrue(fake_bucket.configure_lifecycle.called)
-
-    @testing.gen_test
-    def test_configure_lifecycle_raises_exc(self):
-        fake_bucket = mock.MagicMock()
-        fake_bucket.configure_lifecycle.side_effect = S3ResponseError(
-            400, 'bad config')
+    def test_set_lifecycle_client_error(self):
+        self.actor.s3_conn.put_bucket_lifecycle.side_effect = ClientError(
+            {'Error': {}}, 'Error')
         with self.assertRaises(s3_actor.InvalidBucketConfig):
-            yield self.actor._configure_lifecycle(
-                bucket=fake_bucket, lifecycle=self.actor.lifecycle)
+            yield self.actor._set_lifecycle()
 
     @testing.gen_test
-    def test_execute_absent(self):
-        self.actor._options['state'] = 'absent'
-        self.actor._ensure_bucket = mock.MagicMock()
-        self.actor._ensure_bucket.side_effect = [tornado_value(None)]
-        yield self.actor._execute()
-        self.assertTrue(self.actor._ensure_bucket.called)
+    def test_get_tags(self):
+        self.actor.s3_conn.get_bucket_tagging.return_value = {
+            'TagSet': []}
+        ret = yield self.actor._get_tags()
+        self.assertEquals(ret, [])
 
     @testing.gen_test
-    def test_execute_present(self):
-        self.actor._ensure_bucket = mock.MagicMock()
-        self.actor._ensure_bucket.side_effect = [tornado_value(None)]
-        self.actor._ensure_policy = mock.MagicMock()
-        self.actor._ensure_policy.side_effect = [tornado_value(None)]
-        self.actor._ensure_logging = mock.MagicMock()
-        self.actor._ensure_logging.side_effect = [tornado_value(None)]
-        self.actor._ensure_versioning = mock.MagicMock()
-        self.actor._ensure_versioning.side_effect = [tornado_value(None)]
-        self.actor._ensure_lifecycle = mock.MagicMock()
-        self.actor._ensure_lifecycle.side_effect = [tornado_value(None)]
-        yield self.actor._execute()
-        self.assertTrue(self.actor._ensure_bucket.called)
-        self.assertTrue(self.actor._ensure_policy.called)
-        self.assertTrue(self.actor._ensure_logging.called)
-        self.assertTrue(self.actor._ensure_versioning.called)
+    def test_get_tags_empty(self):
+        self.actor.s3_conn.get_bucket_tagging.side_effect = ClientError(
+            {'Error': {}}, 'NoSuchTagSet')
+        ret = yield self.actor._get_tags()
+        self.assertEquals(ret, [])
+
+    @testing.gen_test
+    def test_get_tags_exc(self):
+        self.actor.s3_conn.get_bucket_tagging.side_effect = ClientError(
+            {'Error': {}}, 'SomeOtherError')
+        with self.assertRaises(ClientError):
+            yield self.actor._get_tags()
+
+    @testing.gen_test
+    def test_set_tags_none(self):
+        self.actor._options['tags'] = None
+        yield self.actor._set_tags()
+        self.assertFalse(self.actor.s3_conn.put_bucket_tagging.called)
+
+    @testing.gen_test
+    def test_set_tags(self):
+        self.actor._options['tags'] = [
+            {'key': 'tag1', 'value': 'v1'}
+        ]
+        yield self.actor._set_tags()
+        self.actor.s3_conn.put_bucket_tagging.assert_has_calls([
+            mock.call(
+                Bucket='test',
+                Tagging={'TagSet': [
+                    {'Key': 'tag1', 'Value': 'v1'}
+                ]})])

--- a/kingpin/constants.py
+++ b/kingpin/constants.py
@@ -63,7 +63,7 @@ class SchemaCompareBase(object):
     @classmethod
     def validate(self, option):
         try:
-            jsonschema.validate(option, self.SCHEMA)
+            jsonschema.Draft3Validator(self.SCHEMA).validate(option)
         except jsonschema.exceptions.ValidationError as e:
             raise exceptions.InvalidOptions(
                 'Supplied parameter does not match schema: %s' % e)

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,3 +36,6 @@ boto>=2.32.1
 # kingpin.actors.aws.ecs
 # kingpin.actors.aws.cloudformation
 boto3>=1.3.1
+
+# Used to turn snake_case into CamelCase
+inflection


### PR DESCRIPTION
Boto3 supports the NoncurrentVersionExpiration/Transition settings that
allow us to set Lifecycle policies that truly delete data even in a
versioned bucket. Boto2 simply does not support this.

Migrating to Boto3 is enough work that I decided to also leverage the
new EnsurableBaseActor class to simplify much of the logic. Now there is
no more mocking out of a bucket object, passing around of this object,
etc. Instead we just issue get/set calls directly through the Boto3 API.

Note, WIP .. Tests are still in progress.