### PR TITLE
CF Actor - Add enable_termination_protection option (v2 fixed)

### DIFF
--- a/kingpin/actors/aws/cloudformation.py
+++ b/kingpin/actors/aws/cloudformation.py
@@ -118,12 +118,27 @@ class OnFailureConfig(StringCompareBase):
     """Validates the On Failure option.
 
     The `on_failure` option can take one of the following settings:
-      `DO_NOTHING`, `ROLLBACK`, `DELETE`
+    `DO_NOTHING`, `ROLLBACK`, `DELETE`
 
     This option is applied at stack _creation_ time!
     """
 
     valid = ('DO_NOTHING', 'ROLLBACK', 'DELETE')
+
+
+class TerminationProtectionConfig(StringCompareBase):
+
+    """Validates the TerminationProtectionConfig option.
+
+    The `enable_termination_protection` option can take one of the following
+    settings:
+    `'UNCHANGED'`, `False`, `True`
+
+    `UNCHANGED` means on Create Stack it will default to False, however on
+     Ensure Stack no changes will be applied.
+    """
+
+    valid = ('UNCHANGED', True, False)
 
 
 # CloudFormation has over a dozen different 'stack states'... but for the
@@ -453,6 +468,11 @@ class CloudFormationBaseActor(base.AWSBaseActor):
         if self.option('role_arn'):
             cfg['RoleARN'] = self.option('role_arn')
 
+        enable_termination_protection = self.option(
+            'enable_termination_protection')
+        if enable_termination_protection == 'UNCHANGED':
+            enable_termination_protection = False
+
         try:
             stack = yield self.thread(
                 self.cf3_conn.create_stack,
@@ -461,6 +481,7 @@ class CloudFormationBaseActor(base.AWSBaseActor):
                 OnFailure=self.option('on_failure'),
                 TimeoutInMinutes=self.option('timeout_in_minutes'),
                 Capabilities=self.option('capabilities'),
+                EnableTerminationProtection=enable_termination_protection,
                 **cfg)
         except ClientError as e:
             raise CloudFormationError(e.message)
@@ -508,7 +529,10 @@ class Create(CloudFormationBaseActor):
       CloudFormation template.
 
     :region:
-      AWS region (or zone) string, like 'us-west-2'
+      AWS region (or zone) string, like 'us-west-2'.
+
+    :role_arn:
+      The Amazon IAM Role to use when executing the stack.
 
     :template:
       String of path to CloudFormation template. Can either be in the form of a
@@ -518,6 +542,9 @@ class Create(CloudFormationBaseActor):
     :timeout_in_minutes:
       The amount of time that can pass before the stack status becomes
       CREATE_FAILED.
+
+    :enable_termination_protection:
+      Whether termination protection is enabled for the stack.
 
     **Examples**
 
@@ -532,8 +559,10 @@ class Create(CloudFormationBaseActor):
              "test_param": "%TEST_PARAM_NAME%",
            },
            "region": "us-west-1",
+           "role_arn": "arn:aws:iam::123456789012:role/DeployRole",
            "template": "/examples/cloudformation_test.json",
            "timeout_in_minutes": 45,
+           "enable_termination_protection": true,
          }
        }
 
@@ -561,6 +590,10 @@ class Create(CloudFormationBaseActor):
         'timeout_in_minutes': (int, 60,
                                'The amount of time that can pass before the '
                                'stack status becomes CREATE_FAILED'),
+        'enable_termination_protection': (TerminationProtectionConfig,
+                                          'UNCHANGED',
+                                          'Whether termination protection is '
+                                          'enabled for the stack.')
     }
 
     desc = "Creating CloudFormation Stack {name}"
@@ -703,7 +736,10 @@ class Stack(CloudFormationBaseActor):
       CloudFormation template.
 
     :region:
-      AWS region (or zone) string, like 'us-west-2'
+      AWS region (or zone) string, like 'us-west-2'.
+
+    :role_arn:
+      The Amazon IAM Role to use when executing the stack.
 
     :template:
       String of path to CloudFormation template. Can either be in the form of a
