### PR TITLE
Revert "CF Actor - Add enable_termination_protection option (#453)"

### DIFF
--- a/kingpin/actors/aws/cloudformation.py
+++ b/kingpin/actors/aws/cloudformation.py
@@ -118,26 +118,12 @@ class OnFailureConfig(StringCompareBase):
     """Validates the On Failure option.
 
     The `on_failure` option can take one of the following settings:
-    `DO_NOTHING`, `ROLLBACK`, `DELETE`
+      `DO_NOTHING`, `ROLLBACK`, `DELETE`
 
     This option is applied at stack _creation_ time!
     """
 
     valid = ('DO_NOTHING', 'ROLLBACK', 'DELETE')
-
-
-class TerminationProtectionConfig(StringCompareBase):
-
-    """Validates the TerminationProtectionConfig option.
-
-    The `enable_termination_protection` option can take one of the following
-    settings:
-    `None`, `False`, `True`
-
-    `None` means on Stack Updates no changes will be applied.
-    """
-
-    valid = (None, True, False)
 
 
 # CloudFormation has over a dozen different 'stack states'... but for the
@@ -475,8 +461,6 @@ class CloudFormationBaseActor(base.AWSBaseActor):
                 OnFailure=self.option('on_failure'),
                 TimeoutInMinutes=self.option('timeout_in_minutes'),
                 Capabilities=self.option('capabilities'),
-                EnableTerminationProtection=self.option(
-                    'enable_termination_protection'),
                 **cfg)
         except ClientError as e:
             raise CloudFormationError(e.message)
@@ -524,10 +508,7 @@ class Create(CloudFormationBaseActor):
       CloudFormation template.
 
     :region:
-      AWS region (or zone) string, like 'us-west-2'.
-
-    :role_arn:
-      The Amazon IAM Role to use when executing the stack.
+      AWS region (or zone) string, like 'us-west-2'
 
     :template:
       String of path to CloudFormation template. Can either be in the form of a
@@ -537,9 +518,6 @@ class Create(CloudFormationBaseActor):
     :timeout_in_minutes:
       The amount of time that can pass before the stack status becomes
       CREATE_FAILED.
-
-    :enable_termination_protection:
-      Whether termination protection is enabled for the stack.
 
     **Examples**
 
@@ -554,10 +532,8 @@ class Create(CloudFormationBaseActor):
              "test_param": "%TEST_PARAM_NAME%",
            },
            "region": "us-west-1",
-           "role_arn": "arn:aws:iam::123456789012:role/DeployRole",
            "template": "/examples/cloudformation_test.json",
            "timeout_in_minutes": 45,
-           "enable_termination_protection": true,
          }
        }
 
@@ -585,9 +561,6 @@ class Create(CloudFormationBaseActor):
         'timeout_in_minutes': (int, 60,
                                'The amount of time that can pass before the '
                                'stack status becomes CREATE_FAILED'),
-        'enable_termination_protection': (TerminationProtectionConfig, False,
-                                          'Whether termination protection is  '
-                                          'enabled for the stack.')
     }
 
     desc = "Creating CloudFormation Stack {name}"
@@ -730,10 +703,7 @@ class Stack(CloudFormationBaseActor):
       CloudFormation template.
 
     :region:
-      AWS region (or zone) string, like 'us-west-2'.
-
-    :role_arn:
-      The Amazon IAM Role to use when executing the stack.
+      AWS region (or zone) string, like 'us-west-2'
 
     :template:
       String of path to CloudFormation template. Can either be in the form of a
@@ -743,9 +713,6 @@ class Stack(CloudFormationBaseActor):
     :timeout_in_minutes:
       The amount of time that can pass before the stack status becomes
       CREATE_FAILED.
-
-    :enable_termination_protection:
-      Whether termination protection is enabled for the stack.
 
     **Examples**
 
@@ -761,10 +728,8 @@ class Stack(CloudFormationBaseActor):
              "test_param": "%TEST_PARAM_NAME%",
            },
            "region": "us-west-1",
-           "role_arn": "arn:aws:iam::123456789012:role/DeployRole",
            "template": "/examples/cloudformation_test.json",
            "timeout_in_minutes": 45,
-           "enable_termination_protection": true,
          }
        }
 
@@ -797,9 +762,6 @@ class Stack(CloudFormationBaseActor):
         'timeout_in_minutes': (int, 60,
                                'The amount of time that can pass before the '
                                'stack status becomes CREATE_FAILED'),
-        'enable_termination_protection': (TerminationProtectionConfig, None,
-                                          'Whether termination protection is  '
-                                          'enabled for the stack.')
     }
 
     desc = 'CloudFormation Stack {name}'
@@ -845,10 +807,6 @@ class Stack(CloudFormationBaseActor):
             yield self._delete_stack(stack=stack['StackId'])
             yield self._create_stack(stack=stack['StackName'])
             raise gen.Return()
-
-        # Compare the live and new EnableTerminationProtection parameter and
-        # update it if it is different.
-        yield self._ensure_termination_protection(stack)
 
         # Pull down the live stack template and compare it to the one we have
         # locally.
@@ -1111,45 +1069,6 @@ class Stack(CloudFormationBaseActor):
             change_set_name, 'ExecutionStatus', 'EXECUTE_COMPLETE')
         yield self._wait_until_state(change_set['StackId'],
                                      (COMPLETE + FAILED + DELETED))
-
-    @gen.coroutine
-    def _ensure_termination_protection(self, stack):
-        """Ensures that the EnableTerminationProtection is set to the desired
-           setting (either True or False).
-
-        Checks to to see if the actor is managing EnableTerminationProtection,
-        and if it is, it updates EnableTerminationProtection if the defined
-        value is different from the existing one.
-
-        args:
-            stack: Boto3 Stack dict
-        """
-        existing = stack['EnableTerminationProtection']
-        new = self.option('enable_termination_protection')
-
-        if new is None or existing == new:
-            raise gen.Return()
-
-        yield self._update_termination_protection(stack, new)
-
-    @gen.coroutine
-    @dry('Would have updated EnableTerminationProtection')
-    def _update_termination_protection(self, stack, new):
-        """Updates the EnableTerminationProtection to the new setting.
-
-        args:
-            stack: Boto3 Stack dict
-            new: boolean of updated value for EnableTerminationProtection
-        """
-        self.log.info('Updating EnableTerminationProtection to %s' % str(new))
-
-        try:
-            yield self.thread(
-                self.cf3_conn.update_termination_protection,
-                StackName=stack['StackName'],
-                EnableTerminationProtection=new)
-        except ClientError as e:
-            raise StackFailed(e)
 
     @gen.coroutine
     def _ensure_stack(self):


### PR DESCRIPTION
This reverts commit 7d9ecec57e4434bc70831c552fe7f8e5f908c279.

There's an interesting bug whereby when running the `Stack` actor via the `Group` actor explicitly (either sync or async) and not defining the `enable_termination_protection` option it defaults to `None` and so botocore throws a validation error as it is a `bool` parameter. However, when ran the actor is ran directly (without being explicitly defined under a Group actor) it defaults to `False` and runs file.

NOTE: It's interesting that the Group actor is actually used (`[kingpin.actors.group.Sync] Beginning 2 actions`) when not explicitly defined in the file, but it still defaults properly and runs properly. This leads me to believe there may be some issue with how our options are set when trying to run through different `Group` contexts from a file...