### PR TITLE
Better Exception Messages in AWS CFN Actors

### DIFF
--- a/kingpin/actors/aws/cloudformation.py
+++ b/kingpin/actors/aws/cloudformation.py
@@ -1085,7 +1085,8 @@ class Stack(CloudFormationBaseActor):
 
             # Lastly, if we get here, then something is very wrong and we got
             # some funky status back. Throw an exception.
-            msg = 'Unexpected stack Change Set state received (%s): %s' % (
+            msg = 'Unexpected Change Set state (%s) received (%s): %s' % (
+                status_key,
                 change[status_key],
                 change.get('StatusReason', 'StatusReason not provided.'))
             raise StackFailed(msg)

--- a/kingpin/actors/aws/cloudformation.py
+++ b/kingpin/actors/aws/cloudformation.py
@@ -381,8 +381,7 @@ class CloudFormationBaseActor(base.AWSBaseActor):
             # some funky status back. Throw an exception.
             msg = 'Unexpected Stack state (StackStatus) received (%s): %s' % (
                 stack['StackStatus'],
-                stack.get('StackStatusReason',
-                    'StackStatusReason not provided.'))
+                stack.get('StackStatusReason', 'StackStatusReason not provided.'))
             raise StackFailed(msg)
 
     @gen.coroutine

--- a/kingpin/actors/aws/cloudformation.py
+++ b/kingpin/actors/aws/cloudformation.py
@@ -379,7 +379,7 @@ class CloudFormationBaseActor(base.AWSBaseActor):
 
             # Lastly, if we get here, then something is very wrong and we got
             # some funky status back. Throw an exception.
-            msg = 'Unexpected Stack state received (%s): %s' % (
+            msg = 'Unexpected Stack state (StackStatus) received (%s): %s' % (
                 stack['StackStatus'],
                 stack.get('StackStatusReason',
                     'StackStatusReason not provided.'))

--- a/kingpin/actors/aws/cloudformation.py
+++ b/kingpin/actors/aws/cloudformation.py
@@ -381,7 +381,8 @@ class CloudFormationBaseActor(base.AWSBaseActor):
             # some funky status back. Throw an exception.
             msg = 'Unexpected Stack state (StackStatus) received (%s): %s' % (
                 stack['StackStatus'],
-                stack.get('StackStatusReason', 'StackStatusReason not provided.'))
+                stack.get('StackStatusReason',
+                'StackStatusReason not provided.'))
             raise StackFailed(msg)
 
     @gen.coroutine

--- a/kingpin/actors/aws/cloudformation.py
+++ b/kingpin/actors/aws/cloudformation.py
@@ -379,7 +379,10 @@ class CloudFormationBaseActor(base.AWSBaseActor):
 
             # Lastly, if we get here, then something is very wrong and we got
             # some funky status back. Throw an exception.
-            msg = 'Unxpected stack state received (%s)' % stack['StackStatus']
+            msg = 'Unexpected Stack state received (%s): %s' % (
+                stack['StackStatus'],
+                stack.get('StackStatusReason',
+                    'StackStatusReason not provided.'))
             raise StackFailed(msg)
 
     @gen.coroutine
@@ -1062,7 +1065,7 @@ class Stack(CloudFormationBaseActor):
             except ClientError as e:
                 # If we hit an intermittent error, lets just loop around and
                 # try again.
-                self.log.error('Error receiving change set state: %s' % e)
+                self.log.error('Error receiving Change Set state: %s' % e)
                 yield utils.tornado_sleep(sleep)
                 continue
 
@@ -1082,7 +1085,9 @@ class Stack(CloudFormationBaseActor):
 
             # Lastly, if we get here, then something is very wrong and we got
             # some funky status back. Throw an exception.
-            msg = 'Unxpected stack state received (%s)' % change[status_key]
+            msg = 'Unexpected stack Change Set state received (%s): %s' % (
+                change[status_key],
+                change.get('StatusReason', 'StatusReason not provided.'))
             raise StackFailed(msg)
 
     def _print_change_set(self, change_set):

--- a/kingpin/actors/aws/cloudformation.py
+++ b/kingpin/actors/aws/cloudformation.py
@@ -382,7 +382,7 @@ class CloudFormationBaseActor(base.AWSBaseActor):
             msg = 'Unexpected Stack state (StackStatus) received (%s): %s' % (
                 stack['StackStatus'],
                 stack.get('StackStatusReason',
-                        'StackStatusReason not provided.'))
+                          'StackStatusReason not provided.'))
             raise StackFailed(msg)
 
     @gen.coroutine

--- a/kingpin/actors/aws/cloudformation.py
+++ b/kingpin/actors/aws/cloudformation.py
@@ -382,7 +382,7 @@ class CloudFormationBaseActor(base.AWSBaseActor):
             msg = 'Unexpected Stack state (StackStatus) received (%s): %s' % (
                 stack['StackStatus'],
                 stack.get('StackStatusReason',
-                'StackStatusReason not provided.'))
+                        'StackStatusReason not provided.'))
             raise StackFailed(msg)
 
     @gen.coroutine

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,3 +45,6 @@ inflection
 
 # Hard-code this to pre-8.x to maintain Python 2.x support
 more-itertools<=5.0.0
+
+# Hard-code this to pre-2.0.0 to maintain Python 2.x support
+zipp<2.0.0


### PR DESCRIPTION
There are 3 CFN functions/states here that do slightly different things and it helps to know which function/state you are in when looking at kingpin errors.
1. Failed to create a stack (_wait_until_state)
2. Failed to create a change set (_wait_until_change_set_ready where status='Status')
3. Failed to execute a change set (ie. update a stack) (_wait_until_change_set_ready where status='ExecutionStatus')

Thanks to @smmorneau for originally finding where to edit these.
#481 
#482 