### PR TITLE
Integrate an API Call Queue for cf.describe_stacks.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ deploy:
       tags: true
       python: '2.7'
       all_branches: true
-      condition: $TRAVIS_TAG =~ ^(v[0-9]+.[0-9]+.[0-9]+[a-z]?)|pre_release$
+      condition: $TRAVIS_TAG =~ ^(v[0-9]+.[0-9]+.[0-9]+[a-z]?)|pre_release|test$
       repo: Nextdoor/kingpin
   - provider: pypi
     user: nextdoor

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ deploy:
       tags: true
       python: '2.7'
       all_branches: true
-      condition: $TRAVIS_TAG =~ ^(v[0-9]+.[0-9]+.[0-9]+[a-z]?)|pre_release|test$
+      condition: $TRAVIS_TAG =~ ^(v[0-9]+.[0-9]+.[0-9]+[a-z]?)|pre_release$
       repo: Nextdoor/kingpin
   - provider: pypi
     user: nextdoor

--- a/kingpin/actors/aws/api_call_queue.py
+++ b/kingpin/actors/aws/api_call_queue.py
@@ -1,0 +1,133 @@
+from boto import exception as boto_exception
+from botocore import exceptions as botocore_exceptions
+from tornado import concurrent
+from tornado import gen
+from tornado import queues
+from tornado import ioloop
+
+from kingpin.actors import exceptions
+
+EXECUTOR = concurrent.futures.ThreadPoolExecutor(10)
+
+
+class ApiCallQueue:
+    """
+    Handles queueing up and sending AWS api calls serially,
+    with exponential backoff when there is throttling.
+
+    Supports both boto2 and boto3.
+    """
+
+    def __init__(self):
+        self.executor = EXECUTOR
+
+        self._queue = queues.Queue()
+        ioloop.IOLoop.current().spawn_callback(self._process_queue)
+
+        # Used for controlling how fast the work queue is processed,
+        # with exponential delay on throttling errors.
+        self.delay_min = 0.25
+        self.delay_max = 30
+        # We don't have a delay until we first get throttled.
+        self.delay = 0
+
+        # There are a number of different rate limiting messages
+        # boto2 can return when rate limits are reached, depending
+        # on which apis are used.
+        self.boto2_throttle_strings = (
+            'Throttling',
+            'Rate exceeded',
+            'reached max retries',
+        )
+
+    @gen.coroutine
+    def call(self, api_function, *args, **kwargs):
+        result_queue = queues.Queue(maxsize=1)
+        yield self._queue.put((result_queue, api_function, args, kwargs))
+        result = yield result_queue.get()
+        if isinstance(result, Exception):
+            raise result
+        raise gen.Return(result)
+
+    @gen.coroutine
+    def _process_queue(self):
+        while True:
+            result_queue, api_function, args, kwargs = yield self._queue.get()
+            try:
+                result = yield self._call(api_function, *args, **kwargs)
+            except BaseException as e:
+                result = e
+            yield result_queue.put(result)
+            if self.delay > 0:
+                yield gen.sleep(self.delay)
+
+    @gen.coroutine
+    def _call(self, api_function, *args, **kwargs):
+        while True:
+            try:
+                result = yield self._thread(
+                    api_function, *args, **kwargs)
+                self.decrease_delay()
+                raise gen.Return(result)
+            except boto_exception.BotoServerError as e:
+                # Boto2 exception.
+                if e.error_code in self.boto2_throttle_strings:
+                    self.increase_delay()
+                    yield gen.sleep(self.delay)
+                    continue
+
+                # If we're using temporary IAM credentials, when those expire
+                # we can get back a blank 400 from Amazon. This is confusing,
+                # but it happens because of
+                # https://github.com/boto/boto/issues/898.
+                # In most cases, these temporary IAM creds can be re-loaded by
+                # reaching out to the AWS API (for example, if we're using an
+                # IAM Instance Profile role), so thats what Boto tries to do.
+                # However, if you're using short-term creds (say from SAML
+                # auth'd logins), then this fails and Boto returns a blank
+                # 400.
+                if (e.status == 400 and
+                        e.reason == 'Bad Request' and
+                        e.error_code is None):
+                    msg = 'Access credentials have expired'
+                    e = exceptions.InvalidCredentials(msg)
+                elif e.status == 403:
+                    msg = '%s: %s' % (e.error_code, e.message)
+                    e = exceptions.InvalidCredentials(msg)
+
+                self.decrease_delay()
+                raise e
+            except botocore_exceptions.ClientError as e:
+                # Boto3 exception.
+                if e.response['Error']['Code'] == 'Throttling':
+                    self.increase_delay()
+                    yield gen.sleep(self.delay)
+                    continue
+
+                self.decrease_delay()
+                raise e
+
+    def decrease_delay(self):
+        if self.delay == 0:
+            return
+        if self.delay == self.delay_min:
+            self.delay = 0
+            return
+        self.delay /= 2
+        self.delay = max(self.delay, self.delay_min)
+
+    def increase_delay(self):
+        if self.delay == 0:
+            self.delay = self.delay_min
+            return
+        self.delay *= 2
+        self.delay = min(self.delay, self.delay_max)
+
+    @concurrent.run_on_executor
+    def _thread(self, function, *args, **kwargs):
+        """Execute `function` in a concurrent thread.
+
+        This allows execution of any function in a thread without having
+        to write a wrapper method that is decorated with run_on_executor().
+        """
+        return function(*args, **kwargs)

--- a/kingpin/actors/aws/api_call_queue.py
+++ b/kingpin/actors/aws/api_call_queue.py
@@ -80,7 +80,8 @@ class ApiCallQueue:
         Reads the api functions to call from the internal queue
         along with their individual result queues.
         Calls the api function.
-        That result queue is used to pass back the result or exception from the call.
+        That result queue is used to pass back the result
+        or exception from the call.
         This sleeps between API calls based on `delay`.
         """
         while True:

--- a/kingpin/actors/aws/api_call_queue.py
+++ b/kingpin/actors/aws/api_call_queue.py
@@ -14,6 +14,8 @@ class ApiCallQueue:
     with exponential backoff when there is throttling.
 
     Supports both boto2 and boto3.
+
+    Invoke the `call` method to queue up a new API call.
     """
 
     def __init__(self):
@@ -40,6 +42,30 @@ class ApiCallQueue:
 
     @gen.coroutine
     def call(self, api_function, *args, **kwargs):
