### PR TITLE
Cancel cfn update on timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 build/
 docs/.ropeproject
 .DS_Store
+.idea
+idea/

--- a/kingpin/actors/aws/test/test_cloudformation.py
+++ b/kingpin/actors/aws/test/test_cloudformation.py
@@ -553,40 +553,6 @@ class TestCreate(testing.AsyncTestCase):
         actor._get_stack.return_value = tornado_value(None)
 
         yield actor._execute()
-
-    @testing.gen_test
-    def test_timeout(self):
-        # Create a quick mock.. so we can track whether or not API calls were
-        # actually made.
-        tracker = mock.MagicMock(name='tracker')
-
-        # Create a function and wrap it in our timeout
-        @gen.coroutine
-        def _execute():
-            tracker.reset_mock()
-            yield gen.Task(ioloop.IOLoop.current().add_timeout,
-                           time.time() + 0.2)
-            tracker.call_me()
-
-        self.actor._execute = _execute
-
-        # Set our timeout to 2s, test should work
-        self.actor._timeout = 1
-        yield self.actor.timeout(_execute)
-        tracker.assert_has_calls([mock.call.call_me()])
-
-        # Now set our timeout to 500ms. Exception should be raised, and the
-        # tracker should NOT be called.
-        self.actor._timeout = 0.1
-        with self.assertRaises(exceptions.ActorTimedOut):
-            yield self.actor.timeout(_execute)
-
-        # Set the timeout to 0, which disables it. No exception should be
-        # raised
-        self.actor._timeout = 0
-        yield self.actor.timeout(_execute)
-        self.actor_timeout = None
-        yield self.actor.timeout(_execute)
         
 
 class TestDelete(testing.AsyncTestCase):

--- a/kingpin/actors/aws/test/test_cloudformation.py
+++ b/kingpin/actors/aws/test/test_cloudformation.py
@@ -1,11 +1,15 @@
 import datetime
 import logging
 import json
+import time
 
 from botocore.exceptions import ClientError
+from tornado import gen
+from tornado import ioloop
 from tornado import testing
 import mock
 
+from kingpin.actors import exceptions
 from kingpin.actors.aws import base
 from kingpin.actors.aws import settings
 from kingpin.actors.aws import cloudformation
@@ -550,6 +554,40 @@ class TestCreate(testing.AsyncTestCase):
 
         yield actor._execute()
 
+    @testing.gen_test
+    def test_timeout(self):
+        # Create a quick mock.. so we can track whether or not API calls were
+        # actually made.
+        tracker = mock.MagicMock(name='tracker')
+
+        # Create a function and wrap it in our timeout
+        @gen.coroutine
+        def _execute():
+            tracker.reset_mock()
+            yield gen.Task(ioloop.IOLoop.current().add_timeout,
+                           time.time() + 0.2)
+            tracker.call_me()
+
+        self.actor._execute = _execute
+
+        # Set our timeout to 2s, test should work
+        self.actor._timeout = 1
+        yield self.actor.timeout(_execute)
+        tracker.assert_has_calls([mock.call.call_me()])
+
+        # Now set our timeout to 500ms. Exception should be raised, and the
+        # tracker should NOT be called.
+        self.actor._timeout = 0.1
+        with self.assertRaises(exceptions.ActorTimedOut):
+            yield self.actor.timeout(_execute)
+
+        # Set the timeout to 0, which disables it. No exception should be
+        # raised
+        self.actor._timeout = 0
+        yield self.actor.timeout(_execute)
+        self.actor_timeout = None
+        yield self.actor.timeout(_execute)
+        
 
 class TestDelete(testing.AsyncTestCase):
 
@@ -1188,3 +1226,37 @@ class TestStack(testing.AsyncTestCase):
         self.actor._ensure_stack = mock.MagicMock()
         self.actor._ensure_stack.return_value = tornado_value(None)
         yield self.actor._execute()
+        
+    @testing.gen_test
+    def test_timeout(self):
+        # Create a quick mock.. so we can track whether or not API calls were
+        # actually made.
+        tracker = mock.MagicMock(name='tracker')
+
+        # Create a function and wrap it in our timeout
+        @gen.coroutine
+        def _execute():
+            tracker.reset_mock()
+            yield gen.Task(ioloop.IOLoop.current().add_timeout,
+                           time.time() + 0.2)
+            tracker.call_me()
+        
+        self.actor._execute = _execute
+
+        # Set our timeout to 2s, test should work
+        self.actor._timeout = 1
+        yield self.actor._execution_timeout(_execute)
+        tracker.assert_has_calls([mock.call.call_me()])
+
+        # Now set our timeout to 500ms. Exception should be raised, and the
+        # tracker should NOT be called.
+        self.actor._timeout = 0.1
+        with self.assertRaises(exceptions.ActorTimedOut):
+            yield self.actor._execution_timeout(_execute)
+
+        # Set the timeout to 0, which disables it. No exception should be
+        # raised
+        self.actor._timeout = 0
+        yield self.actor._execution_timeout(_execute)
+        self.actor_timeout = None
+        yield self.actor._execution_timeout(_execute)

