### PR TITLE
Add aws.elbv2.Register/Deregister Support

### DIFF
--- a/docs/kingpin.actors.aws.rst
+++ b/docs/kingpin.actors.aws.rst
@@ -29,6 +29,10 @@ Elastic Load Balancing (ELB)
    :members:
    :exclude-members: CertNotFound, p2f, ELBBaseActor
 
+.. automodule:: kingpin.actors.aws.elbv2
+   :noindex:
+   :members:
+
 Identity and Access Management (IAM)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. automodule:: kingpin.actors.aws.iam

--- a/kingpin/__init__.py
+++ b/kingpin/__init__.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2014 Nextdoor.com, Inc
+# Copyright 2018 Nextdoor.com, Inc

--- a/kingpin/actors/__init__.py
+++ b/kingpin/actors/__init__.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2014 Nextdoor.com, Inc
+# Copyright 2018 Nextdoor.com, Inc

--- a/kingpin/actors/aws/__init__.py
+++ b/kingpin/actors/aws/__init__.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2014 Nextdoor.com, Inc
+# Copyright 2018 Nextdoor.com, Inc

--- a/kingpin/actors/aws/base.py
+++ b/kingpin/actors/aws/base.py
@@ -159,6 +159,11 @@ class AWSBaseActor(base.BaseActor):
             region,
             aws_access_key_id=key,
             aws_secret_access_key=secret)
+        self.elbv2_conn = boto3.client(
+            'elbv2',
+            region_name=region,
+            aws_access_key_id=key,
+            aws_secret_access_key=secret)
         self.cf3_conn = boto3.client(
             'cloudformation',
             region_name=region,

--- a/kingpin/actors/aws/base.py
+++ b/kingpin/actors/aws/base.py
@@ -37,10 +37,10 @@ import logging
 import urllib
 import re
 
-from botocore import exceptions as botocore_exceptions
 from boto import exception as boto_exception
 from boto import utils as boto_utils
 from boto3 import exceptions as boto3_exceptions
+from botocore import exceptions as botocore_exceptions
 from retrying import retry
 from tornado import concurrent
 from tornado import gen

--- a/kingpin/actors/aws/base.py
+++ b/kingpin/actors/aws/base.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2014 Nextdoor.com, Inc
+# Copyright 2018 Nextdoor.com, Inc
 
 """
 :mod:`kingpin.actors.aws.base`

--- a/kingpin/actors/aws/base.py
+++ b/kingpin/actors/aws/base.py
@@ -257,10 +257,10 @@ class AWSBaseActor(base.BaseActor):
 
     @gen.coroutine
     def _find_target_group(self, arn):
-        """Returns an ALB Target Group with the matching name.
+        """Returns an ELBv2 Target Group with the matching name.
 
         Args:
-            name: String-name of the Target  Group to search for
+            name: String-name of the Target Group to search for
 
         Returns:
             A single Target Group reference object

--- a/kingpin/actors/aws/cloudformation.py
+++ b/kingpin/actors/aws/cloudformation.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2014 Nextdoor.com, Inc
+# Copyright 2018 Nextdoor.com, Inc
 
 """
 :mod:`kingpin.actors.aws.cloudformation`

--- a/kingpin/actors/aws/ecs.py
+++ b/kingpin/actors/aws/ecs.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2014 Nextdoor.com, Inc
+# Copyright 2018 Nextdoor.com, Inc
 
 """
 :mod:`kingpin.actors.aws.ecs`

--- a/kingpin/actors/aws/elb.py
+++ b/kingpin/actors/aws/elb.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2014 Nextdoor.com, Inc
+# Copyright 2018 Nextdoor.com, Inc
 
 """
 :mod:`kingpin.actors.aws.elb`

--- a/kingpin/actors/aws/elb.py
+++ b/kingpin/actors/aws/elb.py
@@ -369,12 +369,12 @@ class SetCert(ELBBaseActor):
 
 class RegisterInstance(base.AWSBaseActor):
 
-    """Add an EC2 instance to a load balancer.
+    """Add an EC2 instance to a load balancer or target group.
 
     **Options**
 
     :elb:
-      (str) Name of the ELB
+      (str) Name of the ELB or the Target Group ARN
 
     :instances:
       (str, list) Instance id, or list of ids. Default "self" id.
@@ -397,6 +397,16 @@ class RegisterInstance(base.AWSBaseActor):
            "region": "us-east-1",
          }
        }