@@ -713,6 +749,9 @@ class Stack(CloudFormationBaseActor):
     :timeout_in_minutes:
       The amount of time that can pass before the stack status becomes
       CREATE_FAILED.
+
+    :enable_termination_protection:
+      Whether termination protection is enabled for the stack.
 
     **Examples**
 
@@ -728,8 +767,10 @@ class Stack(CloudFormationBaseActor):
              "test_param": "%TEST_PARAM_NAME%",
            },
            "region": "us-west-1",
+           "role_arn": "arn:aws:iam::123456789012:role/DeployRole",
            "template": "/examples/cloudformation_test.json",
            "timeout_in_minutes": 45,
+           "enable_termination_protection": true,
          }
        }
 
@@ -762,6 +803,10 @@ class Stack(CloudFormationBaseActor):
         'timeout_in_minutes': (int, 60,
                                'The amount of time that can pass before the '
                                'stack status becomes CREATE_FAILED'),
+        'enable_termination_protection': (TerminationProtectionConfig,
+                                          'UNCHANGED',
+                                          'Whether termination protection is '
+                                          'enabled for the stack.')
     }
 
     desc = 'CloudFormation Stack {name}'
@@ -807,6 +852,10 @@ class Stack(CloudFormationBaseActor):
             yield self._delete_stack(stack=stack['StackId'])
             yield self._create_stack(stack=stack['StackName'])
             raise gen.Return()
+
+        # Compare the live and new EnableTerminationProtection parameter and
+        # update it if it is different.
+        yield self._ensure_termination_protection(stack)
 
         # Pull down the live stack template and compare it to the one we have
         # locally.
@@ -1069,6 +1118,45 @@ class Stack(CloudFormationBaseActor):
             change_set_name, 'ExecutionStatus', 'EXECUTE_COMPLETE')
         yield self._wait_until_state(change_set['StackId'],
                                      (COMPLETE + FAILED + DELETED))
+
+    @gen.coroutine
+    def _ensure_termination_protection(self, stack):
+        """Ensures that the EnableTerminationProtection is set to the desired
+           setting (either True or False).
+
+        Checks to to see if the actor is managing EnableTerminationProtection,
+        and if it is, it updates EnableTerminationProtection if the defined
+        value is different from the existing one.
+
+        args:
+            stack: Boto3 Stack dict
+        """
+        existing = stack['EnableTerminationProtection']
+        new = self.option('enable_termination_protection')
+
+        if new == 'UNCHANGED' or existing == new:
+            raise gen.Return()
+
+        yield self._update_termination_protection(stack, new)
+
+    @gen.coroutine
+    @dry('Would have updated EnableTerminationProtection')
+    def _update_termination_protection(self, stack, new):
+        """Updates the EnableTerminationProtection to the new setting.
+
+        args:
+            stack: Boto3 Stack dict
+            new: boolean of updated value for EnableTerminationProtection
+        """
+        self.log.info('Updating EnableTerminationProtection to %s' % str(new))
+
+        try:
+            yield self.thread(
+                self.cf3_conn.update_termination_protection,
+                StackName=stack['StackName'],
+                EnableTerminationProtection=new)
+        except ClientError as e:
+            raise StackFailed(e)
 
     @gen.coroutine
     def _ensure_stack(self):

--- a/kingpin/actors/aws/cloudformation.py
+++ b/kingpin/actors/aws/cloudformation.py
@@ -118,26 +118,12 @@ class OnFailureConfig(StringCompareBase):
     """Validates the On Failure option.
 
     The `on_failure` option can take one of the following settings:
-    `DO_NOTHING`, `ROLLBACK`, `DELETE`
+      `DO_NOTHING`, `ROLLBACK`, `DELETE`
 
     This option is applied at stack _creation_ time!
     """
 
     valid = ('DO_NOTHING', 'ROLLBACK', 'DELETE')
-
-
-class TerminationProtectionConfig(StringCompareBase):
-
-    """Validates the TerminationProtectionConfig option.
-
-    The `enable_termination_protection` option can take one of the following
-    settings:
-    `None`, `False`, `True`
-
-    `None` means on Stack Updates no changes will be applied.
-    """
-
-    valid = (None, True, False)
 
 
 # CloudFormation has over a dozen different 'stack states'... but for the