+        """Call a boto2 or boto3 api function.
+
+        Simply invoke this with an api method and its args and kwargs.
+
+        The api function call is coordinated synchronously across all
+        calls to this `api_call_queue`, and they will run in order.
+
+        I.e., if you invoke this right after another coroutine invoked this,
+        it will block until that other coroutine's call completed.
+
+        If the call ends up being rate limited,
+        it will backoff and try again continuously.
+
+        By serializing the api calls to the specific method,
+        this prevents a stampeding herd effect that you'd normally get
+        with infinite retries.
+
+        There is no limit or timeout on how many times it will retry,
+        so in practice this may block an extremely long time if all responses
+        are rate limit exceptions.
+
+        Any other failures, like connection timeouts or read timeouts,
+        will bubble up immediately and won't be retried here.
+        """
         result_queue = queues.Queue(maxsize=1)
         yield self._queue.put((result_queue, api_function, args, kwargs))
         result = yield result_queue.get()
@@ -49,6 +75,14 @@ class ApiCallQueue:
 
     @gen.coroutine
     def _process_queue(self):
+        """Queue consumer.
+
+        Reads the api functions to call from the internal queue
+        along with their individual result queues.
+        Calls the api function.
+        That result queue is used to pass back the result or exception from the call.
+        This sleeps between API calls based on `delay`.
+        """
         while True:
             result_queue, api_function, args, kwargs = yield self._queue.get()
             try:
@@ -60,30 +94,45 @@ class ApiCallQueue:
 
     @gen.coroutine
     def _call(self, api_function, *args, **kwargs):
+        """Calls the provided api_function in a background thread.
+
+        If the api function returns a response cleanly, this will return it.
+        If the api function raises an exception, this raises it up.
+
+        For as long as the api function returns a boto2 or boto3
+        rate limiting exception, this will backoff and try again.
+        """
         while True:
             try:
-                result = yield self._thread(
-                    api_function, *args, **kwargs)
-                self.decrease_delay()
+                result = yield self._thread(api_function, *args, **kwargs)
+                self._decrease_delay()
                 raise gen.Return(result)
             except boto_exception.BotoServerError as e:
                 # Boto2 exception.
                 if e.error_code in self.boto2_throttle_strings:
-                    self.increase_delay()
+                    self._increase_delay()
                     yield gen.sleep(self.delay)
                 else:
-                    self.decrease_delay()
+                    self._decrease_delay()
                     raise e
             except botocore_exceptions.ClientError as e:
                 # Boto3 exception.
                 if e.response['Error']['Code'] == 'Throttling':
-                    self.increase_delay()
+                    self._increase_delay()
                     yield gen.sleep(self.delay)
                 else:
-                    self.decrease_delay()
+                    self._decrease_delay()
                     raise e
 
-    def decrease_delay(self):
+    def _decrease_delay(self):
+        """Decrease `delay` by one step.
+
+        If `delay` is already 0, do nothing.
+        If `delay` is `delay_min`, go to 0.
+
+        Otherwise, divide `delay` by 2.
+        If that goes below `delay_min`, go to `delay_min`.
+        """
         if self.delay == 0:
             return
         if self.delay == self.delay_min:
@@ -92,7 +141,14 @@ class ApiCallQueue:
         self.delay /= 2
         self.delay = max(self.delay, self.delay_min)
 
-    def increase_delay(self):
+    def _increase_delay(self):
+        """Increase `delay` by one step.
+
+        If `delay` is already 0, go to `delay_min`.
+
+        Otherwise, multiply `delay` by 2.
+        If that goes above `delay_max`, go to `delay_max`.
+        """
         if self.delay == 0:
             self.delay = self.delay_min
             return

--- a/kingpin/actors/aws/api_call_queue.py
+++ b/kingpin/actors/aws/api_call_queue.py
@@ -87,7 +87,7 @@ class ApiCallQueue:
             result_queue, api_function, args, kwargs = yield self._queue.get()
             try:
                 result = yield self._call(api_function, *args, **kwargs)
-            except BaseException as e:
+            except Exception as e:
                 result = e
             yield result_queue.put(result)
             yield gen.sleep(self.delay)

--- a/kingpin/actors/aws/base.py
+++ b/kingpin/actors/aws/base.py
@@ -192,7 +192,7 @@ class AWSBaseActor(base.BaseActor):
         """
         try:
             return api_function(*args, **kwargs)
-        except (boto_exception.BotoServerError, boto3_exceptions.Boto3Error):
+        except (boto_exception.BotoServerError, boto3_exceptions.Boto3Error) as e:
             raise self._wrap_boto_exception(e)
 
     @gen.coroutine
@@ -225,7 +225,7 @@ class AWSBaseActor(base.BaseActor):
         queue = NAMED_API_CALL_QUEUES[queue_name]
         try:
             result = yield queue.call(api_function, *args, **kwargs)
-        except (boto_exception.BotoServerError, boto3_exceptions.Boto3Error):
+        except (boto_exception.BotoServerError, boto3_exceptions.Boto3Error) as e:
             raise self._wrap_boto_exception(e)
         else:
             raise gen.Return(result)

--- a/kingpin/actors/aws/base.py
+++ b/kingpin/actors/aws/base.py
@@ -192,7 +192,7 @@ class AWSBaseActor(base.BaseActor):
         """
         try:
             return api_function(*args, **kwargs)
-        except Exception as e:
+        except (boto_exception.BotoServerError, boto3_exceptions.Boto3Error):
             raise self._wrap_boto_exception(e)
 
     @gen.coroutine
@@ -216,7 +216,8 @@ class AWSBaseActor(base.BaseActor):
         If the queue doesn't exist, it will be created.
 
         Example:
-            >>> zones = yield api_call_with_queueing(ec2_conn.get_all_zones)
+            >>> zones = yield api_call_with_queueing(
+            >>>     ec2_conn.get_all_zones, queue_name='get_all_zones')
         """
         if queue_name not in NAMED_API_CALL_QUEUES:
             NAMED_API_CALL_QUEUES[queue_name] = (
@@ -224,7 +225,7 @@ class AWSBaseActor(base.BaseActor):
         queue = NAMED_API_CALL_QUEUES[queue_name]
         try:
             result = yield queue.call(api_function, *args, **kwargs)
-        except Exception as e:
+        except (boto_exception.BotoServerError, boto3_exceptions.Boto3Error):
             raise self._wrap_boto_exception(e)
         else:
             raise gen.Return(result)

--- a/kingpin/actors/aws/base.py
+++ b/kingpin/actors/aws/base.py
@@ -209,7 +209,7 @@ class AWSBaseActor(base.BaseActor):
         and the delay between the calls will increase as
         recoverable api failures happen.
 
-        The API function is assumed to be a synchronous function.
+        The api function is assumed to be a synchronous function.
         It will be run on a concurrent thread using run_on_executor.
 
         The queue_identifier argument specifies which queue to use.

--- a/kingpin/actors/aws/base.py
+++ b/kingpin/actors/aws/base.py
@@ -192,7 +192,8 @@ class AWSBaseActor(base.BaseActor):
         """
         try:
             return api_function(*args, **kwargs)
