### PR TITLE
ECS: Optionally reuse existing count when updating a service.

### DIFF
--- a/kingpin/actors/aws/test/integration_ecs.py
+++ b/kingpin/actors/aws/test/integration_ecs.py
@@ -176,6 +176,7 @@ class IntegrationECS(testing.AsyncTestCase):
                  'cluster': self.cluster,
                  'task_definition': definition,
                  'service_name': '%s_%s' % (name, '03'),
+                 'use_existing_count': False,
                  'count': 1})
         yield actor.execute()
 
@@ -190,6 +191,7 @@ class IntegrationECS(testing.AsyncTestCase):
                  'cluster': self.cluster,
                  'task_definition': definition,
                  'service_name': '%s_%s' % (name, '03'),
+                 'use_existing_count': False,
                  'count': 2})
         yield actor.execute()
 
@@ -232,6 +234,7 @@ class IntegrationECS(testing.AsyncTestCase):
                  'cluster': self.cluster,
                  'task_definition': definition,
                  'service_name': '%s_%s' % (name, '04'),
+                 'use_existing_count': False,
                  'count': 0})
         yield actor.execute()
 

--- a/kingpin/actors/aws/test/test_ecs.py
+++ b/kingpin/actors/aws/test/test_ecs.py
@@ -1035,13 +1035,11 @@ class TestUpdateService(testing.AsyncTestCase):
         expected = ({
                     'cluster': self.actor.option('cluster'),
                     'service': service_name,
-                    'desiredCount': self.actor.option('count'),
                     'deploymentConfiguration': configuration
                     },)
         self.assertEqual(call_args, expected)
 
         self.actor._options['cluster'] = 'cluster'
-        self.actor._options['count'] = 5
         yield self.actor._update_service(
             service_name=service_name,
             existing_service={'taskDefinition': 'arn/family:2'})
@@ -1049,7 +1047,6 @@ class TestUpdateService(testing.AsyncTestCase):
         expected = ({
                     'cluster': self.actor.option('cluster'),
                     'service': service_name,
-                    'desiredCount': self.actor.option('count'),
                     'deploymentConfiguration': configuration
                     },)
         self.assertEqual(call_args, expected)
@@ -1076,7 +1073,6 @@ class TestUpdateService(testing.AsyncTestCase):
                     'cluster': self.actor.option('cluster'),
                     'service': service_name,
                     'taskDefinition': 'arn/family:1',
-                    'desiredCount': self.actor.option('count'),
                     'deploymentConfiguration': configuration
                     },)
         self.assertEqual(call_args, expected)
@@ -1210,6 +1206,16 @@ class TestEnsureServicePresent(testing.AsyncTestCase):
         self.assertEqual(self.actor._create_service._call_count, 0)
         self.assertEqual(self.actor._update_service._call_count, 1)
         self.assertEqual(self.actor._wait_for_service_update._call_count, 0)
+
+    @testing.gen_test
+    def test_not_use_existing_count(self):
+        self.actor._options['use_existing_count'] = False
+        yield self.actor._ensure_service_present(
+            service_name=self.service_name,
+            existing_service={'status': 'ACTIVE'})
+        self.assertEqual(self.actor._create_service._call_count, 0)
+        self.assertEqual(self.actor._update_service._call_count, 1)
+        self.assertEqual(self.actor._wait_for_service_update._call_count, 1)
 
 
 class TestEnsureServiceAbsent(testing.AsyncTestCase):


### PR DESCRIPTION
@mikhail @diranged 