@@ -475,8 +461,6 @@ class CloudFormationBaseActor(base.AWSBaseActor):
                 OnFailure=self.option('on_failure'),
                 TimeoutInMinutes=self.option('timeout_in_minutes'),
                 Capabilities=self.option('capabilities'),
-                EnableTerminationProtection=self.option(
-                    'enable_termination_protection'),
                 **cfg)
         except ClientError as e:
             raise CloudFormationError(e.message)
@@ -524,10 +508,7 @@ class Create(CloudFormationBaseActor):
       CloudFormation template.
 
     :region:
-      AWS region (or zone) string, like 'us-west-2'.
-
-    :role_arn:
-      The Amazon IAM Role to use when executing the stack.
+      AWS region (or zone) string, like 'us-west-2'
 
     :template:
       String of path to CloudFormation template. Can either be in the form of a
@@ -537,9 +518,6 @@ class Create(CloudFormationBaseActor):
     :timeout_in_minutes:
       The amount of time that can pass before the stack status becomes
       CREATE_FAILED.
-
-    :enable_termination_protection:
-      Whether termination protection is enabled for the stack.
 
     **Examples**
 
@@ -554,10 +532,8 @@ class Create(CloudFormationBaseActor):
              "test_param": "%TEST_PARAM_NAME%",
            },
            "region": "us-west-1",
-           "role_arn": "arn:aws:iam::123456789012:role/DeployRole",
            "template": "/examples/cloudformation_test.json",
            "timeout_in_minutes": 45,
-           "enable_termination_protection": true,
          }
        }
 
@@ -585,9 +561,6 @@ class Create(CloudFormationBaseActor):
         'timeout_in_minutes': (int, 60,
                                'The amount of time that can pass before the '
                                'stack status becomes CREATE_FAILED'),
-        'enable_termination_protection': (TerminationProtectionConfig, False,
-                                          'Whether termination protection is  '
-                                          'enabled for the stack.')
     }
 
     desc = "Creating CloudFormation Stack {name}"
@@ -730,10 +703,7 @@ class Stack(CloudFormationBaseActor):
       CloudFormation template.
 
     :region:
-      AWS region (or zone) string, like 'us-west-2'.
-
-    :role_arn:
-      The Amazon IAM Role to use when executing the stack.
+      AWS region (or zone) string, like 'us-west-2'
 
     :template:
       String of path to CloudFormation template. Can either be in the form of a
@@ -743,9 +713,6 @@ class Stack(CloudFormationBaseActor):
     :timeout_in_minutes:
       The amount of time that can pass before the stack status becomes
       CREATE_FAILED.
-
-    :enable_termination_protection:
-      Whether termination protection is enabled for the stack.
 
     **Examples**
 
@@ -761,10 +728,8 @@ class Stack(CloudFormationBaseActor):
              "test_param": "%TEST_PARAM_NAME%",
            },
            "region": "us-west-1",
-           "role_arn": "arn:aws:iam::123456789012:role/DeployRole",
            "template": "/examples/cloudformation_test.json",
            "timeout_in_minutes": 45,
-           "enable_termination_protection": true,
          }
        }
 
@@ -797,9 +762,6 @@ class Stack(CloudFormationBaseActor):
         'timeout_in_minutes': (int, 60,
                                'The amount of time that can pass before the '
                                'stack status becomes CREATE_FAILED'),
-        'enable_termination_protection': (TerminationProtectionConfig, None,
-                                          'Whether termination protection is  '
-                                          'enabled for the stack.')
     }
 
     desc = 'CloudFormation Stack {name}'
@@ -845,10 +807,6 @@ class Stack(CloudFormationBaseActor):
             yield self._delete_stack(stack=stack['StackId'])
             yield self._create_stack(stack=stack['StackName'])
             raise gen.Return()
-
-        # Compare the live and new EnableTerminationProtection parameter and
-        # update it if it is different.
-        yield self._ensure_termination_protection(stack)
 
         # Pull down the live stack template and compare it to the one we have
         # locally.