-        except (boto_exception.BotoServerError, boto3_exceptions.Boto3Error) as e:
+        except (boto_exception.BotoServerError,
+                boto3_exceptions.Boto3Error) as e:
             raise self._wrap_boto_exception(e)
 
     @gen.coroutine
@@ -225,7 +226,8 @@ class AWSBaseActor(base.BaseActor):
         queue = NAMED_API_CALL_QUEUES[queue_name]
         try:
             result = yield queue.call(api_function, *args, **kwargs)
-        except (boto_exception.BotoServerError, boto3_exceptions.Boto3Error) as e:
+        except (boto_exception.BotoServerError,
+                boto3_exceptions.Boto3Error) as e:
             raise self._wrap_boto_exception(e)
         else:
             raise gen.Return(result)

--- a/kingpin/actors/aws/cloudformation.py
+++ b/kingpin/actors/aws/cloudformation.py
@@ -260,7 +260,7 @@ class CloudFormationBaseActor(base.AWSBaseActor):
             cfg = {'TemplateBody': body}
             self.log.info('Validating template with AWS...')
             try:
-                yield self.thread(self.cf3_conn.validate_template, **cfg)
+                yield self.api_call(self.cf3_conn.validate_template, **cfg)
             except ClientError as e:
                 raise InvalidTemplate(e.message)
 
@@ -268,7 +268,7 @@ class CloudFormationBaseActor(base.AWSBaseActor):
             cfg = {'TemplateURL': url}
             self.log.info('Validating template (%s) with AWS...' % url)
             try:
-                yield self.thread(self.cf3_conn.validate_template, **cfg)
+                yield self.api_call(self.cf3_conn.validate_template, **cfg)
             except ClientError as e:
                 raise InvalidTemplate(e.message)
 
@@ -316,8 +316,10 @@ class CloudFormationBaseActor(base.AWSBaseActor):
             <Stack Dict> or <None>
         """
         try:
-            stacks = yield self.thread(self.cf3_conn.describe_stacks,
-                                       StackName=stack)
+            stacks = yield self.api_call_with_queueing(
+                self.cf3_conn.describe_stacks,
+                queue_name='describe_stacks',
+                StackName=stack)
         except ClientError as e:
             if 'does not exist' in e.message:
                 raise gen.Return(None)
@@ -334,8 +336,8 @@ class CloudFormationBaseActor(base.AWSBaseActor):
             stack: Stack name or stack ID
         """
         try:
-            ret = yield self.thread(self.cf3_conn.get_template,
-                                    StackName=stack)
+            ret = yield self.api_call(self.cf3_conn.get_template,
+                                      StackName=stack)
         except ClientError as e:
             raise CloudFormationError(e)
 
@@ -400,7 +402,7 @@ class CloudFormationBaseActor(base.AWSBaseActor):
             [<list of human readable strings>]
         """
         try:
-            raw = yield self.thread(
+            raw = yield self.api_call(
                 self.cf3_conn.describe_stack_events, StackName=stack)
         except ClientError:
             raise gen.Return([])
@@ -433,7 +435,7 @@ class CloudFormationBaseActor(base.AWSBaseActor):
 
         self.log.info('Deleting stack')
         try:
-            ret = yield self.thread(
+            ret = yield self.api_call(
                 self.cf3_conn.delete_stack, StackName=stack)
         except ClientError as e:
             raise CloudFormationError(e.message)
@@ -474,7 +476,7 @@ class CloudFormationBaseActor(base.AWSBaseActor):
             enable_termination_protection = False
 
         try:
-            stack = yield self.thread(
+            stack = yield self.api_call(
                 self.cf3_conn.create_stack,
                 StackName=stack,
                 Parameters=self._parameters,
@@ -503,7 +505,6 @@ class CloudFormationBaseActor(base.AWSBaseActor):
 
 
 class Create(CloudFormationBaseActor):
-
     """Creates a CloudFormation stack.
 
     Creates a CloudFormation stack from scratch and waits until the stack is
@@ -638,7 +639,6 @@ class Create(CloudFormationBaseActor):
 
 
 class Delete(CloudFormationBaseActor):
-
     """Deletes a CloudFormation stack
 
     **Options**
@@ -680,7 +680,6 @@ class Delete(CloudFormationBaseActor):
 
 
 class Stack(CloudFormationBaseActor):
-
     """Manages the state of a CloudFormation stack.
 
     This actor can manage the following aspects of a CloudFormation stack in
@@ -928,8 +927,8 @@ class Stack(CloudFormationBaseActor):
         # cruft. THis isn't necessary in the real run, because the changeset
         # cannot be deleted once its been applied.
         if self._dry:
-            yield self.thread(self.cf3_conn.delete_change_set,
-                              ChangeSetName=change_set_req['Id'])
+            yield self.api_call(self.cf3_conn.delete_change_set,
+                                ChangeSetName=change_set_req['Id'])
 
         self.log.info('Done updating template')
 
@@ -1005,8 +1004,9 @@ class Stack(CloudFormationBaseActor):
 
         self.log.info('Generating a stack Change Set...')
         try:
-            change_set_req = yield self.thread(self.cf3_conn.create_change_set,
-                                               **change_opts)
+            change_set_req = yield self.api_call(
+                self.cf3_conn.create_change_set,
+                **change_opts)
         except ClientError as e:
             raise CloudFormationError(e)
 
@@ -1036,7 +1036,7 @@ class Stack(CloudFormationBaseActor):
                       (change_set_name, desired_state))
         while True:
             try:
