### PR TITLE
Paginate the IAM get_all_entities() method call

### DIFF
--- a/kingpin/actors/aws/iam/test/test_entities.py
+++ b/kingpin/actors/aws/iam/test/test_entities.py
@@ -272,16 +272,6 @@ class TestEntityBaseActor(testing.AsyncTestCase):
         self.actor.iam_conn.get_all_bases.reset_mock()
         self.assertEquals(ret, None)
 
-        # Next, lets return TOO MANY matching entities. This is bad.
-        self.actor.iam_conn.get_all_bases.return_value = {
-            'list_bases_response': {
-                'list_bases_result': {
-                    'bases': [matching_entity, matching_entity]}}}
-        with self.assertRaises(exceptions.RecoverableActorFailure):
-            yield self.actor._get_entity('test')
-        self.assertTrue(self.actor.iam_conn.get_all_bases.called)
-        self.actor.iam_conn.get_all_bases.reset_mock()
-
         # Finally, lets return one matching and a non matching entity
         self.actor.iam_conn.get_all_bases.return_value = {
             'list_bases_response': {

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -3,6 +3,6 @@ mock==1.0.1
 pep8
 pyflakes
 coverage
-Sphinx==1.4
+Sphinx==1.6.3
 sphinx_rtd_theme
 functools32


### PR DESCRIPTION
If you have more than 100 iam entities, by default you have to paginate
the results. Build in pagination, but also set the max_items to 1000
(API limit) so that we can get all our results back in one API call.

This closes #446 