@@ -1111,45 +1069,6 @@ class Stack(CloudFormationBaseActor):
             change_set_name, 'ExecutionStatus', 'EXECUTE_COMPLETE')
         yield self._wait_until_state(change_set['StackId'],
                                      (COMPLETE + FAILED + DELETED))
-
-    @gen.coroutine
-    def _ensure_termination_protection(self, stack):
-        """Ensures that the EnableTerminationProtection is set to the desired
-           setting (either True or False).
-
-        Checks to to see if the actor is managing EnableTerminationProtection,
-        and if it is, it updates EnableTerminationProtection if the defined
-        value is different from the existing one.
-
-        args:
-            stack: Boto3 Stack dict
-        """
-        existing = stack['EnableTerminationProtection']
-        new = self.option('enable_termination_protection')
-
-        if new is None or existing == new:
-            raise gen.Return()
-
-        yield self._update_termination_protection(stack, new)
-
-    @gen.coroutine
-    @dry('Would have updated EnableTerminationProtection')
-    def _update_termination_protection(self, stack, new):
-        """Updates the EnableTerminationProtection to the new setting.
-
-        args:
-            stack: Boto3 Stack dict
-            new: boolean of updated value for EnableTerminationProtection
-        """
-        self.log.info('Updating EnableTerminationProtection to %s' % str(new))
-
-        try:
-            yield self.thread(
-                self.cf3_conn.update_termination_protection,
-                StackName=stack['StackName'],
-                EnableTerminationProtection=new)
-        except ClientError as e:
-            raise StackFailed(e)
 
     @gen.coroutine
     def _ensure_stack(self):

--- a/kingpin/actors/aws/test/test_cloudformation.py
+++ b/kingpin/actors/aws/test/test_cloudformation.py
@@ -21,6 +21,7 @@ def create_fake_stack(name, status):
         'CreationTime': datetime.datetime.now(),
         'StackName': name,
         'StackStatus': status,
+        'EnableTerminationProtection': False,
         'Parameters': [
             {'ParameterKey': 'key1', 'ParameterValue': 'value1'}
         ],