+
+    .. code-block:: yaml
+
+       ---
+       actor: aws.elb.RegisterInstance
+       desc: Run RegisterInstance
+       options:
+         elb: prod-loadbalancer
+         instances: i-123456
+         region: us-east-1
 
     **Dry run**
 
@@ -489,6 +499,16 @@ class DeregisterInstance(base.AWSBaseActor):
            "region": "us-west-2"
          }
        }
+
+    .. code-block:: yaml
+
+       ---
+       actor: aws.elb.DeregisterInstance
+       desc: Run DeregisterInstance
+       options:
+         elb: prod-loadbalancer
+         instances: i-123456
+         region: us-east-1
 
     Extremely simple way to remove the local instance running this code from
     all ELBs its been joined to:

--- a/kingpin/actors/aws/elbv2.py
+++ b/kingpin/actors/aws/elbv2.py
@@ -1,0 +1,212 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2014 Nextdoor.com, Inc
+
+"""
+:mod:`kingpin.actors.aws.elbv2`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+"""
+
+import logging
+
+from tornado import concurrent
+from tornado import gen
+
+from kingpin import utils
+from kingpin.actors import exceptions
+from kingpin.actors.aws import base
+from kingpin.actors.utils import dry
+from kingpin.constants import REQUIRED
+
+import botocore.exceptions
+
+log = logging.getLogger(__name__)
+
+__author__ = 'Matt Wise <matt@nextdoor.com>'
+
+
+# This executor is used by the tornado.concurrent.run_on_executor()
+# decorator. We would like this to be a class variable so its shared
+# across RightScale objects, but we see testing IO errors when we
+# do this.
+EXECUTOR = concurrent.futures.ThreadPoolExecutor(10)
+
+
+class RegisterInstance(base.AWSBaseActor):
+
+    """Add an EC2 instance to a target group.
+
+    **Options**
+
+    :target_group:
+      (str) Name of the Target Group ARN or its short name
+
+    :instances:
+      (str, list) Instance id, or list of ids. Default "self" id.
+
+    :region:
+      (str) AWS region (or zone) name, like us-west-2
+
+    **Example**
+
+    .. code-block:: yaml
+
+       ---
+       actor: aws.elbv2.RegisterInstance
+       desc: Run RegisterInstance
+       options:
+         target_group: prod-loadbalancer
+         instances: i-123456
+         region: us-east-1
+
+    **Dry run**
+
+    Will find the specified Target Group, but not take any actions regarding
+    instances.
+    """
+
+    all_options = {
+        'target_group': (str, REQUIRED,
+                         'Name of the Target Group or its full ARN'),
+        'region': (str, REQUIRED, 'AWS region (or zone) name, like us-west-2'),
+        'instances': ((str, list), None, (
+            'Instance id, or list of ids. If no value is specified then '
+            'the instance id of the executing machine is used.'))
+    }
+
+    @gen.coroutine
+    @dry('Would add {1} to {0}')
+    def _add(self, arn, targets):
+        """Registers the supplied Targets with the Target Group ARN.
+
+        http://boto3.readthedocs.io/en/latest/reference/services/
+        elbv2.html#ElasticLoadBalancingv2.Client.register_targets
+
+        Args:
+            arn: ELBv2 Target ARN
+            targets: A list of Instance IDs or Target IP Addresses.
+        """
+
+        #  TODO: In the future, add support for the optional Port and
+        #  AvailabilityZone parameters. For now, keeping this dead simple.
+        targets = [{'Id': t} for t in targets]
+
+        try:
+            yield self.thread(
+                self.elbv2_conn.register_targets,
+                TargetGroupArn=arn,
+                Targets=targets)
+        except botocore.exceptions.ClientError as e:
+            raise exceptions.UnrecoverableActorFailure(e.message)
+
+    @gen.coroutine
+    def _execute(self):
+        arn = yield self._find_target_group(self.option('target_group'))
+        instances = self.option('instances')
+
+        if not instances:
+            self.log.debug('No instance provided. Using current instance id.')
+            iid = yield self._get_meta_data('instance-id')
+            instances = [iid]
+            self.log.debug('Instances is: %s' % instances)
+
+        if type(instances) is not list:
+            instances = [instances]
+
+        self.log.info(('Adding the following instances to Target Group: '
+                       '%s' % ', '.join(instances)))
+        yield self._add(arn, instances)
+
+
+class DeregisterInstance(base.AWSBaseActor):
+
+    """Remove EC2 instance(s) from a Target Group.
+
+    **Options**
+
+    :elb:
+      (str) Name of the Target Group.
+
+    :instances:
+      (str, list) Instance id, or list of ids
+
+    :region:
+      (str) AWS region (or zone) name, like us-west-2
+
+    **Example**
+
+    .. code-block:: yaml
+
+       actor: aws.elbv2.DeregisterInstance
+       desc: Run DeregisterInstance
+       options:
+         target_group: my-webserver-elb
+         instances: i-abcdeft
+         region: us-west-2
+
+    **Dry run**
+
+    Will find the Target Group but not take any actions regarding the
+    instances.
+    """
+
+    all_options = {
+        'target_group': (str, REQUIRED,
+                         'Name of the Target Group or its full ARN'),
+        'region': (str, REQUIRED, 'AWS region (or zone) name, like us-west-2'),
+        'instances': ((str, list), None, (
+            'Instance id, or list of ids. If no value is specified then '
+            'the instance id of the executing machine is used.')),
+    }
+
+    @gen.coroutine
+    @dry('Would remove instances from {0}: {1}')
+    def _remove(self, arn, targets):
+        """Deregisters the supplied Targets with the Target Group ARN.
+
+        http://boto3.readthedocs.io/en/latest/reference/services/
+        elbv2.html#ElasticLoadBalancingv2.Client.deregister_targets
+
+        Args:
+            arn: ELBv2 Target ARN
+            targets: A list of Instance IDs or Target IP Addresses.
+        """
+        #  TODO: In the future, add support for the optional Port and
+        #  AvailabilityZone parameters. For now, keeping this dead simple.
+        targets = [{'Id': t} for t in targets]
+
+        try:
+            yield self.thread(
+                self.elbv2_conn.deregister_targets,
+                TargetGroupArn=arn,
+                Targets=targets)
+        except botocore.exceptions.ClientError as e:
+            raise exceptions.UnrecoverableActorFailure(e.message)
+
+    @gen.coroutine
+    def _execute(self):
+        arn = yield self._find_target_group(self.option('target_group'))
+        instances = self.option('instances')
+
+        if not instances:
+            self.log.debug('No instance provided. Using current instance id.')
+            iid = yield self._get_meta_data('instance-id')
+            instances = [iid]
+            self.log.debug('Instances is: %s' % instances)
+
+        if type(instances) is not list:
+            instances = [instances]
+
+        self.log.info(('Removing the following instances from the target group: '
+                       '%s' % ', '.join(instances)))
+        yield self._remove(arn, instances)

