### PR TITLE
Downgrade zipp

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -45,3 +45,6 @@ inflection
 
 # Hard-code this to pre-8.x to maintain Python 2.x support
 more-itertools<=5.0.0
+
+# Hard-code this to pre-2.0.0 to maintain Python 2.x support
+zipp<2.0.0


### PR DESCRIPTION
zipp>=2.0.0 drops support for python 2.