### PR TITLE
Fix Group Actor Context Token Substitution

### DIFF
--- a/kingpin/actors/base.py
+++ b/kingpin/actors/base.py
@@ -146,7 +146,8 @@ class BaseActor(object):
 
         # Fill the context into the description, condition, and options.
         actor = self._type.replace('kingpin.actors.','')
-        act = {'actor': actor, 'desc': desc, 'condition': condition, 'options': options}
+        act = {'actor': actor, 'condition': condition, 'options': options}
+        if desc: act['desc'] = desc
         # strict about this -- but in the future, when we have a
         # runtime_context object, we may loosen this restriction).
         updated_act = self._fill_in_contexts(act, context=self._init_context,
@@ -411,7 +412,7 @@ class BaseActor(object):
         # Inject contexts into condition
         try:
             updated_act['condition'] = utils.populate_with_tokens(
-                act.get('condition', ''),
+                str(act.get('condition', '')),
                 context,
                 self.left_context_separator,
                 self.right_context_separator,
@@ -449,7 +450,7 @@ class BaseActor(object):
             # Only group actors can define sub-actors, therefore it is safe to
             # substitue for all context tokens from this point forward.
             # Convert our options dict into a string for fast parsing.
-            options_string = json.dumps(options)
+            options_string = json.dumps(act['options'])
 
             # Generate a new string with the values parsed out. At this point, if
             # any value is un-matched, an exception is raised and execution fails.

--- a/kingpin/actors/base.py
+++ b/kingpin/actors/base.py
@@ -382,13 +382,13 @@ class BaseActor(object):
         """Parses the act and updates it with the supplied context.
 
         Recursively parses the description, condition, and options in the
-        act and substitues in context tokens. Does not substitute for the
+        act and substitutes in context tokens. Does not substitute for the
         options in any group actors which define a context.
 
         Args:
             act: The act into which to fill context tokens.
             context: Dictionary of context tokens.
-            strict: bool whether or not to allow missing context keys to be
+            strict: Bool whether or not to allow missing context keys to be
                     skipped over.
 
         Returns:
@@ -398,7 +398,7 @@ class BaseActor(object):
             exceptions.InvalidOptions
         """
         updated_act = act.copy()
-        # Inject contexts into Description
+        # Inject contexts into the description.
         try:
             updated_act['desc'] = utils.populate_with_tokens(
                 act.get('desc', ''),
@@ -410,7 +410,7 @@ class BaseActor(object):
             msg = 'Context for description failed: %s' % e
             raise exceptions.InvalidOptions(msg)
 
-        # Inject contexts into condition
+        # Inject contexts into the condition.
         try:
             updated_act['condition'] = utils.populate_with_tokens(
                 str(act.get('condition', '')),
@@ -422,7 +422,7 @@ class BaseActor(object):
             msg = 'Context for condition failed: %s' % e
             raise exceptions.InvalidOptions(msg)
 
-        # Inject contexts into options, skipping over any sub-actors which
+        # Inject contexts into the options, skipping over any sub-actors which
         # declare more context tokens.
         if act['actor'].startswith('group.'):
             options = act['options']

--- a/kingpin/actors/base.py
+++ b/kingpin/actors/base.py
@@ -43,9 +43,10 @@ from tornado import gen
 from tornado import httpclient
 from tornado import httputil
 
+from kingpin import actors
 from kingpin import utils
 from kingpin.actors import exceptions
-from kingpin.actors.utils import timer
+from kingpin.actors.utils import timer, get_actor_class
 from kingpin.constants import REQUIRED, STATE
 
 log = logging.getLogger(__name__)
@@ -151,8 +152,7 @@ class BaseActor(object):
             self._timeout = self.default_timeout
 
         # Fill the context into the description, condition, and options.
-        actor = self._type.replace('kingpin.actors.', '')
-        act = self.Act(actor=actor, desc=desc, condition=str(condition),
+        act = self.Act(actor=self._type, desc=desc, condition=str(condition),
                        options=options)
         updated_act = self._fill_contexts_in_act(
             act, context=self._init_context, strict=self.strict_init_context)
@@ -434,7 +434,7 @@ class BaseActor(object):
 
         # Inject contexts into the options, skipping over any group sub-actors
         # which declare more context tokens.
-        if act.actor.startswith('group.'):
+        if actors.group == sys.modules[get_actor_class(act.actor).__module__]:
             updated_options = act.options.copy()
             if 'contexts' in updated_options:
                 # Inject contexts into the group's context.

--- a/kingpin/actors/base.py
+++ b/kingpin/actors/base.py
@@ -434,7 +434,9 @@ class BaseActor(object):
 
         # Inject contexts into the options, skipping over any group sub-actors
         # which declare more context tokens.
-        if actors.group == sys.modules[get_actor_class(act.actor).__module__]:
+        actor_module = sys.modules[get_actor_class(act.actor).__module__]
+        actor_is_group = (actor_module == actors.group)
+        if actor_is_group:
             updated_options = act.options.copy()
             if 'contexts' in updated_options:
                 # Inject contexts into the group's context.

--- a/kingpin/actors/base.py
+++ b/kingpin/actors/base.py
@@ -145,9 +145,10 @@ class BaseActor(object):
             self._timeout = self.default_timeout
 
         # Fill the context into the description, condition, and options.
-        actor = self._type.replace('kingpin.actors.','')
+        actor = self._type.replace('kingpin.actors.', '')
         act = {'actor': actor, 'condition': condition, 'options': options}
-        if desc: act['desc'] = desc
+        if desc:
+            act['desc'] = desc
         # strict about this -- but in the future, when we have a
         # runtime_context object, we may loosen this restriction).
         updated_act = self._fill_in_contexts(act, context=self._init_context,
@@ -380,9 +381,9 @@ class BaseActor(object):
     def _fill_in_contexts(self, act, context={}, strict=True):
         """Parses the act and updates it with the supplied context.
 
-        Recursively parses the description, condition, and options in the act
-        and substitues in context tokens. Does not substitute for the options in
-        any group actors which define a context.
+        Recursively parses the description, condition, and options in the
+        act and substitues in context tokens. Does not substitute for the
+        options in any group actors which define a context.
 
         Args:
             act: The act into which to fill context tokens.
@@ -430,12 +431,14 @@ class BaseActor(object):
                 # Stop substituting tokens after here, since this actor will
                 # define other context tokens.
                 try:
-                    options['contexts'] = utils.populate_with_tokens(
-                        options['contexts'],
+                    contexts_string = json.dumps(options['contexts'])
+                    updated_contexts_string = utils.populate_with_tokens(
+                        contexts_string,
                         context,
                         self.left_context_separator,
                         self.right_context_separator,
                         strict=strict)
+                    options['contexts'] = json.loads(updated_contexts_string)
                 except LookupError as e:
                     msg = 'Context for group contexts failed: %s' % e
                     raise exceptions.InvalidOptions(msg)
@@ -448,14 +451,15 @@ class BaseActor(object):
             updated_act['options'] = options
         else:
             # Only group actors can define sub-actors, therefore it is safe to
-            # substitue for all context tokens from this point forward.
-            # Convert our options dict into a string for fast parsing.
+            # substitute for all context tokens from this point forward.
+            # Therefore, convert our options dict into a string for faster
+            # parsing.
             options_string = json.dumps(act['options'])
 
-            # Generate a new string with the values parsed out. At this point, if
-            # any value is un-matched, an exception is raised and execution fails.
-            # This stops execution during a dry run, before any live changes are
-            # made.
+            # Generate a new string with the values parsed out. At this point,
+            # if any value is un-matched, an exception is raised and execution
+            # fails. This stops execution during a dry run, before any live
+            # changes are made.
             try:
                 new_options_string = utils.populate_with_tokens(
                     options_string,

--- a/kingpin/actors/group.py
+++ b/kingpin/actors/group.py
@@ -55,12 +55,6 @@ class BaseGroupActor(base.BaseActor):
         'acts': (list, REQUIRED, "Array of actor definitions.")
     }
 
-    # Override the BaseActor strict_init_context setting. Since there may be
-    # nested-groups that have their own context tokens, we do not require
-    # that all of the {KEY}'s inside of the self._options dict are filled in
-    # the moment that this actor is instantiated.
-    strict_init_context = False
-
     def __init__(self, *args, **kwargs):
         """Initializes all of the sub actors.
 

--- a/kingpin/actors/test/test_base.py
+++ b/kingpin/actors/test/test_base.py
@@ -369,7 +369,7 @@ class TestBaseActor(testing.AsyncTestCase):
         res = yield self.actor.execute()
         self.assertEquals(res, None)
 
-    def test_fill_in_contexts_desc(self):
+    def test_fill_contexts_in_act_desc(self):
         base.BaseActor.all_options = {
             'test_opt': (str, REQUIRED, 'Test option')
         }

--- a/kingpin/actors/test/test_group.py
+++ b/kingpin/actors/test/test_group.py
@@ -191,6 +191,13 @@ class TestBaseGroupActor(TestGroupActorBaseClass):
         ret = actor._build_action_group({'TEST': 'CONTEXT'})
         self.assertEquals(ret[0]._init_context, {'TEST': 'CONTEXT'})
 
+    def test_fill_in_contexts_invalid_context(self):
+        with self.assertRaises(exceptions.InvalidOptions):
+            group.BaseGroupActor(
+                desc='Unit Test Action',
+                options={'contexts': '{BAR}.foo', 'acts': []},
+                init_context={})
+
     @testing.gen_test
     def test_execute_success(self):
         actor = group.BaseGroupActor('Unit Test Action', {'acts': []})

--- a/kingpin/actors/test/test_group.py
+++ b/kingpin/actors/test/test_group.py
@@ -191,7 +191,7 @@ class TestBaseGroupActor(TestGroupActorBaseClass):
         ret = actor._build_action_group({'TEST': 'CONTEXT'})
         self.assertEquals(ret[0]._init_context, {'TEST': 'CONTEXT'})
 
-    def test_fill_in_contexts_invalid_context(self):
+    def test_fill_contexts_in_act_invalid_context(self):
         with self.assertRaises(exceptions.InvalidOptions):
             group.BaseGroupActor(
                 desc='Unit Test Action',

--- a/kingpin/utils.py
+++ b/kingpin/utils.py
@@ -294,6 +294,7 @@ def populate_with_tokens(string, tokens, left_wrapper='%', right_wrapper='%',
     # If we aren't strict, we return...
     if not strict:
         return string
+
     # If we are strict, we check if we missed anything. If we did, raise an
     # exception.
     missed_tokens = list(set(re.findall(r'%s[\w]+%s' %

--- a/kingpin/utils.py
+++ b/kingpin/utils.py
@@ -267,6 +267,7 @@ def populate_with_tokens(string, tokens, left_wrapper='%', right_wrapper='%',
         string='foo %ME% %bar%'
         populate_with_tokens(string, os.environ)  # 'foo biz %bar%'
     """
+
     # First things first, swap out all instances of %<str>% with any matching
     # token variables found. If no items are in the hash (none, empty hash,
     # etc), then skip this.

--- a/kingpin/utils.py
+++ b/kingpin/utils.py
@@ -267,7 +267,6 @@ def populate_with_tokens(string, tokens, left_wrapper='%', right_wrapper='%',
         string='foo %ME% %bar%'
         populate_with_tokens(string, os.environ)  # 'foo biz %bar%'
     """
-
     # First things first, swap out all instances of %<str>% with any matching
     # token variables found. If no items are in the hash (none, empty hash,
     # etc), then skip this.

--- a/kingpin/utils.py
+++ b/kingpin/utils.py
@@ -294,7 +294,6 @@ def populate_with_tokens(string, tokens, left_wrapper='%', right_wrapper='%',
     # If we aren't strict, we return...
     if not strict:
         return string
-
     # If we are strict, we check if we missed anything. If we did, raise an
     # exception.
     missed_tokens = list(set(re.findall(r'%s[\w]+%s' %


### PR DESCRIPTION
Fixes #448.

This PR fixes a problem where context tokens would be filled before all relevant contexts were loaded. Context tokens are now only filled after all parent actor contexts have been loaded. See #448 for examples.

cc @diranged @mikhail