--- a/kingpin/actors/aws/elbv2.py
+++ b/kingpin/actors/aws/elbv2.py
@@ -10,11 +10,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2014 Nextdoor.com, Inc
+# Copyright 2018 Nextdoor.com, Inc
 
 """
 :mod:`kingpin.actors.aws.elbv2`
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 """
 
 import logging
@@ -22,7 +22,6 @@ import logging
 from tornado import concurrent
 from tornado import gen
 
-from kingpin import utils
 from kingpin.actors import exceptions
 from kingpin.actors.aws import base
 from kingpin.actors.utils import dry

--- a/kingpin/actors/aws/elbv2.py
+++ b/kingpin/actors/aws/elbv2.py
@@ -206,6 +206,7 @@ class DeregisterInstance(base.AWSBaseActor):
         if type(instances) is not list:
             instances = [instances]
 
-        self.log.info(('Removing the following instances from the target group: '
-                       '%s' % ', '.join(instances)))
+        self.log.info(
+            ('Removing the following instances from the target group: '
+             '%s' % ', '.join(instances)))
         yield self._remove(arn, instances)

--- a/kingpin/actors/aws/iam/__init__.py
+++ b/kingpin/actors/aws/iam/__init__.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2014 Nextdoor.com, Inc
+# Copyright 2018 Nextdoor.com, Inc
 
 """
 :mod:`kingpin.actors.aws.iam`

--- a/kingpin/actors/aws/iam/base.py
+++ b/kingpin/actors/aws/iam/base.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2014 Nextdoor.com, Inc
+# Copyright 2018 Nextdoor.com, Inc
 
 """
 :mod:`kingpin.actors.aws.iam.base`