--- a/kingpin/actors/base.py
+++ b/kingpin/actors/base.py
@@ -378,7 +378,7 @@ class BaseActor(object):
 
         Parses the objects self._options dict (by converting it into a JSON
         string, substituting, and then turning it back into a dict) and the
-        self._desc string and replaces any {KEY}s with the valoues from the
+        self._desc string and replaces any {KEY}s with the values from the
         context dict that was supplied.
 
         Args:
@@ -478,7 +478,7 @@ class BaseActor(object):
         """
         self.log.debug('Beginning')
 
-        # Any exception thats raised by an actors _execute() method will
+        # Any exception that's raised by an actors _execute() method will
         # automatically cause actor failure and we return right away.
         result = None
 
@@ -488,7 +488,10 @@ class BaseActor(object):
             raise gen.Return()
 
         try:
-            result = yield self.timeout(self._execute)
+            if hasattr(self, '_execution_timeout'):
+                result = yield self._execution_timeout(self._execute)
+            else:
+                result = yield self.timeout(self._execute)
         except exceptions.ActorException as e:
             # If exception is not RecoverableActorFailure
             # or if warn_on_failure is not set, then escalate.
@@ -506,7 +509,7 @@ class BaseActor(object):
             # We don't like general exception catch clauses like this, but
             # because actors can be written by third parties and automatically
             # imported, its impossible for us to catch every exception
-            # possible. This is a failsafe thats meant to throw a strong
+            # possible. This is a failsafe that's meant to throw a strong
             # warning.
             log.critical('Unexpected exception caught! '
                          'Please contact the author (%s) and provide them '
@@ -594,7 +597,7 @@ class EnsurableBaseActor(BaseActor):
 
     # A list of option names that are _not_ automatically managed. These are
     # useful if you have special behaviors like 'commit' on change, or if you
-    # have parameters that are unmutable ('name').
+    # have parameters that are immutable ('name').
     unmanaged_options = []
 
     def __init__(self, *args, **kwargs):
@@ -753,7 +756,7 @@ class HTTPBaseActor(BaseActor):
 
         Sorts the arguments so that the returned string is predictable and in
         alphabetical order. Effectively wraps the tornado.httputil.url_concat
-        method and properly strips out None values, as well as lowercases
+        method and properly strips out None values, as well as lowercase
         Bool values.
 
         Args:
@@ -779,7 +782,7 @@ class HTTPBaseActor(BaseActor):
         return full_url
 
     # TODO: Add a retry/backoff timer here. If the remote endpoint returns
-    # garbled data (ie, maybe a 500 errror or something else thats not in
+    # garbled data (ie, maybe a 500 error or something else thats not in
     # JSON format, we should back off and try again.
     @gen.coroutine
     def _fetch(self, url, post=None, auth_username=None, auth_password=None):

--- a/kingpin/actors/test/test_base.py
+++ b/kingpin/actors/test/test_base.py
@@ -195,7 +195,7 @@ class TestBaseActor(testing.AsyncTestCase):
         
         # Set the _execution_timeout attr of an actor.
         self.actor._timeout = 2
-        self.actor._execution_timeout = self.actor.timeout
+        self._execution_timeout = self.actor.timeout
         yield self.actor.timeout(_execute)
 
     @testing.gen_test

--- a/kingpin/actors/test/test_base.py
+++ b/kingpin/actors/test/test_base.py
@@ -192,6 +192,10 @@ class TestBaseActor(testing.AsyncTestCase):
         yield self.actor.timeout(_execute)
         self.actor_timeout = None
         yield self.actor.timeout(_execute)
+        
+        # Set the _execution_timeout attr of an actor.
+        self.actor._execution_timeout = self.timeout
+        yield self.actor.timeout(_execute)
 
     @testing.gen_test
     def test_httplib_debugging(self):

--- a/kingpin/actors/test/test_base.py
+++ b/kingpin/actors/test/test_base.py
@@ -194,6 +194,7 @@ class TestBaseActor(testing.AsyncTestCase):
         yield self.actor.timeout(_execute)
         
         # Set the _execution_timeout attr of an actor.
+        self.actor._timeout = 2
         self.actor._execution_timeout = self.actor.timeout
         yield self.actor.timeout(_execute)
 

--- a/kingpin/actors/test/test_base.py
+++ b/kingpin/actors/test/test_base.py
@@ -194,7 +194,7 @@ class TestBaseActor(testing.AsyncTestCase):
         yield self.actor.timeout(_execute)
         
         # Set the _execution_timeout attr of an actor.
-        self.actor._execution_timeout = self.timeout
+        self.actor._execution_timeout = self.actor.timeout
         yield self.actor.timeout(_execute)
 
     @testing.gen_test


### PR DESCRIPTION
When we get into a state where our CloudFormation stack is unable to update, the Kingpin actor will time out. However, the stack then has to be cancelled (and therefore rolled back) manually, and this manual step has been missed several times before. 

This change is intended so that when the CloudFormation actor in particular times out, it will also cancel the stack update.