### PR TITLE
Add some more immutable fields now that we're passing them in update.

### DIFF
--- a/kingpin/actors/aws/test/test_ecs.py
+++ b/kingpin/actors/aws/test/test_ecs.py
@@ -300,10 +300,18 @@ class TestLoadServiceDefinition(testing.AsyncTestCase):
     @testing.gen_test
     def test_default(self):
         result = self.actor._load_service_definition(None, {})
-        self.assertEqual(result, {})
+        self.assertEqual(result['deploymentConfiguration'], {})
+        self.assertEqual(result['launchType'], 'EC2')
+        self.assertEqual(result['loadBalancers'], [])
+        self.assertEqual(result['placementConstraints'], [])
+        self.assertEqual(result['placementStrategy'], [])
 
         result = self.actor._load_service_definition('', {})
-        self.assertEqual(result, {})
+        self.assertEqual(result['deploymentConfiguration'], {})
+        self.assertEqual(result['launchType'], 'EC2')
+        self.assertEqual(result['loadBalancers'], [])
+        self.assertEqual(result['placementConstraints'], [])
+        self.assertEqual(result['placementStrategy'], [])
 
     def _test(self, service_definition):
         with mock.patch('kingpin.utils.convert_script_to_dict',


### PR DESCRIPTION
They need default values for the immutability check, because the ECS api returns defaults if they're not set.