--- a/kingpin/actors/aws/iam/certs.py
+++ b/kingpin/actors/aws/iam/certs.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2014 Nextdoor.com, Inc
+# Copyright 2018 Nextdoor.com, Inc
 
 """
 :mod:`kingpin.actors.aws.iam.certs`

--- a/kingpin/actors/aws/iam/entities.py
+++ b/kingpin/actors/aws/iam/entities.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2014 Nextdoor.com, Inc
+# Copyright 2018 Nextdoor.com, Inc
 
 """
 :mod:`kingpin.actors.aws.iam.entities`

--- a/kingpin/actors/aws/s3.py
+++ b/kingpin/actors/aws/s3.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2016 Nextdoor.com, Inc
+# Copyright 2018 Nextdoor.com, Inc
 
 """
 :mod:`kingpin.actors.aws.s3`

--- a/kingpin/actors/aws/settings.py
+++ b/kingpin/actors/aws/settings.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2014 Nextdoor.com, Inc
+# Copyright 2018 Nextdoor.com, Inc
 
 """
 :mod:`kingpin.actors.aws.settings`

--- a/kingpin/actors/aws/sqs.py
+++ b/kingpin/actors/aws/sqs.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2014 Nextdoor.com, Inc
+# Copyright 2018 Nextdoor.com, Inc
 
 """
 :mod:`kingpin.actors.aws.sqs`

--- a/kingpin/actors/aws/test/__init__.py
+++ b/kingpin/actors/aws/test/__init__.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2014 Nextdoor.com, Inc
+# Copyright 2018 Nextdoor.com, Inc

--- a/kingpin/actors/aws/test/test_base.py
+++ b/kingpin/actors/aws/test/test_base.py
@@ -38,7 +38,7 @@ TARGET_GROUP_RESPONSE = {
         'Port': 80,
         'Protocol': 'HTTP',
         'TargetGroupArn':
-            'arn:aws:elasticloadbalancing:us-east-1:123:targetgroup/unittest/123',
+            'arn:aws:elb:us-east-1:123:targetgroup/unittest/123',
         'TargetGroupName': 'kingpin-integration-test',
         'UnhealthyThresholdCount': 2,
         'VpcId': 'vpc-123'
@@ -144,7 +144,7 @@ class TestBase(testing.AsyncTestCase):
         target = yield actor._find_target_group('123')
         self.assertEquals(
             target,
-            'arn:aws:elasticloadbalancing:us-east-1:123:targetgroup/unittest/123')
+            'arn:aws:elb:us-east-1:123:targetgroup/unittest/123')
         c_mock.describe_target_groups.assert_called_with(
             Names=['123'])
 

--- a/kingpin/actors/aws/test/test_elbv2.py
+++ b/kingpin/actors/aws/test/test_elbv2.py
@@ -1,0 +1,145 @@
+import logging
+
+from tornado import testing
+import mock
+import botocore.exceptions
+
+from kingpin.actors import exceptions
+from kingpin.actors.aws import elbv2 as elbv2_actor
+from kingpin.actors.aws import settings
+from kingpin.actors.test import helper
+
+log = logging.getLogger(__name__)
+
+
+class TestRegisterInstance(testing.AsyncTestCase):
+
+    def setUp(self):
+        super(TestRegisterInstance, self).setUp()
+        settings.AWS_ACCESS_KEY_ID = 'unit-test'
+        settings.AWS_SECRET_ACCESS_KEY = 'unit-test'
+        settings.RETRYING_SETTINGS = {'stop_max_attempt_number': 1}
+        reload(elbv2_actor)
+
+    @testing.gen_test
+    def test_add(self):
+        actor = elbv2_actor.RegisterInstance('UTA', {
+            'target_group': 'test',
+            'region': 'us-east-1',
+            'instances': 'test'})
+        actor.elbv2_conn = mock.Mock()
+        actor.elbv2_conn.register_targets.return_value = {}
+
+        yield actor._add('target_group_arn', ['i-un173s7'])
+
+        actor.elbv2_conn.register_targets.assert_called_with(
+            TargetGroupArn='target_group_arn',
+            Targets=[{'Id': 'i-un173s7'}])
+
+    @testing.gen_test
+    def test_add_exception(self):
+        actor = elbv2_actor.RegisterInstance('UTA', {
+            'target_group': 'test',
+            'region': 'us-east-1',
+            'instances': 'test'})
+        actor.elbv2_conn = mock.Mock()
+        exc = botocore.exceptions.ClientError({'Error': {}}, 'Test')
+        actor.elbv2_conn.register_targets.side_effect = exc
+
+        with self.assertRaises(exceptions.UnrecoverableActorFailure):
+            yield actor._add('target_group_arn', ['i-un173s7'])
+
+    @testing.gen_test
+    def test_execute(self):
+        actor = elbv2_actor.RegisterInstance('UTA', {
+            'target_group': 'test',
+            'region': 'us-east-1',
+            'instances': 'i-test'})
+
+        actor._find_target_group = mock.Mock()
+        actor._find_target_group.return_value = helper.tornado_value('arn')
+        actor._add = mock.Mock()
+        actor._add.return_value = helper.tornado_value(mock.Mock())
+        yield actor._execute()
+        actor._add.assert_called_with('arn', ['i-test'])
+
+    @testing.gen_test
+    def test_execute_self(self):
+        # No instance id specified
+        actor = elbv2_actor.RegisterInstance('UTA', {
+            'target_group': 'test',
+            'region': 'us-east-1'})
+
+        actor._find_target_group = mock.Mock()
+        actor._find_target_group.return_value = helper.tornado_value('arn')
+        actor._add = mock.Mock()
+        actor._get_meta_data = helper.mock_tornado('i-test')
+        actor._add.return_value = helper.tornado_value(mock.Mock())
+        yield actor._execute()
+        actor._add.assert_called_with('arn', ['i-test'])
+
+
+class TestDeregisterInstance(testing.AsyncTestCase):
+
+    def setUp(self):
+        super(TestDeregisterInstance, self).setUp()
+        settings.AWS_ACCESS_KEY_ID = 'unit-test'
+        settings.AWS_SECRET_ACCESS_KEY = 'unit-test'
+        settings.RETRYING_SETTINGS = {'stop_max_attempt_number': 1}
+        reload(elbv2_actor)
+
+    @testing.gen_test
+    def test_remove(self):
+        actor = elbv2_actor.DeregisterInstance('UTA', {
+            'target_group': 'test',
+            'region': 'us-east-1',
+            'instances': 'test'})
+        actor.elbv2_conn = mock.Mock()
+        actor.elbv2_conn.deregister_targets.return_value = {}
+
+        yield actor._remove('target_group_arn', ['i-un173s7'])
+
+        actor.elbv2_conn.deregister_targets.assert_called_with(
+            TargetGroupArn='target_group_arn',
+            Targets=[{'Id': 'i-un173s7'}])
+
+    @testing.gen_test
+    def test_remove_exception(self):
+        actor = elbv2_actor.DeregisterInstance('UTA', {
+            'target_group': 'test',
+            'region': 'us-east-1',
+            'instances': 'test'})
+        actor.elbv2_conn = mock.Mock()
+        exc = botocore.exceptions.ClientError({'Error': {}}, 'Test')
+        actor.elbv2_conn.deregister_targets.side_effect = exc
+
+        with self.assertRaises(exceptions.UnrecoverableActorFailure):
+            yield actor._remove('target_group_arn', ['i-un173s7'])
+
+    @testing.gen_test
+    def test_execute(self):
+        actor = elbv2_actor.DeregisterInstance('UTA', {
+            'target_group': 'elb-test',
+            'region': 'us-east-1',
+            'instances': 'i-test'})
+
+        actor._find_target_group = mock.Mock()
+        actor._find_target_group.return_value = helper.tornado_value('arn')
+        actor._remove = mock.Mock()
+        actor._remove.return_value = helper.tornado_value(mock.Mock())
+        yield actor._execute()
+        actor._remove.assert_called_with('arn', ['i-test'])
+
+    @testing.gen_test
+    def test_execute_self(self):
+        actor = elbv2_actor.DeregisterInstance('UTA', {
+            'target_group': 'elb-test',
+            'region': 'us-east-1'})
+
+        actor._find_target_group = mock.Mock()
+        actor._find_target_group.return_value = helper.tornado_value('arn')
+        actor._get_meta_data = helper.mock_tornado('i-test')
+        actor._remove = mock.Mock()
+        actor._remove.return_value = helper.tornado_value(mock.Mock())
+        yield actor._execute()
+        actor._remove.assert_called_with('arn', ['i-test'])

--- a/kingpin/actors/base.py
+++ b/kingpin/actors/base.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2014 Nextdoor.com, Inc
+# Copyright 2018 Nextdoor.com, Inc
 
 """
 :mod:`kingpin.actors.base`

