### PR TITLE
Bugfix on PUTing large RightScale Scripts

### DIFF
--- a/kingpin/actors/rightscale/rightscript.py
+++ b/kingpin/actors/rightscale/rightscript.py
@@ -126,7 +126,6 @@ class RightScript(base.EnsurableRightScaleBaseActor):
                 'description': self.option('description'),
                 'name': self.option('name'),
                 'packages': self.option('packages'),
-                'source': self._desired_source,
             })
 
     def _read_source(self):
@@ -228,9 +227,14 @@ class RightScript(base.EnsurableRightScaleBaseActor):
         self.changed = True
 
     @gen.coroutine
+    @dry('Would have updated the RightScale Source')
     def _set_source(self):
-        self.log.warning('Source does not match')
-        yield self._update_params()
+        self.log.info('Updating RightScript source...')
+        self.script = yield self._client.update(
+            self.script,
+            self._desired_source,
+            sub_resource='source')
+        self.changed = True
 
     @gen.coroutine
     def _get_source(self):

--- a/kingpin/actors/rightscale/test/test_api.py
+++ b/kingpin/actors/rightscale/test/test_api.py
@@ -284,6 +284,20 @@ class TestRightScale(testing.AsyncTestCase):
         self.assertEquals(ret, 'test')
 
     @testing.gen_test
+    def test_update_with_string_and_sub_resource(self):
+        # Create a mock and the params we're going to pass in
+        sa_mock = mock.MagicMock()
+        sa_mock.test_res.update.return_value = True
+        sa_mock.self.show.return_value = 'test'
+        params = 'some_string'
+
+        ret = yield self.client.update(sa_mock, params,
+                                       sub_resource='test_res')
+        sa_mock.test_res.update.assert_called_once_with(data=params)
+
+        self.assertEquals(ret, 'test')
+
+    @testing.gen_test
     def test_get_server_array_inputs(self):
         array = mock.Mock()
         ret = yield self.client.get_server_array_inputs(array)

--- a/kingpin/actors/rightscale/test/test_rightscript.py
+++ b/kingpin/actors/rightscale/test/test_rightscript.py
@@ -120,11 +120,17 @@ class TestRightScript(testing.AsyncTestCase):
 
     @testing.gen_test
     def test_set_source(self):
-        self.actor._update_params = mock.MagicMock()
-        self.actor._update_params.side_effect = [
-            helper.tornado_value(None)]
-        yield self.actor._set_source()
-        self.assertTrue(self.actor._update_params.called)
+        self.actor.script = mock.MagicMock(name='script')
+        with mock.patch.object(self.actor._client,
+                               'update') as update:
+            update.return_value = helper.tornado_value(self.actor.script)
+            yield self.actor._set_source()
+            self.assertTrue(self.actor.changed)
+            update.assert_has_calls([
+                mock.call(
+                    self.actor.script,
+                    'echo script1\n',
+                    sub_resource='source')])
 
     @testing.gen_test
     def test_set_description(self):
@@ -164,8 +170,7 @@ class TestRightScript(testing.AsyncTestCase):
             self.assertTrue(self.actor.changed)
             update.assert_has_calls([mock.call(
                 self.actor.script,
-                [('right_script[source]', 'echo script1\n'),
-                 ('right_script[packages]', u'curl'),
+                [('right_script[packages]', u'curl'),
                  ('right_script[description]', u'test description'),
                  ('right_script[name]', u'test-name')])])
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
 # General App Requirements
 
+# Py3 Compat
+six
+
 # 4.1+ is required for the @gen.with_timeout decorator.
 # http://tornado.readthedocs.org/en/latest/gen.html#tornado.gen.with_timeout
 tornado>=4.1


### PR DESCRIPTION
The old code used a functional, but limited API endpoint
(http://reference.rightscale.com/api1.5/resources/ResourceRightScripts.html#update)
to PUT our Script 'Source' as a URL argument. This new code separates
the concept of updating script meta parameters, from its source. The
source is updated with a special dedicated url
(http://reference.rightscale.com/api1.5/resources/ResourceRightScripts.html#update_source)
and the body of the script data is pushed as part of the request
headers, rather than the URL arguments.