### PR TITLE
Fix Snyk Integration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ retrying
 #
 # NOTE: Version specified in the setup.py file
 # NOTE: mock is used inside the rightscale actor
-python-rightscale @ https://github.com/diranged/python-rightscale-1/tarball/nextdoor#egg=python-rightscale-0.1.7
+python-rightscale @ https://github.com/diranged/python-rightscale-1/tarball/nextdoor#egg=python-rightscale
 mock==1.0.1
 
 # kingpin.actors.aws


### PR DESCRIPTION
Changing line 33 to `python-rightscale @ https://github.com/diranged/python-rightscale-1/tarball/nextdoor#egg=python-rightscale` will save the egg using the same names as the lib's name, which will allow Snyk to identify and link the library with its sources.