--- a/kingpin/actors/exceptions.py
+++ b/kingpin/actors/exceptions.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2014 Nextdoor.com, Inc
+# Copyright 2018 Nextdoor.com, Inc
 """
 :mod:`kingpin.actors.exceptions`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/kingpin/actors/group.py
+++ b/kingpin/actors/group.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2014 Nextdoor.com, Inc
+# Copyright 2018 Nextdoor.com, Inc
 
 """
 :mod:`kingpin.actors.group`

--- a/kingpin/actors/hipchat.py
+++ b/kingpin/actors/hipchat.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2014 Nextdoor.com, Inc
+# Copyright 2018 Nextdoor.com, Inc
 
 """
 :mod:`kingpin.actors.hipchat`

--- a/kingpin/actors/librato.py
+++ b/kingpin/actors/librato.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2014 Nextdoor.com, Inc
+# Copyright 2018 Nextdoor.com, Inc
 
 """
 :mod:`kingpin.actors.librato`

--- a/kingpin/actors/misc.py
+++ b/kingpin/actors/misc.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2014 Nextdoor.com, Inc
+# Copyright 2018 Nextdoor.com, Inc
 
 """
 :mod:`kingpin.actors.misc`

--- a/kingpin/actors/packagecloud.py
+++ b/kingpin/actors/packagecloud.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2014 Nextdoor.com, Inc
+# Copyright 2018 Nextdoor.com, Inc
 
 """
 :mod:`kingpin.actors.packagecloud`

