### PR TITLE
Log status reason on stack and change set failures

### DIFF
--- a/kingpin/actors/aws/cloudformation.py
+++ b/kingpin/actors/aws/cloudformation.py
@@ -379,7 +379,8 @@ class CloudFormationBaseActor(base.AWSBaseActor):
 
             # Lastly, if we get here, then something is very wrong and we got
             # some funky status back. Throw an exception.
-            msg = 'Unxpected stack state received (%s)' % stack['StackStatus']
+            msg = 'Unexpected stack state received (%s): %s' % (
+                stack['StackStatus'], stack['StackStatusReason'])
             raise StackFailed(msg)
 
     @gen.coroutine
@@ -1082,7 +1083,8 @@ class Stack(CloudFormationBaseActor):
 
             # Lastly, if we get here, then something is very wrong and we got
             # some funky status back. Throw an exception.
-            msg = 'Unxpected stack state received (%s)' % change[status_key]
+            msg = 'Unexpected stack state received (%s): %s' % (
+                change[status_key], change['StatusReason'])
             raise StackFailed(msg)
 
     def _print_change_set(self, change_set):

--- a/kingpin/actors/aws/test/test_cloudformation.py
+++ b/kingpin/actors/aws/test/test_cloudformation.py
@@ -22,6 +22,7 @@ def create_fake_stack(name, status):
         'CreationTime': datetime.datetime.now(),
         'StackName': name,
         'StackStatus': status,
+        'StackStatusReason': '',
         'EnableTerminationProtection': False,
         'Parameters': [
             {'ParameterKey': 'key1', 'ParameterValue': 'value1'}
@@ -1038,7 +1039,7 @@ class TestStack(testing.AsyncTestCase):
     def test_wait_until_change_set_ready_failed_status(self):
         available = {'Status': 'AVAILABLE'}
         update_in_progress = {'Status': 'UPDATE_IN_PROGRESS'}
-        update_failed = {'Status': 'UPDATE_FAILED'}
+        update_failed = {'Status': 'UPDATE_FAILED', 'StatusReason': 'Template error'}
         self.actor.cf3_conn.describe_change_set.side_effect = [
             available,
             update_in_progress,

--- a/kingpin/actors/aws/test/test_cloudformation.py
+++ b/kingpin/actors/aws/test/test_cloudformation.py
@@ -1039,7 +1039,10 @@ class TestStack(testing.AsyncTestCase):
     def test_wait_until_change_set_ready_failed_status(self):
         available = {'Status': 'AVAILABLE'}
         update_in_progress = {'Status': 'UPDATE_IN_PROGRESS'}
-        update_failed = {'Status': 'UPDATE_FAILED', 'StatusReason': 'Template error'}
+        update_failed = {
+            'Status': 'UPDATE_FAILED',
+            'StatusReason': 'Template error'
+        }
         self.actor.cf3_conn.describe_change_set.side_effect = [
             available,
             update_in_progress,


### PR DESCRIPTION
Display status reasons to clarify errors and improve debugging during kingpin runs.

`describe_stacks` returns a `StackStatusReason`: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-describing-stacks.html#using-cfn-describing-stacks-describe-stacks

`describe-change-set` returns a `StatusReason`: https://docs.aws.amazon.com/cli/latest/reference/cloudformation/describe-change-set.html#examples