### PR TITLE
Filter out ResolvedValue from the params

### DIFF
--- a/kingpin/actors/aws/test/test_cloudformation.py
+++ b/kingpin/actors/aws/test/test_cloudformation.py
@@ -659,7 +659,8 @@ class TestStack(testing.AsyncTestCase):
         remote = [
             {'ParameterKey': 'BucketName', 'ParameterValue': 'name'},
             {'ParameterKey': 'BucketPassword', 'ParameterValue': '***'},
-            {'ParameterKey': 'Metadata', 'ParameterValue': '2.0'}
+            {'ParameterKey': 'Metadata', 'ParameterValue': '2.0',
+             'ResolvedValue': 'Resolved'}
         ]
         ret = self.actor._diff_params_safely(remote, self.actor._parameters)
         self.assertEquals(True, ret)

--- a/kingpin/version.py
+++ b/kingpin/version.py
@@ -13,4 +13,4 @@
 # Copyright 2018 Nextdoor.com, Inc
 
 
-__version__ = '0.5.6'
+__version__ = '0.5.7'


### PR DESCRIPTION
When using SSM parameters the resolved values are returned for the stack. They can't be compared as the local params aren't resolved (obviously).