-                change = yield self.thread(
+                change = yield self.api_call(
                     self.cf3_conn.describe_change_set,
                     ChangeSetName=change_set_name)
             except ClientError as e:
@@ -1109,8 +1109,8 @@ class Stack(CloudFormationBaseActor):
         """
         self.log.info('Executing change set %s' % change_set_name)
         try:
-            yield self.thread(self.cf3_conn.execute_change_set,
-                              ChangeSetName=change_set_name)
+            yield self.api_call(self.cf3_conn.execute_change_set,
+                                ChangeSetName=change_set_name)
         except ClientError as e:
             raise StackFailed(e)
 
@@ -1151,7 +1151,7 @@ class Stack(CloudFormationBaseActor):
         self.log.info('Updating EnableTerminationProtection to %s' % str(new))
 
         try:
-            yield self.thread(
+            yield self.api_call(
                 self.cf3_conn.update_termination_protection,
                 StackName=stack['StackName'],
                 EnableTerminationProtection=new)

--- a/kingpin/actors/aws/ecs.py
+++ b/kingpin/actors/aws/ecs.py
@@ -242,7 +242,7 @@ class ECSBaseActor(base.AWSBaseActor):
         self.log.info('Registering task definition with family {}'.format(
             family))
 
-        response = yield self.thread(
+        response = yield self.api_call(
             self.ecs_conn.register_task_definition, **task_definition)
 
         # Parse data from the server's response.
@@ -264,7 +264,7 @@ class ECSBaseActor(base.AWSBaseActor):
         """
         self.log.info(
             'Deregistering task definition {}.'.format(task_definition_name))
-        yield self.thread(
+        yield self.api_call(
             self.ecs_conn.deregister_task_definition,
             taskDefinition=task_definition_name)
 
@@ -301,7 +301,7 @@ class ECSBaseActor(base.AWSBaseActor):
         """
         self.log.info('Describing task definition {}.'.format(
             task_definition_name))
-        task_definition = yield self.thread(
+        task_definition = yield self.api_call(
             self.ecs_conn.describe_task_definition,
             taskDefinition=task_definition_name)
 
@@ -329,7 +329,7 @@ class ECSBaseActor(base.AWSBaseActor):
             'Listing task definitions '
             'with status {} and family prefix {}.'.format(
                 status, family_prefix))
-        task_definitions = yield self.thread(
+        task_definitions = yield self.api_call(
             self._read_list_task_definitions_paginator,
             status=status,
             familyPrefix=family_prefix)
@@ -528,7 +528,7 @@ class RunTask(ECSBaseActor):
             seconds=30)
 
         while True:
-            response = yield self.thread(
+            response = yield self.api_call(
                 self.ecs_conn.run_task,
                 cluster=self.option('cluster'),
                 taskDefinition=task_definition_name,
@@ -577,7 +577,7 @@ class RunTask(ECSBaseActor):
         Returns:
             A boolean indicating whether all tasks are done.
         """
-        response = yield self.thread(
+        response = yield self.api_call(
             self.ecs_conn.describe_tasks,
             cluster=self.option('cluster'),
             tasks=tasks)
@@ -838,7 +838,7 @@ class Service(ECSBaseActor):
         Raises:
             RecoverableActorFailure if number of services found is not 1.
         """
-        response = yield self.thread(
+        response = yield self.api_call(
             self.ecs_conn.describe_services,
             cluster=self.option('cluster'),
             services=[service_name])
@@ -958,7 +958,7 @@ class Service(ECSBaseActor):
 
         self.log.info('Creating service.')
 
-        yield self.thread(
+        yield self.api_call(
             self.ecs_conn.create_service,
             **create_parameters)
 
@@ -1020,7 +1020,7 @@ class Service(ECSBaseActor):
 
         self.log.info('Updating service.')
 
-        yield self.thread(
+        yield self.api_call(
             self.ecs_conn.update_service,
             **update_parameters)
 
@@ -1071,9 +1071,9 @@ class Service(ECSBaseActor):
                     service_name, status))
         else:
             yield self._stop_service(service_name, existing_service)
-            yield self.thread(self.ecs_conn.delete_service,
-                              cluster=self.option('cluster'),
-                              service=service_name)
+            yield self.api_call(self.ecs_conn.delete_service,
+                                cluster=self.option('cluster'),
+                                service=service_name)
         if deregister:
             task_definition_names = yield self._list_task_definitions(
                 status='ACTIVE',

--- a/kingpin/actors/aws/elbv2.py
+++ b/kingpin/actors/aws/elbv2.py
@@ -101,7 +101,7 @@ class RegisterInstance(base.AWSBaseActor):
         targets = [{'Id': t} for t in targets]
 
         try:
-            yield self.thread(
+            yield self.api_call(
                 self.elbv2_conn.register_targets,
                 TargetGroupArn=arn,
                 Targets=targets)
@@ -185,7 +185,7 @@ class DeregisterInstance(base.AWSBaseActor):
         targets = [{'Id': t} for t in targets]
 
         try:
-            yield self.thread(
+            yield self.api_call(
                 self.elbv2_conn.deregister_targets,
                 TargetGroupArn=arn,
                 Targets=targets)

--- a/kingpin/actors/aws/iam/certs.py
+++ b/kingpin/actors/aws/iam/certs.py
@@ -92,7 +92,7 @@ class UploadCert(base.IAMBaseActor):
     @gen.coroutine
     def _upload(self, cert_name, cert_body, private_key, cert_chain, path):
         """Create a new server certificate in AWS IAM."""
-        yield self.thread(
+        yield self.api_call(
             self.iam_conn.upload_server_cert,
             cert_name=cert_name,
             cert_body=cert_body,
@@ -164,7 +164,7 @@ class DeleteCert(base.IAMBaseActor):
 
         self.log.debug('Searching for cert "%s"...' % name)
         try:
-            yield self.thread(self.iam_conn.get_server_certificate, name)
+            yield self.api_call(self.iam_conn.get_server_certificate, name)
         except BotoServerError as e:
             raise exceptions.UnrecoverableActorFailure(
                 'Could not find cert %s. Reason: %s' % (name, e))
@@ -172,7 +172,7 @@ class DeleteCert(base.IAMBaseActor):
     @gen.coroutine
     def _delete(self, cert_name):
         """Delete a server certificate in AWS IAM."""
-        yield self.thread(self.iam_conn.delete_server_cert, cert_name)
+        yield self.api_call(self.iam_conn.delete_server_cert, cert_name)
 
     @gen.coroutine
     def _execute(self):

--- a/kingpin/actors/aws/iam/entities.py
+++ b/kingpin/actors/aws/iam/entities.py
@@ -1037,8 +1037,9 @@ class InstanceProfile(EntityBaseActor):
 
         try:
             self.log.info('Removing role %s from %s' % (role, name))
-            yield self.api_call(self.iam_conn.remove_role_from_instance_profile,
-                                name, role)
+            yield self.api_call(
+                self.iam_conn.remove_role_from_instance_profile,
+                name, role)
         except BotoServerError as e:
             if e.status != 404:
                 raise exceptions.RecoverableActorFailure(

--- a/kingpin/actors/aws/test/test_api_call_queue.py
+++ b/kingpin/actors/aws/test/test_api_call_queue.py
@@ -1,0 +1,385 @@
+import logging
+import time
+
+from boto import exception as boto_exception
+from botocore import exceptions as botocore_exceptions
+from tornado import concurrent
+from tornado import gen
+from tornado import testing
+
+from kingpin.actors.aws import api_call_queue
+
+log = logging.getLogger(__name__)
+
+
+class TestApiCallQueue(testing.AsyncTestCase):
+    boto2_exception = boto_exception.BotoServerError(
+        '400', 'Bad request',
+        {'Error': {'Code': 'Bad request'}})
+    boto2_throttle_exception_1 = boto_exception.BotoServerError(
+        '429', 'Rate limit',
+        {'Error': {'Code': 'Throttling'}})
+    boto2_throttle_exception_2 = boto_exception.BotoServerError(
+        '429', 'Rate limit',
+        {'Error': {'Code': 'Rate exceeded'}})
+    boto2_throttle_exception_3 = boto_exception.BotoServerError(
+        '429', 'Rate limit',
+        {'Error': {'Code': 'reached max retries'}})
+
+    boto3_exception = botocore_exceptions.ClientError(
+        {'Error': {'Code': 'Bad request'}}, 'Test')
+    boto3_throttle_exception = botocore_exceptions.ClientError(
+        {'Error': {'Code': 'Throttling'}}, 'Test')
+
+    def setUp(self):
+        super(TestApiCallQueue, self).setUp()
+        self.api_call_queue = api_call_queue.ApiCallQueue()
+        self.api_call_queue.delay_min = 0.05
+        self.api_call_queue.delay_max = 0.2
+
+        self.executor = concurrent.futures.ThreadPoolExecutor(10)
+
+    @testing.gen_test
+    def test_plain_call(self):
+        """Test that a single api call through the queue works."""
+        result = yield self.api_call_queue.call(self._mock_api_function_sync)
+        self.assertEqual(result, 'OK')
+
+    @testing.gen_test
+    def test_concurrent_calls_with_delay(self):
+        """
+        Test concurrent calls with some latency run serially
+        and return independent results.
+
+        The api_call_queue runs calls synchronously and serially.
+        """
+        api_call_queue_calls = [
+            self.api_call_queue.call(
+                self._mock_api_function_sync, result=1, delay=0.05),
+            self.api_call_queue.call(
+                self._mock_api_function_sync, result=2, delay=0.05),
+            self.api_call_queue.call(
+                self._mock_api_function_sync, result=3, delay=0.05),
+            self.api_call_queue.call(
+                self._mock_api_function_sync, result=4, delay=0.05),
+            self.api_call_queue.call(
+                self._mock_api_function_sync, result=5, delay=0.05),
+        ]
+
+        start = time.time()
+        results = yield gen.multi(api_call_queue_calls)
+        stop = time.time()
+        run_time = stop - start
+
+        self.assertTrue(0.25 <= run_time < 0.35)
+        self.assertEqual(results, [1, 2, 3, 4, 5])
+
+    @testing.gen_test
+    def test_api_call_queue_future_is_nonblocking(self):
+        """
+        Test that the api call queue future is nonblocking for other futures.
+        It needs to execute in a different thread because of the synchronous
+        nature of AWS APIs.
+        """
+        futures = [
+            self.api_call_queue.call(
+                self._mock_api_function_sync, result=1, delay=0.05),
+            self._mock_api_function_async(result=2, delay=0.05),
+            self._mock_api_function_async(result=3, delay=0.05),
+            self._mock_api_function_async(result=4, delay=0.05),
+            self._mock_api_function_async(result=5, delay=0.05),
+        ]
+
+        start = time.time()
+        results = yield gen.multi(futures)
+        stop = time.time()
+        run_time = stop - start
+
+        self.assertTrue(0.05 <= run_time < 0.15)
+        self.assertEqual(results, [1, 2, 3, 4, 5])
+
+    @testing.gen_test
+    def test_api_call_queue_raises_exceptions(self):
+        """
+        Test that the api call queue raises exceptions and proceeds to execute
+        other queued api calls.
+        """
+
+        @gen.coroutine
+        def _call_without_exception():
+            result = yield self.api_call_queue.call(
+                self._mock_api_function_sync, delay=0.05)
+            self.assertEqual(result, 'OK')
+            raise gen.Return('no exception')
+
+        @gen.coroutine
+        def _call_with_exception():
+            with self.assertRaises(ValueError):
+                yield self.api_call_queue.call(
+                    self._mock_api_function_sync,
+                    exception=ValueError('test exception'),
+                    delay=0.05)
+            raise gen.Return('exception')
+
+        @gen.coroutine
+        def _call_with_exception_after_boto2_rate_limit():
+            """
+            First rate limit, then raise an exception.
+            This should take:
+                call delay * 2 + min rate limiting delay * 1
+            """
+            with self.assertRaises(boto_exception.BotoServerError):
+                yield self.api_call_queue.call(
+                    self._mock_api_function_sync,
+                    exception=[
+                        self.boto2_throttle_exception_1,
+                        self.boto2_exception],
+                    delay=0.05)
+            raise gen.Return('exception')
+
+        @gen.coroutine
+        def _call_with_exception_after_boto3_rate_limit():
+            """
+            First rate limit, then raise an exception.
+            This should take:
+                call delay * 2 + min rate limiting delay * 1
+            """
+            with self.assertRaises(botocore_exceptions.ClientError):
+                yield self.api_call_queue.call(
+                    self._mock_api_function_sync,
+                    exception=[
+                        self.boto3_throttle_exception,
+                        self.boto3_exception],
+                    delay=0.05)
+            raise gen.Return('exception')
+
+        call_wrappers = [
+            # Should take 0.05s.
+            _call_without_exception(),
+            # Should take 0.05s.
+            _call_with_exception(),
+            # Should take 0.05s.
+            _call_without_exception(),
+            # Should take 0.05s + 0.05s + 0.05s.
+            _call_with_exception_after_boto2_rate_limit(),
+            # Should take 0.05s + 0.05s + 0.05s.
+            _call_with_exception_after_boto3_rate_limit(),
+        ]
+
+        start = time.time()
+        results = yield gen.multi(call_wrappers)
+        stop = time.time()
+        run_time = stop - start
+
+        self.assertTrue(0.45 <= run_time < 0.55)
+        self.assertEqual(
+            results,
+            ['no exception', 'exception', 'no exception',
+             'exception', 'exception'])
+
+    @testing.gen_test
+    def test_rate_limiting_boto2(self):
+        """
+        Test that rate limiting with boto2 works.
+        """
+        # Each one of these will raise a throttling exception, then succeed.
+        # Between calls, each should delay for 1 cycle of `delay_min`.
+        # Delay min is 0.05s, so total runtime should be ~0.15s.
+        api_call_queue_calls = [
+            self.api_call_queue.call(
+                self._mock_api_function_sync,
+                result=1,
+                exception=[self.boto2_throttle_exception_1]),
+            self.api_call_queue.call(
+                self._mock_api_function_sync,
+                result=2,
+                exception=[self.boto2_throttle_exception_2]),
+            self.api_call_queue.call(
+                self._mock_api_function_sync,
+                result=3,
+                exception=[self.boto2_throttle_exception_3]),
+        ]
+
+        start = time.time()
+        results = yield gen.multi(api_call_queue_calls)
+        stop = time.time()
+        run_time = stop - start
+
+        self.assertTrue(0.15 <= run_time < 0.25)
+        self.assertEqual(results, [1, 2, 3])
+
+    @testing.gen_test
+    def test_rate_limiting_boto3(self):
+        """
+        Test that rate limiting with boto3 works.
+        """
+        # Each one of these will raise a throttling exception, then succeed.
+        # Between calls, each should delay for 1 cycle of `delay_min`.
+        # Delay min is 0.05s, so total runtime should be ~0.15s.
+        api_call_queue_calls = [
+            self.api_call_queue.call(
+                self._mock_api_function_sync,
+                result=1,
+                exception=[self.boto3_throttle_exception]),
+            self.api_call_queue.call(
+                self._mock_api_function_sync,
+                result=2,
+                exception=[self.boto3_throttle_exception]),
+            self.api_call_queue.call(
+                self._mock_api_function_sync,
+                result=3,
+                exception=[self.boto3_throttle_exception]),
+        ]
+
+        start = time.time()
+        results = yield gen.multi(api_call_queue_calls)
+        stop = time.time()
+        run_time = stop - start
+
+        self.assertTrue(0.15 <= run_time < 0.25)
+        self.assertEqual(results, [1, 2, 3])
+
+    @testing.gen_test
+    def test_rate_limit_stepping(self):
+        """
+        Test that rate limiting steps delay up and down.
+        """
+
+        # The delay will step from delay_min to delay_max by doubling.
+        # 0s -> 0.05s -> 0.10s -> 0.20s.
+        # When a call succeeds, the delay goes back down a step.
+
+        def _throttle_twice(result):
+            # This will raise two throttling exception, then succeed.
+            # Because of that, this should end with the delay going up
+            # one step.
+            return self.api_call_queue.call(
+                self._mock_api_function_sync,
+                result=result,
+                exception=[
+                    self.boto2_throttle_exception_1,
+                    self.boto3_throttle_exception])
+
+        api_call_queue_calls = [
+            _throttle_twice(result=1),
+        ]
+
+        start = time.time()
+        results = yield gen.multi(api_call_queue_calls)
+        stop = time.time()
+        run_time = stop - start
+
+        # Delay should be up one step total: delay_min.
+
+        self.assertEqual(
+            self.api_call_queue.delay,
+            self.api_call_queue.delay_min)
+        self.assertTrue(0.15 <= run_time < 0.25)
+        self.assertEqual(results, [1])
+
+        # Do it again, to go up one more step.
+
+        api_call_queue_calls = [
+            _throttle_twice(result=2),
+        ]
+
+        start = time.time()
+        results = yield gen.multi(api_call_queue_calls)
+        stop = time.time()
+        run_time = stop - start
+
+        # Delay should be up two steps total: delay_min * 2.
+
+        self.assertEqual(
+            self.api_call_queue.delay,
+            self.api_call_queue.delay_min * 2)
+        self.assertTrue(0.35 <= run_time < 0.45)
+        self.assertEqual(results, [2])
+
+        # Do it again, to go up one more step.
+
+        api_call_queue_calls = [
+            _throttle_twice(result=3),
+        ]
+
+        start = time.time()
+        results = yield gen.multi(api_call_queue_calls)
+        stop = time.time()
+        run_time = stop - start
+
+        # Delay should be up to delay_min * 2 again,
+        # because it always goes down once it succeeds,
+        # but total runtime should be ~0.5s:
+        # (0delay_min * 2 + delay_max + delay_max).
+
+        self.assertEqual(
+            self.api_call_queue.delay,
+            self.api_call_queue.delay_min * 2)
+        self.assertTrue(0.5 <= run_time < 0.6)
+        self.assertEqual(results, [3])
+
+        # Now do it with successes to step back down.
+
+        api_call_queue_calls = [
+            self.api_call_queue.call(
+                self._mock_api_function_sync, result=4),
+            self.api_call_queue.call(
+                self._mock_api_function_sync, result=5),
+            self.api_call_queue.call(
+                self._mock_api_function_sync, result=6),
+        ]
+
+        start = time.time()
+        results = yield gen.multi(api_call_queue_calls)
+        stop = time.time()
+        run_time = stop - start
+
+        # Delay should be up to 0 again.
+        # Total runtime should be ~0.15s:
+        # (delay_min * 2 + delay_min).
+
+        self.assertEqual(self.api_call_queue.delay, 0)
+        self.assertTrue(0.15 <= run_time < 0.25)
+        self.assertEqual(results, [4, 5, 6])
+
+    def _mock_api_function_sync(self, result='OK',
+                                exception=None,
+                                delay=None):
+        """
+        Mock a synchronous call to AWS.
+
+        Args:
+            result: Value to return.
+            exception:
+                If this is an exception:
+
+                Raise instead of returning.
+
+                If this is a list:
+
+                Raise and pop off the first exception
+                instead of returning.
+                On subsequent calls, the next exception will be raised.
+                If the list is exhausted, it will not raise an exception.
+            delay: If set, delay before returning a result or exception.
+
+        Returns:
+            This will return `result`.
+            If `result` is not set, this will return the string 'OK'.
+        """
+        if delay is not None:
+            time.sleep(delay)
+        if exception is not None:
+            if isinstance(exception, Exception):
+                raise exception
+            elif len(exception) > 0:
+                raise exception.pop(0)
+
+        return result
+
+    @concurrent.run_on_executor
+    def _mock_api_function_async(self, *args, **kwargs):
+        """
+        Wrapper around _mock_api_function_sync that runs it on another thread.
+        """
+        return self._mock_api_function_sync(*args, **kwargs)

--- a/kingpin/actors/aws/test/test_base.py
+++ b/kingpin/actors/aws/test/test_base.py
@@ -93,6 +93,32 @@ class TestBase(testing.AsyncTestCase):
             yield actor._find_elb('')
 
     @testing.gen_test
+    def test_api_call_queue_400(self):
+        actor = base.AWSBaseActor('Unit Test Action', {})
+        actor.elb_conn = mock.Mock()
+        actor.elb_conn.get_all_load_balancers = mock.MagicMock()
+        exc = BotoServerError(400, 'Bad Request')
+        actor.elb_conn.get_all_load_balancers.side_effect = exc
+
+        with self.assertRaises(exceptions.InvalidCredentials):
+            yield actor.api_call_with_queueing(
+                actor.elb_conn.get_all_load_balancers,
+                queue_name='get_all_load_balancers')
+
+    @testing.gen_test
+    def test_api_call_queue_403(self):
+        actor = base.AWSBaseActor('Unit Test Action', {})
+        actor.elb_conn = mock.Mock()
+        actor.elb_conn.get_all_load_balancers = mock.MagicMock()
+        exc = BotoServerError(403, 'The security token')
+        actor.elb_conn.get_all_load_balancers.side_effect = exc
+
+        with self.assertRaises(exceptions.InvalidCredentials):
+            yield actor.api_call_with_queueing(
+                actor.elb_conn.get_all_load_balancers,
+                queue_name='get_all_load_balancers')
+
+    @testing.gen_test
     def test_find_elb(self):
         actor = base.AWSBaseActor('Unit Test Action', {})
         actor.elb_conn = mock.Mock()

--- a/kingpin/actors/aws/test/test_base.py
+++ b/kingpin/actors/aws/test/test_base.py
@@ -71,7 +71,7 @@ class TestBase(testing.AsyncTestCase):
         self.assertEquals(actor.ec2_conn.region.name, 'us-west-1')
 
     @testing.gen_test
-    def test_thread_400(self):
+    def test_api_call_400(self):
         actor = base.AWSBaseActor('Unit Test Action', {})
         actor.elb_conn = mock.Mock()
         actor.elb_conn.get_all_load_balancers = mock.MagicMock()
@@ -82,7 +82,7 @@ class TestBase(testing.AsyncTestCase):
             yield actor._find_elb('')
 
     @testing.gen_test
-    def test_thread_403(self):
+    def test_api_call_403(self):
         actor = base.AWSBaseActor('Unit Test Action', {})
         actor.elb_conn = mock.Mock()
         actor.elb_conn.get_all_load_balancers = mock.MagicMock()

--- a/kingpin/actors/aws/test/test_base.py
+++ b/kingpin/actors/aws/test/test_base.py
@@ -168,7 +168,7 @@ class TestBase(testing.AsyncTestCase):
     def test_find_target_group_exception_error(self):
         actor = base.AWSBaseActor('Unit Test Action', {})
         c_mock = mock.Mock()
-        exc = botocore.exceptions.ClientError({'Error': {}}, 'Test')
+        exc = botocore.exceptions.ClientError({'Error': {'Code': ''}}, 'Test')
         c_mock.describe_target_groups.side_effect = exc
         actor.elbv2_conn = c_mock
 

--- a/kingpin/actors/aws/test/test_cloudformation.py
+++ b/kingpin/actors/aws/test/test_cloudformation.py
@@ -6,6 +6,7 @@ from botocore.exceptions import ClientError
 from tornado import testing
 import mock
 
+from kingpin.actors.aws import base
 from kingpin.actors.aws import settings
 from kingpin.actors.aws import cloudformation
 from kingpin.actors.test.helper import tornado_value
@@ -59,6 +60,10 @@ class TestCloudFormationBaseActor(testing.AsyncTestCase):
         self.actor = cloudformation.CloudFormationBaseActor(
             'unittest', {'region': 'us-east-1'})
         self.actor.cf3_conn = mock.MagicMock(name='cf3_conn')
+
+        # Need to recreate the api call queues between tests
+        # because nose creates a new ioloop per test run.
+        base.NAMED_API_CALL_QUEUES = {}
 
     def test_discover_noecho_params(self):
         file = 'examples/test/aws.cloudformation/cf.integration.json'
@@ -355,6 +360,9 @@ class TestCreate(testing.AsyncTestCase):
         settings.AWS_SECRET_ACCESS_KEY = 'unit-test'
         settings.RETRYING_SETTINGS = {'stop_max_attempt_number': 1}
         reload(cloudformation)
+        # Need to recreate the api call queues between tests
+        # because nose creates a new ioloop per test run.
+        base.NAMED_API_CALL_QUEUES = {}
 
     @testing.gen_test
     def test_create_stack_file(self):
@@ -551,6 +559,9 @@ class TestDelete(testing.AsyncTestCase):
         settings.AWS_SECRET_ACCESS_KEY = 'unit-test'
         settings.RETRYING_SETTINGS = {'stop_max_attempt_number': 1}
         reload(cloudformation)
+        # Need to recreate the api call queues between tests
+        # because nose creates a new ioloop per test run.
+        base.NAMED_API_CALL_QUEUES = {}
 
     @testing.gen_test
     def test_execute(self):
@@ -596,6 +607,9 @@ class TestStack(testing.AsyncTestCase):
         settings.AWS_SECRET_ACCESS_KEY = 'unit-test'
         settings.RETRYING_SETTINGS = {'stop_max_attempt_number': 1}
         reload(cloudformation)
+        # Need to recreate the api call queues between tests
+        # because nose creates a new ioloop per test run.
+        base.NAMED_API_CALL_QUEUES = {}
 
         self.actor = cloudformation.Stack(
             options={

--- a/kingpin/actors/aws/test/test_elbv2.py
+++ b/kingpin/actors/aws/test/test_elbv2.py
@@ -43,7 +43,7 @@ class TestRegisterInstance(testing.AsyncTestCase):
             'region': 'us-east-1',
             'instances': 'test'})
         actor.elbv2_conn = mock.Mock()
-        exc = botocore.exceptions.ClientError({'Error': {}}, 'Test')
+        exc = botocore.exceptions.ClientError({'Error': {'Code': ''}}, 'Test')
         actor.elbv2_conn.register_targets.side_effect = exc
 
         with self.assertRaises(exceptions.UnrecoverableActorFailure):
@@ -110,7 +110,7 @@ class TestDeregisterInstance(testing.AsyncTestCase):
             'region': 'us-east-1',
             'instances': 'test'})
         actor.elbv2_conn = mock.Mock()
-        exc = botocore.exceptions.ClientError({'Error': {}}, 'Test')
+        exc = botocore.exceptions.ClientError({'Error': {'Code': ''}}, 'Test')
         actor.elbv2_conn.deregister_targets.side_effect = exc
 
         with self.assertRaises(exceptions.UnrecoverableActorFailure):

--- a/kingpin/actors/aws/test/test_s3.py
+++ b/kingpin/actors/aws/test/test_s3.py
@@ -163,7 +163,7 @@ class TestBucket(testing.AsyncTestCase):
     @testing.gen_test
     def test_delete_bucket_409(self):
         self.actor.s3_conn.delete_bucket.side_effect = ClientError(
-            {'Error': {}}, 'Error')
+            {'Error': {'Code': ''}}, 'Error')
         with self.assertRaises(exceptions.RecoverableActorFailure):
             yield self.actor._delete_bucket()
 
@@ -184,7 +184,7 @@ class TestBucket(testing.AsyncTestCase):
     def test_get_policy_empty(self):
         self.actor._bucket_exists = True
         self.actor.s3_conn.get_bucket_policy.side_effect = ClientError(
-            {'Error': {}}, 'NoSuchBucketPolicy')
+            {'Error': {'Code': ''}}, 'NoSuchBucketPolicy')
         ret = yield self.actor._get_policy()
         self.assertEquals('', ret)
 
@@ -192,7 +192,7 @@ class TestBucket(testing.AsyncTestCase):
     def test_get_policy_exc(self):
         self.actor._bucket_exists = True
         self.actor.s3_conn.get_bucket_policy.side_effect = ClientError(
-            {'Error': {}}, 'SomeOtherError')
+            {'Error': {'Code': ''}}, 'SomeOtherError')
         with self.assertRaises(ClientError):
             yield self.actor._get_policy()
 
@@ -237,7 +237,7 @@ class TestBucket(testing.AsyncTestCase):
     def test_set_policy_malformed_policy(self):
         self.actor.policy = {}
         self.actor.s3_conn.put_bucket_policy.side_effect = ClientError(
-            {'Error': {}}, 'MalformedPolicy')
+            {'Error': {'Code': ''}}, 'MalformedPolicy')
         with self.assertRaises(exceptions.RecoverableActorFailure):
             yield self.actor._set_policy()
 
@@ -248,7 +248,7 @@ class TestBucket(testing.AsyncTestCase):
     def test_set_policy_client_error(self):
         self.actor.policy = {}
         self.actor.s3_conn.put_bucket_policy.side_effect = ClientError(
-            {'Error': {}}, 'Some Other Error')
+            {'Error': {'Code': ''}}, 'Some Other Error')
         with self.assertRaises(exceptions.RecoverableActorFailure):
             yield self.actor._set_policy()
 
@@ -317,7 +317,7 @@ class TestBucket(testing.AsyncTestCase):
     @testing.gen_test
     def test_set_logging_client_error(self):
         self.actor.s3_conn.put_bucket_logging.side_effect = ClientError(
-            {'Error': {}}, 'Some error')
+            {'Error': {'Code': ''}}, 'Some error')
         with self.assertRaises(s3_actor.InvalidBucketConfig):
             yield self.actor._set_logging()
 
@@ -385,7 +385,7 @@ class TestBucket(testing.AsyncTestCase):
     def test_get_lifecycle_empty(self):
         self.actor._bucket_exists = True
         self.actor.s3_conn.get_bucket_lifecycle.side_effect = ClientError(
-            {'Error': {}}, 'NoSuchLifecycleConfiguration')
+            {'Error': {'Code': ''}}, 'NoSuchLifecycleConfiguration')
         ret = yield self.actor._get_lifecycle()
         self.assertEquals(ret, [])
 
@@ -393,7 +393,7 @@ class TestBucket(testing.AsyncTestCase):
     def test_get_lifecycle_clienterror(self):
         self.actor._bucket_exists = True
         self.actor.s3_conn.get_bucket_lifecycle.side_effect = ClientError(
-            {'Error': {}}, 'SomeOtherError')
+            {'Error': {'Code': ''}}, 'SomeOtherError')
         with self.assertRaises(ClientError):
             yield self.actor._get_lifecycle()
 
@@ -439,7 +439,7 @@ class TestBucket(testing.AsyncTestCase):
     @testing.gen_test
     def test_set_lifecycle_client_error(self):
         self.actor.s3_conn.put_bucket_lifecycle.side_effect = ClientError(
-            {'Error': {}}, 'Error')
+            {'Error': {'Code': ''}}, 'Error')
         with self.assertRaises(s3_actor.InvalidBucketConfig):
             yield self.actor._set_lifecycle()
 
@@ -481,7 +481,7 @@ class TestBucket(testing.AsyncTestCase):
     def test_get_tags_empty(self):
         self.actor._bucket_exists = True
         self.actor.s3_conn.get_bucket_tagging.side_effect = ClientError(
-            {'Error': {}}, 'NoSuchTagSet')
+            {'Error': {'Code': ''}}, 'NoSuchTagSet')
         ret = yield self.actor._get_tags()
         self.assertEquals(ret, [])
 
@@ -489,7 +489,7 @@ class TestBucket(testing.AsyncTestCase):
     def test_get_tags_exc(self):
         self.actor._bucket_exists = True
         self.actor.s3_conn.get_bucket_tagging.side_effect = ClientError(
-            {'Error': {}}, 'SomeOtherError')
+            {'Error': {'Code': ''}}, 'SomeOtherError')
         with self.assertRaises(ClientError):
             yield self.actor._get_tags()
 

--- a/kingpin/version.py
+++ b/kingpin/version.py
@@ -13,4 +13,4 @@
 # Copyright 2018 Nextdoor.com, Inc
 
 
-__version__ = '0.5.3'
+__version__ = '0.5.4'


### PR DESCRIPTION
This will serialize all the requests to the CloudFormation describe_stacks API to better protect against rate limits.

This is a pretty complicated implementation, and I don't like how it integrates with testing at the moment.
Each test creates a new ioloop, breaking the existing ApiCallQueues, as the process_queue callback will not be re-entered. Haven't figured out a way around this yet other than clearly the ApiCallQueues between tests.