@@ -387,6 +388,33 @@ class TestCreate(testing.AsyncTestCase):
         self.assertEquals(ret, 'arn:123')
         actor.cf3_conn.create_stack.assert_called_with(
             TemplateBody=mock.ANY,
+            EnableTerminationProtection=False,
+            Parameters=[],
+            RoleARN=u'test_role_arn',
+            TimeoutInMinutes=60,
+            Capabilities=[],
+            StackName='test',
+            OnFailure='DELETE')
+
+    @testing.gen_test
+    def test_create_stack_file_with_termination_protection_true(self):
+        stack = 'examples/test/aws.cloudformation/cf.integration.json'
+        actor = cloudformation.Create(
+            'Unit Test Action',
+            {'name': 'unit-test-cf',
+             'region': 'us-west-2',
+             'role_arn': 'test_role_arn',
+             'template': stack})
+        actor._options['enable_termination_protection'] = True
+        actor._wait_until_state = mock.MagicMock(name='_wait_until_state')
+        actor._wait_until_state.side_effect = [tornado_value(None)]
+        actor.cf3_conn.create_stack = mock.MagicMock(name='create_stack_mock')
+        actor.cf3_conn.create_stack.return_value = {'StackId': 'arn:123'}
+        ret = yield actor._create_stack(stack='test')
+        self.assertEquals(ret, 'arn:123')
+        actor.cf3_conn.create_stack.assert_called_with(
+            TemplateBody=mock.ANY,
+            EnableTerminationProtection=True,
             Parameters=[],
             RoleARN=u'test_role_arn',
             TimeoutInMinutes=60,
@@ -674,6 +702,98 @@ class TestStack(testing.AsyncTestCase):
         self.actor._ensure_template.return_value = tornado_value(None)
         yield self.actor._update_stack(fake_stack)
         self.actor._ensure_template.assert_called_with(fake_stack)
+
+    @testing.gen_test
+    def test_update_stack_ensure_termination_protection_default_to_true(self):
+        fake_stack = create_fake_stack('fake', 'CREATE_COMPLETE')
+        self.actor._options['enable_termination_protection'] = True
+
+        self.actor._update_termination_protection = mock.MagicMock(
+            name='_update_termination_protection')
+        self.actor._update_termination_protection.return_value = tornado_value(
+            None)
+
+        self.actor._ensure_template = mock.MagicMock(name='_ensure_stack')
+        self.actor._ensure_template.return_value = tornado_value(None)
+
+        yield self.actor._update_stack(fake_stack)
+        self.actor._update_termination_protection.assert_called_with(
+            fake_stack, True)
+
+    @testing.gen_test
+    def test_update_stack_ensure_termination_protection_true_to_false(self):
+        fake_stack = create_fake_stack('fake', 'CREATE_COMPLETE')
+        fake_stack['EnableTerminationProtection'] = True
+        self.actor._options['enable_termination_protection'] = False
+
+        self.actor._update_termination_protection = mock.MagicMock(
+            name='_update_termination_protection')
+        self.actor._update_termination_protection.return_value = tornado_value(
+            None)
+
+        self.actor._ensure_template = mock.MagicMock(name='_ensure_stack')
+        self.actor._ensure_template.return_value = tornado_value(None)
+
+        yield self.actor._update_stack(fake_stack)
+        self.actor._update_termination_protection.assert_called_with(
+            fake_stack, False)
+
+    @testing.gen_test
+    def test_update_stack_ensure_termination_protection_true_to_true(self):
+        fake_stack = create_fake_stack('fake', 'CREATE_COMPLETE')
+        fake_stack['EnableTerminationProtection'] = True
+        self.actor._options['enable_termination_protection'] = True
+
+        self.actor._update_termination_protection = mock.MagicMock(
+            name='_update_termination_protection')
+        self.actor._update_termination_protection.return_value = tornado_value(
+            None)
+
+        self.actor._ensure_template = mock.MagicMock(name='_ensure_stack')
+        self.actor._ensure_template.return_value = tornado_value(None)
+
+        yield self.actor._update_stack(fake_stack)
+        self.assertFalse(self.actor._update_termination_protection.called)
+
+    @testing.gen_test
+    def test_update_stack_update_termination_protection(self):
+        fake_stack = create_fake_stack('fake', 'CREATE_COMPLETE')
+        self.actor._options['enable_termination_protection'] = True
+
+        self.actor.cf3_conn.update_termination_protection.return_value = (
+            tornado_value(None))
+
+        self.actor._ensure_template = mock.MagicMock(name='_ensure_stack')
+        self.actor._ensure_template.return_value = tornado_value(None)
+
+        yield self.actor._update_stack(fake_stack)
+        self.actor.cf3_conn.update_termination_protection.assert_has_calls(
+            [mock.call(
+                StackName='fake',
+                EnableTerminationProtection=True
+            )])
+
+    @testing.gen_test
+    def test_update_stack_update_termination_protection_error(self):
+        fake_stack = create_fake_stack('fake', 'CREATE_COMPLETE')
+        self.actor._options['enable_termination_protection'] = True
+
+        fake_update = {
+            'ResponseMetadata': {
+                'HTTPStatusCode': 400,
+                'RequestId': 'dfc1a12c-22c1-11e6-80b1-8fd4cf167f54'
+            },
+            'Error': {
+                'Message': 'Template format error: JSON not well-formed',
+                'Code': 'ValidationError',
+                'Type': 'Sender'
+            }
+        }
+
+        self.actor.cf3_conn.update_termination_protection.side_effect = (
+            ClientError(fake_update, 'FakeOperation'))
+        with self.assertRaises(cloudformation.StackFailed):
+            yield self.actor._update_stack(fake_stack)
 
     @testing.gen_test
     def test_ensure_template_with_url_quietly_exits(self):


### PR DESCRIPTION
This is the original feature with the fix for a bug where `Create` class can pass through `None` to `EnableTerminationProtection` because of how `None` is handled and then defaulted according to the configuration. With using the `UNCHANGED` string and logic on that, it is more explicit.