### PR TITLE
Use PEP 508 URL formatting for easier Pip install

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -6,7 +6,7 @@ The simplest installation method is via
 
 .. code-block:: bash
 
-    $ pip install --process-dependency-links kingpin
+    $ pip install kingpin
 
 Note, we *strongly* recommend running the code inside a Python virtual
 environment. All of our examples below will show how to do this.
@@ -28,7 +28,7 @@ Github Checkout/Install
     Receiving objects: 100% (1824/1824), 283.35 KiB, done.
     Resolving deltas: 100% (1330/1330), done.
     (.venv)$ cd kingpin/
-    (.venv)$ python setup.py install
+    (.venv)$ pip install .
     zip_safe flag not set; analyzing archive contents...
     ...
 
@@ -42,7 +42,7 @@ Direct PIP Install
     Installing setuptools, pip...done.
     $ source .venv/bin/activate
     (.venv) $ git clone https://github.com/Nextdoor/kingpin
-    (.venv)$ pip install --process-dependency-links git+https://github.com/Nextdoor/kingpin.git
+    (.venv)$ pip install git+https://github.com/Nextdoor/kingpin.git
     Downloading/unpacking git+https://github.com/Nextdoor/kingpin.git
       Cloning https://github.com/Nextdoor/kingpin.git (to master) to /var/folders/j6/qyd2dp6n3f156h6xknndt35m00010b/T/pip-H9LwNt-build
     ...

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ retrying
 #
 # NOTE: Version specified in the setup.py file
 # NOTE: mock is used inside the rightscale actor
-python-rightscale>=0.1.7
+python-rightscale @ https://github.com/diranged/python-rightscale-1/tarball/nextdoor#egg=python-rightscale-0.1.7
 mock==1.0.1
 
 # kingpin.actors.aws

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ retrying
 #
 # NOTE: Version specified in the setup.py file
 # NOTE: mock is used inside the rightscale actor
-git+https://github.com/diranged/python-rightscale-1/tarball/nextdoor#egg=python-rightscale-0.1.7
+python-rightscale>=0.1.7
 mock==1.0.1
 
 # kingpin.actors.aws

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ retrying
 #
 # NOTE: Version specified in the setup.py file
 # NOTE: mock is used inside the rightscale actor
-python-rightscale>=0.1.7
+git+https://github.com/diranged/python-rightscale-1/tarball/nextdoor#egg=python-rightscale-0.1.7
 mock==1.0.1
 
 # kingpin.actors.aws

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,14 @@ def maybe_rm(path):
             os.remove(path)
 
 
+def read_requirements(requirements):
+    """Parse requirements from requirements.txt."""
+    reqs_path = requirements
+    with open(reqs_path, 'r') as f:
+        requirements = [line.rstrip() for line in f]
+    return requirements
+
+
 class Pep8Command(Command):
     description = 'Pep8 Lint Checks'
     user_options = []
@@ -161,12 +169,9 @@ setup(
     keywords='apache',
     packages=find_packages(),
     test_suite='nose.collector',
-    tests_require=open('%s/requirements.test.txt' % DIR).readlines(),
+    tests_require=read_requirements('%s/requirements.test.txt' % DIR),
     setup_requires=[],
-    install_requires=open('%s/requirements.txt' % DIR).readlines(),
-    dependency_links=[
-        'https://github.com/diranged/python-rightscale-1/tarball/nextdoor#egg=python-rightscale-0.1.7'
-    ],
+    install_requires=read_requirements('%s/requirements.txt' % DIR),
     entry_points={
         'console_scripts': [
             'kingpin = kingpin.bin.deploy:begin'

--- a/setup.py
+++ b/setup.py
@@ -163,7 +163,7 @@ setup(
     test_suite='nose.collector',
     tests_require=open('%s/requirements.test.txt' % DIR).readlines(),
     setup_requires=[],
-    #install_requires=open('%s/requirements.txt' % DIR).readlines(),
+    install_requires=open('%s/requirements.txt' % DIR).readlines(),
     dependency_links=[
         'https://github.com/diranged/python-rightscale-1/tarball/nextdoor#egg=python-rightscale-0.1.7'
     ],

--- a/setup.py
+++ b/setup.py
@@ -163,7 +163,7 @@ setup(
     test_suite='nose.collector',
     tests_require=open('%s/requirements.test.txt' % DIR).readlines(),
     setup_requires=[],
-    install_requires=open('%s/requirements.txt' % DIR).readlines(),
+    #install_requires=open('%s/requirements.txt' % DIR).readlines(),
     dependency_links=[
         'https://github.com/diranged/python-rightscale-1/tarball/nextdoor#egg=python-rightscale-0.1.7'
     ],


### PR DESCRIPTION
Thanks to https://github.com/pypa/pip/issues/4187#issuecomment-452862842, we can finally install
Kingpin easily with a simple `pip install` command.