--- a/kingpin/actors/pingdom.py
+++ b/kingpin/actors/pingdom.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2014 Nextdoor.com, Inc
+# Copyright 2018 Nextdoor.com, Inc
 
 """
 :mod:`kingpin.actors.pingdom`

--- a/kingpin/actors/rightscale/__init__.py
+++ b/kingpin/actors/rightscale/__init__.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2014 Nextdoor.com, Inc
+# Copyright 2018 Nextdoor.com, Inc
 
 import logging
 

--- a/kingpin/actors/rightscale/alerts.py
+++ b/kingpin/actors/rightscale/alerts.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2014 Nextdoor.com, Inc
+# Copyright 2018 Nextdoor.com, Inc
 
 """
 :mod:`kingpin.actors.rightscale.alerts`

--- a/kingpin/actors/rightscale/api.py
+++ b/kingpin/actors/rightscale/api.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2014 Nextdoor.com, Inc
+# Copyright 2018 Nextdoor.com, Inc
 
 """
 :mod:`kingpin.actors.rightscale.api`

--- a/kingpin/actors/rightscale/base.py
+++ b/kingpin/actors/rightscale/base.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2014 Nextdoor.com, Inc
+# Copyright 2018 Nextdoor.com, Inc
 
 """
 :mod:`kingpin.actors.rightscale.base`

--- a/kingpin/actors/rightscale/deployment.py
+++ b/kingpin/actors/rightscale/deployment.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2014 Nextdoor.com, Inc
+# Copyright 2018 Nextdoor.com, Inc
 
 """
 :mod:`kingpin.actors.rightscale.deployment`

--- a/kingpin/actors/rightscale/mci.py
+++ b/kingpin/actors/rightscale/mci.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2014 Nextdoor.com, Inc
+# Copyright 2018 Nextdoor.com, Inc
 
 """
 :mod:`kingpin.actors.rightscale.mci`

--- a/kingpin/actors/rightscale/rightscript.py
+++ b/kingpin/actors/rightscale/rightscript.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2014 Nextdoor.com, Inc
+# Copyright 2018 Nextdoor.com, Inc
 
 """
 :mod:`kingpin.actors.rightscale.rightscript`

--- a/kingpin/actors/rightscale/server_array.py
+++ b/kingpin/actors/rightscale/server_array.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2014 Nextdoor.com, Inc
+# Copyright 2018 Nextdoor.com, Inc
 
 """
 :mod:`kingpin.actors.rightscale.server_array`

