### PR TITLE
ECS: Stop setting defaults for immutable fields.

### DIFF
--- a/kingpin/actors/aws/ecs.py
+++ b/kingpin/actors/aws/ecs.py
@@ -404,18 +404,6 @@ class ECSBaseActor(base.AWSBaseActor):
             except jsonschema.exceptions.ValidationError as e:
                 raise exceptions.InvalidOptions(e)
 
-        # Set default values.
-        service_definition.setdefault(
-            'deploymentConfiguration', {})
-        service_definition.setdefault(
-            'launchType', 'EC2')
-        service_definition.setdefault(
-            'loadBalancers', [])
-        service_definition.setdefault(
-            'placementConstraints', [])
-        service_definition.setdefault(
-            'placementStrategy', [])
-
         return service_definition
 
     @staticmethod
@@ -1134,7 +1122,7 @@ class Service(ECSBaseActor):
             old_field = old_params.get(immutable_field_name)
 
             # If the newly supplied fields are None, then they aren't defined
-            # in the service definition at all. Its OK to ignore them.
+            # in the service definition at all. It's OK to ignore them.
             if new_field is None:
                 continue
 

--- a/kingpin/actors/aws/test/test_ecs.py
+++ b/kingpin/actors/aws/test/test_ecs.py
@@ -300,8 +300,10 @@ class TestLoadServiceDefinition(testing.AsyncTestCase):
     @testing.gen_test
     def test_default(self):
         result = self.actor._load_service_definition(None, {})
+        self.assertEqual(result, {})
 
         result = self.actor._load_service_definition('', {})
+        self.assertEqual(result, {})
 
     def _test(self, service_definition):
         with mock.patch('kingpin.utils.convert_script_to_dict',

--- a/kingpin/actors/aws/test/test_ecs.py
+++ b/kingpin/actors/aws/test/test_ecs.py
@@ -300,18 +300,8 @@ class TestLoadServiceDefinition(testing.AsyncTestCase):
     @testing.gen_test
     def test_default(self):
         result = self.actor._load_service_definition(None, {})
-        self.assertEqual(result['deploymentConfiguration'], {})
-        self.assertEqual(result['launchType'], 'EC2')
-        self.assertEqual(result['loadBalancers'], [])
-        self.assertEqual(result['placementConstraints'], [])
-        self.assertEqual(result['placementStrategy'], [])
 
         result = self.actor._load_service_definition('', {})
-        self.assertEqual(result['deploymentConfiguration'], {})
-        self.assertEqual(result['launchType'], 'EC2')
-        self.assertEqual(result['loadBalancers'], [])
-        self.assertEqual(result['placementConstraints'], [])
-        self.assertEqual(result['placementStrategy'], [])
 
     def _test(self, service_definition):
         with mock.patch('kingpin.utils.convert_script_to_dict',


### PR DESCRIPTION
If they aren't supplied, amazon provides a default.