### PR TITLE
make kingpin.zip - remove process dep links option (deprecated)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ pack: kingpin.zip
 kingpin.zip:
 	rm -rf zip
 	mkdir -p zip
-	pip install --process-dependency-links --target ./zip ./
+	pip install --target ./zip ./
 	find ./zip -name '*.pyc' -delete
 	find ./zip -name '*.egg-info' | xargs rm -rf
 	cd zip; ln -sf kingpin/bin/deploy.py ./__main__.py


### PR DESCRIPTION
We already use PEP-0508, so we're good to go without this option.
https://www.python.org/dev/peps/pep-0508/#examples
https://mail.python.org/pipermail/distutils-sig/2013-October/022937.html