--- a/kingpin/actors/rightscale/server_template.py
+++ b/kingpin/actors/rightscale/server_template.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2014 Nextdoor.com, Inc
+# Copyright 2018 Nextdoor.com, Inc
 
 """
 :mod:`kingpin.actors.rightscale.server_template`

--- a/kingpin/actors/rightscale/settings.py
+++ b/kingpin/actors/rightscale/settings.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2014 Nextdoor.com, Inc
+# Copyright 2018 Nextdoor.com, Inc
 
 """
 :mod:`kingpin.actors.rightscale.settings`

--- a/kingpin/actors/rollbar.py
+++ b/kingpin/actors/rollbar.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2014 Nextdoor.com, Inc
+# Copyright 2018 Nextdoor.com, Inc
 
 """
 :mod:`kingpin.actors.rollbar`

--- a/kingpin/actors/slack.py
+++ b/kingpin/actors/slack.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2014 Nextdoor.com, Inc
+# Copyright 2018 Nextdoor.com, Inc
 
 """
 :mod:`kingpin.actors.slack`

--- a/kingpin/actors/spotinst.py
+++ b/kingpin/actors/spotinst.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2014 Nextdoor.com, Inc
+# Copyright 2018 Nextdoor.com, Inc
 
 """
 :mod:`kingpin.actors.spotinst`

--- a/kingpin/actors/support/__init__.py
+++ b/kingpin/actors/support/__init__.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2014 Nextdoor.com, Inc
+# Copyright 2018 Nextdoor.com, Inc

--- a/kingpin/actors/support/api.py
+++ b/kingpin/actors/support/api.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2014 Nextdoor.com, Inc
+# Copyright 2018 Nextdoor.com, Inc
 """
 This package provides a quick way of creating custom API clients for JSON-based
 REST APIs. The majority of the work is in the creation of a _CONFIG dictionary

--- a/kingpin/actors/test/__init__.py
+++ b/kingpin/actors/test/__init__.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2014 Nextdoor.com, Inc
+# Copyright 2018 Nextdoor.com, Inc
 
 """This is used to allow unit tests to instantiate fake actor objects
 from within the test directory structure."""

--- a/kingpin/actors/utils.py
+++ b/kingpin/actors/utils.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2014 Nextdoor.com, Inc
+# Copyright 2018 Nextdoor.com, Inc
 
 """
 :mod:`kingpin.actors.utils`

--- a/kingpin/bin/__init__.py
+++ b/kingpin/bin/__init__.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2014 Nextdoor.com, Inc
+# Copyright 2018 Nextdoor.com, Inc

--- a/kingpin/bin/deploy.py
+++ b/kingpin/bin/deploy.py
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2014 Nextdoor.com, Inc
+# Copyright 2018 Nextdoor.com, Inc
 """CLI Script Runner for Kingpin."""
 
 import argparse

--- a/kingpin/constants.py
+++ b/kingpin/constants.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2014 Nextdoor.com, Inc
+# Copyright 2018 Nextdoor.com, Inc
 
 import jsonschema
 

--- a/kingpin/exceptions.py
+++ b/kingpin/exceptions.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2014 Nextdoor.com, Inc
+# Copyright 2018 Nextdoor.com, Inc
 
 
 class KingpinException(Exception):

--- a/kingpin/schema.py
+++ b/kingpin/schema.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2014 Nextdoor.com, Inc
+# Copyright 2018 Nextdoor.com, Inc
 
 import jsonschema
 

--- a/kingpin/test/__init__.py
+++ b/kingpin/test/__init__.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2014 Nextdoor.com, Inc
+# Copyright 2018 Nextdoor.com, Inc

--- a/kingpin/version.py
+++ b/kingpin/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright 2014 Nextdoor.com, Inc
+# Copyright 2018 Nextdoor.com, Inc
 
 
 __version__ = '0.4.1'


### PR DESCRIPTION
This PR adds support to Register and Deregister targets from an Amazon ELBv2 Target Group. The initial support here is around adding `instance` targets, but it leaves it open down the road to add `ip` targets as well.