### PR TITLE
Compare S3 bucket tags with some intelligence.

### DIFF
--- a/kingpin/actors/aws/s3.py
+++ b/kingpin/actors/aws/s3.py
@@ -830,6 +830,26 @@ class Bucket(base.EnsurableAWSBaseActor):
         raise gen.Return(tagset)
 
     @gen.coroutine
+    def _compare_tags(self):
+        new = self.option('tags')
+        if new is None:
+            self.log.debug('Not managing Tags')
+            raise gen.Return(True)
+
+        exist = yield self._get_tags()
+
+        diff = self._diff_dicts(exist, new)
+        if not diff:
+            self.log.debug('Bucket tags match')
+            raise gen.Return(True)
+
+        self.log.info('Bucket tags differs from Amazons:')
+        for line in diff.split('\n'):
+            self.log.info('Diff: %s' % line)
+
+        raise gen.Return(False)
+
+    @gen.coroutine
     @dry('Would have pushed tags')
     def _set_tags(self):
         tags = self.option('tags')

--- a/kingpin/actors/aws/test/test_s3.py
+++ b/kingpin/actors/aws/test/test_s3.py
@@ -494,6 +494,40 @@ class TestBucket(testing.AsyncTestCase):
             yield self.actor._get_tags()
 
     @testing.gen_test
+    def test_compare_tags(self):
+        self.actor._bucket_exists = True
+        self.actor._options['tags'] = [
+            {'key': 'test_key', 'value': 'test_value'}
+        ]
+        self.actor.s3_conn.get_bucket_tagging.return_value = {
+            'TagSet': [
+                {'Key': 'test_key', 'Value': 'test_value'},
+            ]}
+        ret = yield self.actor._compare_tags()
+        self.assertTrue(ret)
+
+    @testing.gen_test
+    def test_compare_tags_false(self):
+        self.actor._bucket_exists = True
+        self.actor._options['tags'] = [
+            {'key': 'test_key', 'value': 'test_value'}
+        ]
+        self.actor.s3_conn.get_bucket_tagging.return_value = {
+            'TagSet': [
+                {'Key': 'k1', 'Value': 'v1'},
+                {'Key': 'k2', 'Value': 'v2'}
+            ]}
+        ret = yield self.actor._compare_tags()
+        self.assertFalse(ret)
+
+    @testing.gen_test
+    def test_compare_tags_not_managing(self):
+        self.actor._bucket_exists = True
+        self.actor._options['tags'] = None
+        ret = yield self.actor._compare_tags()
+        self.assertTrue(ret)
+
+    @testing.gen_test
     def test_set_tags_none(self):
         self.actor._options['tags'] = None
         yield self.actor._set_tags()


### PR DESCRIPTION
We can't simply use the logic in the base class compare_xxx() method
because it takes into account order in lists, which don't matter with
tags. Instead we need a dedicated compare_tags() method that understands
this.