### PR TITLE
S3 Lifecycle Policy: Add Filter Option

### DIFF
--- a/kingpin/actors/aws/s3.py
+++ b/kingpin/actors/aws/s3.py
@@ -149,8 +149,7 @@ class LifecycleConfig(SchemaCompareBase):
     .. code-block:: json
 
         [
-          {
-            "id": "unique_rule_identifier",
+          { "id": "unique_rule_identifier",
             "filter": {
               "prefix": "/some_path"
             },
@@ -410,17 +409,17 @@ class Bucket(base.EnsurableAWSBaseActor):
       A list of indevitual Lifecycle configurations. Each dictionary includes
       keys for:
 
-        * `id`
-        * `status`
-        * `filter` (or `prefix`, which is deprecated)
+      * `id`
+      * `status`
+      * `filter` (or `prefix`, which is deprecated)
 
       and at least one of:
 
-        * `transition`
-        * `noncurrent_version_transition`
-        * `expiration`
-        * `noncurrent_version_expiration`
-        * `abort_incomplete_multipart_upload`
+      * `transition`
+      * `noncurrent_version_transition`
+      * `expiration`
+      * `noncurrent_version_expiration`
+      * `abort_incomplete_multipart_upload`
 
       If an empty list is supplied, or the list in any way does not match what
       is currently configured in Amazon, the appropriate changes will be made.
@@ -480,8 +479,7 @@ class Bucket(base.EnsurableAWSBaseActor):
            "region": "us-west-2",
            "policy": "./examples/aws.s3/amazon_put.json",
            "lifecycle": [
-              {
-                "id": "main",
+              { "id": "main",
                 "filter": {
                     "prefix": "/"
                 },

--- a/kingpin/actors/aws/s3.py
+++ b/kingpin/actors/aws/s3.py
@@ -406,7 +406,7 @@ class Bucket(base.EnsurableAWSBaseActor):
     :lifecycle:
       (:py:class:`LifecycleConfig`, None)
 
-      A list of indevitual Lifecycle configurations. Each dictionary includes
+      A list of individual Lifecycle configurations. Each dictionary includes
       keys for:
 
       * `id`

--- a/kingpin/actors/aws/s3.py
+++ b/kingpin/actors/aws/s3.py
@@ -254,8 +254,12 @@ class LifecycleConfig(SchemaCompareBase):
 
                 # Expiration and Transition can be empty, or have
                 # configurations associated with them.
+                #
+                # Note that we allow the actor to just accept a number of days
+                # instead of an object and we create the correct json with days
+                # in the init. Hence the object type of str/int/obj here.
                 'expiration': {
-                    'type': 'object',
+                    'type': ['string', 'integer', 'object'],
                     'pattern': '^[0-9]+$',
                     'additionalProperties': False,
                     'properties': {
@@ -397,7 +401,8 @@ class Bucket(base.EnsurableAWSBaseActor):
       (:py:class:`LifecycleConfig`, None)
 
       A list of individual Lifecycle configurations. Each dictionary includes
-      keys for the `id`, `prefix` and `status` as required parameters.
+      keys for the `id`, `status` as required parameters.
+      Optionally you can supply an `prefix` and/or `filter` dictionary.
       Optionally you can supply an `expiration` and/or `transition` dictionary.
 
       If an empty list is supplied, or the list in any way does not match what
@@ -874,7 +879,7 @@ class Bucket(base.EnsurableAWSBaseActor):
 
         try:
             raw = yield self.api_call(
-                self.s3_conn.get_bucket_lifecycle,
+                self.s3_conn.get_bucket_lifecycle_configuration,
                 Bucket=self.option('name'))
         except ClientError as e:
             if 'NoSuchLifecycleConfiguration' in e.message:

--- a/kingpin/actors/aws/s3.py
+++ b/kingpin/actors/aws/s3.py
@@ -409,15 +409,18 @@ class Bucket(base.EnsurableAWSBaseActor):
 
       A list of indevitual Lifecycle configurations. Each dictionary includes
       keys for:
-        - `id`
-        - `status`
-        - `filter` (or `prefix`, which is deprecated)
+
+        * `id`
+        * `status`
+        * `filter` (or `prefix`, which is deprecated)
+
       and at least one of:
-        - `transition`
-        - `noncurrent_version_transition`
-        - `expiration`
-        - `noncurrent_version_expiration`
-        - `abort_incomplete_multipart_upload`
+
+        * `transition`
+        * `noncurrent_version_transition`
+        * `expiration`
+        * `noncurrent_version_expiration`
+        * `abort_incomplete_multipart_upload`
 
       If an empty list is supplied, or the list in any way does not match what
       is currently configured in Amazon, the appropriate changes will be made.

--- a/kingpin/actors/aws/s3.py
+++ b/kingpin/actors/aws/s3.py
@@ -586,7 +586,7 @@ class Bucket(base.EnsurableAWSBaseActor):
             if not any(k in c for k in ('prefix', 'filter')):
                 raise InvalidBucketConfig(
                     'You must supply at least a prefix or filter '
-                    ' configuration in your config: %s' % c)
+                    'configuration in your config: %s' % c)
 
             # You must supply at least 'expiration' or 'transition' in your
             # lifecycle config. This is tricky to check in the jsonschema, so

--- a/kingpin/actors/aws/s3.py
+++ b/kingpin/actors/aws/s3.py
@@ -149,8 +149,11 @@ class LifecycleConfig(SchemaCompareBase):
     .. code-block:: json
 
         [
-          { "id": "unique_rule_identifier",
-            "prefix": "/some_path",
+          {
+            "id": "unique_rule_identifier",
+            "filter": {
+              "prefix": "/some_path"
+            },
             "status": "Enabled",
             "expiration": {
               "days": 365,
@@ -414,10 +417,17 @@ class Bucket(base.EnsurableAWSBaseActor):
     :lifecycle:
       (:py:class:`LifecycleConfig`, None)
 
-      A list of individual Lifecycle configurations. Each dictionary includes
-      keys for the `id`, `status` as required parameters.
-      Optionally you can supply an `prefix` and/or `filter` dictionary.
-      Optionally you can supply an `expiration` and/or `transition` dictionary.
+      A list of indevitual Lifecycle configurations. Each dictionary includes
+      keys for:
+        - `id`
+        - `status`
+        - `filter` (or `prefix`, which is deprecated)
+      and at least one of:
+        - `transition`
+        - `noncurrent_version_transition`
+        - `expiration`
+        - `noncurrent_version_expiration`
+        - `abort_incomplete_multipart_upload`
 
       If an empty list is supplied, or the list in any way does not match what
       is currently configured in Amazon, the appropriate changes will be made.
@@ -477,8 +487,11 @@ class Bucket(base.EnsurableAWSBaseActor):
            "region": "us-west-2",
            "policy": "./examples/aws.s3/amazon_put.json",
            "lifecycle": [
-              { "id": "main",
-                "prefix": "/",
+              {
+                "id": "main",
+                "filter": {
+                    "prefix": "/"
+                },
                 "status": "Enabled",
                 "expiration": 30,
               }

--- a/kingpin/actors/aws/s3.py
+++ b/kingpin/actors/aws/s3.py
@@ -931,7 +931,7 @@ class Bucket(base.EnsurableAWSBaseActor):
         self.log.info('Updating the Bucket Lifecycle config')
         try:
             yield self.api_call(
-                self.s3_conn.put_bucket_lifecycle,
+                self.s3_conn.put_bucket_lifecycle_configuration,
                 Bucket=self.option('name'),
                 LifecycleConfiguration={'Rules': self.lifecycle})
         except (ParamValidationError, ClientError) as e:

--- a/kingpin/actors/aws/s3.py
+++ b/kingpin/actors/aws/s3.py
@@ -175,6 +175,21 @@ class LifecycleConfig(SchemaCompareBase):
     """
 
     SCHEMA = {
+        'definitions': {
+            'tag': {
+                'type': 'object',
+                'required': ['key', 'value'],
+                'additionalProperties': False,
+                'properties': {
+                    'key': {
+                        'type': 'string',
+                    },
+                    'value': {
+                        'type': 'string',
+                    },
+                }
+            }
+        },
         # The outer wrapper must be a list of properly formatted objects,
         # or Null if we are not going to manage this configuration at all.
         'type': ['array', 'null'],
@@ -221,17 +236,7 @@ class LifecycleConfig(SchemaCompareBase):
                             'type': 'string',
                         },
                         'tag': {
-                            'type': 'object',
-                            'required': ['key', 'value'],
-                            'additionalProperties': False,
-                            'properties': {
-                                'key': {
-                                    'type': 'string',
-                                },
-                                'value': {
-                                    'type': 'string',
-                                },
-                            }
+                            '$ref': '#/definitions/tag'
                         },
                         'and': {
                             'type': 'object',
@@ -243,22 +248,7 @@ class LifecycleConfig(SchemaCompareBase):
                                     'type': 'string',
                                 },
                                 'tag': {
-                                    'type': 'array',
-                                    'uniqueItems': True,
-                                    'minItems': 1,
-                                    'items': {
-                                        'type': 'object',
-                                        'required': ['key', 'value'],
-                                        'additionalProperties': False,
-                                        'properties': {
-                                            'key': {
-                                                'type': 'string',
-                                            },
-                                            'value': {
-                                                'type': 'string',
-                                            },
-                                        }
-                                    }
+                                    '$ref': '#/definitions/tag'
                                 },
                             }
                         }

--- a/kingpin/actors/aws/s3.py
+++ b/kingpin/actors/aws/s3.py
@@ -178,40 +178,7 @@ class LifecycleConfig(SchemaCompareBase):
         'uniqueItems': True,
         'items': {
             'type': 'object',
-            'allOf': [
-                {
-                    'required': ['id', 'status'],
-                },
-                {
-                    'oneOf': [
-                        {
-                            'required': 'filter'
-                        },
-                        {
-                            'required': 'prefix'
-                        }
-                    ]
-                },
-                {
-                    'anyOf': [
-                        {
-                            'required': 'transition'
-                        },
-                        {
-                            'required': 'noncurrent_version_transition'
-                        },
-                        {
-                            'required': 'expiration'
-                        },
-                        {
-                            'required': 'noncurrent_version_expiration'
-                        },
-                        {
-                            'required': 'abort_incomplete_multipart_upload'
-                        }
-                    ]
-                }
-            ],
+            'required': ['id', 'status'],
             'additionalProperties': False,
             'properties': {
                 # The ID must be a string. We do not allow for it to be
@@ -219,21 +186,17 @@ class LifecycleConfig(SchemaCompareBase):
                 'id': {
                     'type': 'string',
                     'minLength': 1,
-                    'maxLength': 255
+                    'maxLength': 255,
                 },
-
-               # The Status field must be 'Enabled' or 'Disabled'
-                'status': {
+                'prefix': {
                     'type': 'string',
-                    'enum': ['Enabled', 'Disabled']
                 },
-
                 # Filter is a new way of defining rule prefixes
                 'filter': {
                     'type': 'object',
+                    'additionalProperties': False,
                     'minProperties': 1,
                     'maxProperties': 1,
-                    'additionalProperties': False,
                     'properties': {
                         'prefix': {
                             'type': 'string',
@@ -283,10 +246,36 @@ class LifecycleConfig(SchemaCompareBase):
                     }
                 },
 
-                'prefix': {
-                    'type': 'string'
+                # The Status field must be 'Enabled' or 'Disabled'
+                'status': {
+                    'type': 'string',
+                    'enum': ['Enabled', 'Disabled'],
                 },
 
+                # Expiration and Transition can be empty, or have
+                # configurations associated with them.
+                #
+                # Note that we allow the actor to just accept a number of days
+                # instead of an object and we create the correct json with days
+                # in the init. Hence the object type of str/int/obj here.
+                'expiration': {
+                    'type': ['string', 'integer', 'object'],
+                    'pattern': '^[0-9]+$',
+                    'additionalProperties': False,
+                    'properties': {
+                        'days': {
+                            'type': ['string', 'integer'],
+                            'pattern': '^[0-9]+$',
+                        },
+                        'date': {
+                            'type': 'string',
+                            'format': 'date-time',
+                        },
+                        'expired_object_delete_marker': {
+                            'type': 'boolean',
+                        }
+                    }
+                },
                 'transition': {
                     'type': 'object',
                     'required': ['storage_class'],
@@ -318,28 +307,6 @@ class LifecycleConfig(SchemaCompareBase):
                         'storage_class': {
                             'type': 'string',
                             'enum': ['GLACIER', 'STANDARD_IA']
-                        }
-                    }
-                },
-                #
-                # Note that we allow the actor to just accept a number of days
-                # instead of an object and we create the correct json with days
-                # in the init. Hence the object type of str/int/obj here.
-                'expiration': {
-                    'type': ['string', 'integer', 'object'],
-                    'pattern': '^[0-9]+$',
-                    'additionalProperties': False,
-                    'properties': {
-                        'days': {
-                            'type': ['string', 'integer'],
-                            'pattern': '^[0-9]+$',
-                        },
-                        'date': {
-                            'type': 'string',
-                            'format': 'date-time',
-                        },
-                        'expired_object_delete_marker': {
-                            'type': 'boolean',
                         }
                     }
                 },
@@ -612,6 +579,25 @@ class Bucket(base.EnsurableAWSBaseActor):
         rules = []
         for c in config:
             self.log.debug('Generating lifecycle rule from foo: %s' % c)
+
+            # You must supply at least 'prefix' or 'filter' in your
+            # lifecycle config. This is tricky to check in the jsonschema, so
+            # we do it here.
+            if not any(k in c for k in ('prefix', 'filter')):
+                raise InvalidBucketConfig(
+                    'You must supply at least a prefix or filter '
+                    'configuration in your config: %s' % c)
+
+            # You must supply at least 'expiration' or 'transition' in your
+            # lifecycle config. This is tricky to check in the jsonschema, so
+            # we do it here.
+            if not any(k in c for k in ('expiration', 'transition',
+                                        'abort_incomplete_multipart_upload',
+                                        'noncurrent_version_expiration',
+                                        'noncurrent_version_transition')):
+                raise InvalidBucketConfig(
+                    'You must supply at least an expiration or transition '
+                    'configuration in your config: %s' % c)
 
             # Convert the snake_case into CamelCase.
             c = self._snake_to_camel(c)

--- a/kingpin/actors/aws/s3.py
+++ b/kingpin/actors/aws/s3.py
@@ -585,8 +585,8 @@ class Bucket(base.EnsurableAWSBaseActor):
             # we do it here.
             if not any(k in c for k in ('prefix', 'filter')):
                 raise InvalidBucketConfig(
-                    'You must supply at least a prefix or filter configuration '
-                    'in your config: %s' % c)
+                    'You must supply at least a prefix or filter '
+                    ' configuration in your config: %s' % c)
 
             # You must supply at least 'expiration' or 'transition' in your
             # lifecycle config. This is tricky to check in the jsonschema, so

--- a/kingpin/actors/aws/s3.py
+++ b/kingpin/actors/aws/s3.py
@@ -178,30 +178,38 @@ class LifecycleConfig(SchemaCompareBase):
         'uniqueItems': True,
         'items': {
             'type': 'object',
-            'required': ['id', 'status'],
-            'oneOf': [
+            'allOf': [
                 {
-                    'required': 'filter'
+                    'required': ['id', 'status'],
                 },
                 {
-                    'required': 'prefix'
-                }
-            ],
-            'anyOf': [
-                {
-                    'required': 'transition'
+                    'oneOf': [
+                        {
+                            'required': 'filter'
+                        },
+                        {
+                            'required': 'prefix'
+                        }
+                    ]
                 },
                 {
-                    'required': 'noncurrent_version_transition'
-                },
-                {
-                    'required': 'expiration'
-                },
-                {
-                    'required': 'noncurrent_version_expiration'
-                },
-                {
-                    'required': 'abort_incomplete_multipart_upload'
+                    'anyOf': [
+                        {
+                            'required': 'transition'
+                        },
+                        {
+                            'required': 'noncurrent_version_transition'
+                        },
+                        {
+                            'required': 'expiration'
+                        },
+                        {
+                            'required': 'noncurrent_version_expiration'
+                        },
+                        {
+                            'required': 'abort_incomplete_multipart_upload'
+                        }
+                    ]
                 }
             ],
             'additionalProperties': False,

--- a/kingpin/actors/aws/test/test_s3.py
+++ b/kingpin/actors/aws/test/test_s3.py
@@ -397,16 +397,18 @@ class TestBucket(testing.AsyncTestCase):
     @testing.gen_test
     def test_get_lifecycle_empty(self):
         self.actor._bucket_exists = True
-        self.actor.s3_conn.get_bucket_lifecycle_configuration.side_effect = ClientError(
-            {'Error': {'Code': ''}}, 'NoSuchLifecycleConfiguration')
+        self.actor.s3_conn.get_bucket_lifecycle_configuration.side_effect = \
+            ClientError(
+                {'Error': {'Code': ''}}, 'NoSuchLifecycleConfiguration')
         ret = yield self.actor._get_lifecycle()
         self.assertEquals(ret, [])
 
     @testing.gen_test
     def test_get_lifecycle_clienterror(self):
         self.actor._bucket_exists = True
-        self.actor.s3_conn.get_bucket_lifecycle_configuration.side_effect = ClientError(
-            {'Error': {'Code': ''}}, 'SomeOtherError')
+        self.actor.s3_conn.get_bucket_lifecycle_configuration.side_effect = \
+            ClientError(
+                {'Error': {'Code': ''}}, 'SomeOtherError')
         with self.assertRaises(ClientError):
             yield self.actor._get_lifecycle()
 
@@ -444,15 +446,19 @@ class TestBucket(testing.AsyncTestCase):
     def test_set_lifecycle(self):
         self.actor.lifecycle = [{'test': 'test'}]
         yield self.actor._set_lifecycle()
-        self.actor.s3_conn.put_bucket_lifecycle_configuration.assert_has_calls([
-            mock.call(
-                Bucket='test',
-                LifecycleConfiguration={'Rules': [{'test': 'test'}]})])
+        self.actor.s3_conn.put_bucket_lifecycle_configuration.assert_has_calls(
+            [
+                mock.call(
+                    Bucket='test',
+                    LifecycleConfiguration={'Rules': [{'test': 'test'}]})
+            ]
+        )
 
     @testing.gen_test
     def test_set_lifecycle_client_error(self):
-        self.actor.s3_conn.put_bucket_lifecycle_configuration.side_effect = ClientError(
-            {'Error': {'Code': ''}}, 'Error')
+        self.actor.s3_conn.put_bucket_lifecycle_configuration.side_effect = \
+            ClientError(
+                {'Error': {'Code': ''}}, 'Error')
         with self.assertRaises(s3_actor.InvalidBucketConfig):
             yield self.actor._set_lifecycle()
 

--- a/kingpin/actors/aws/test/test_s3.py
+++ b/kingpin/actors/aws/test/test_s3.py
@@ -61,6 +61,13 @@ class TestBucket(testing.AsyncTestCase):
                         'invalid_data': 'bad_field'
                     }})
 
+    def test_generate_lifecycle_missing_prefix(self):
+        bad_config = [
+            {'id': 'test', 'state': 'Enabled'}
+        ]
+        with self.assertRaises(s3_actor.InvalidBucketConfig):
+            self.actor._generate_lifecycle(bad_config)
+
     def test_generate_lifecycle_missing_expiration(self):
         bad_config = [
             {'id': 'test', 'prefix': '/', 'state': 'Enabled'}

--- a/kingpin/actors/aws/test/test_s3.py
+++ b/kingpin/actors/aws/test/test_s3.py
@@ -29,9 +29,7 @@ class TestBucket(testing.AsyncTestCase):
                     'id': 'test',
                     'prefix': '/test',
                     'status': 'Enabled',
-                    'expiration': {
-                        'days': 30
-                    },
+                    'expiration': '30'
                     'transition': {
                         'days': 45,
                         'storage_class': 'GLACIER',

--- a/kingpin/actors/aws/test/test_s3.py
+++ b/kingpin/actors/aws/test/test_s3.py
@@ -29,7 +29,7 @@ class TestBucket(testing.AsyncTestCase):
                     'id': 'test',
                     'prefix': '/test',
                     'status': 'Enabled',
-                    'expiration': '30'
+                    'expiration': '30',
                     'transition': {
                         'days': 45,
                         'storage_class': 'GLACIER',

--- a/kingpin/actors/aws/test/test_s3.py
+++ b/kingpin/actors/aws/test/test_s3.py
@@ -59,6 +59,20 @@ class TestBucket(testing.AsyncTestCase):
                         'invalid_data': 'bad_field'
                     }})
 
+    def test_generate_lifecycle_missing_prefix(self):
+        bad_config = [
+            {'id': 'test', 'state': 'Enabled'}
+        ]
+        with self.assertRaises(s3_actor.InvalidBucketConfig):
+            self.actor._generate_lifecycle(bad_config)
+
+    def test_generate_lifecycle_missing_expiration(self):
+        bad_config = [
+            {'id': 'test', 'prefix': '/', 'state': 'Enabled'}
+        ]
+        with self.assertRaises(s3_actor.InvalidBucketConfig):
+            self.actor._generate_lifecycle(bad_config)
+
     def test_generate_lifecycle_valid_config(self):
         # Validates that the generated config called by the __init__ class is
         # correct based on the actor configuration in the setUp() method above

--- a/kingpin/actors/aws/test/test_s3.py
+++ b/kingpin/actors/aws/test/test_s3.py
@@ -29,7 +29,9 @@ class TestBucket(testing.AsyncTestCase):
                     'id': 'test',
                     'prefix': '/test',
                     'status': 'Enabled',
-                    'expiration': "30",
+                    'expiration': {
+                        'days': 30
+                    },
                     'transition': {
                         'days': 45,
                         'storage_class': 'GLACIER',
@@ -376,7 +378,7 @@ class TestBucket(testing.AsyncTestCase):
     @testing.gen_test
     def test_get_lifecycle(self):
         self.actor._bucket_exists = True
-        self.actor.s3_conn.get_bucket_lifecycle.return_value = {
+        self.actor.s3_conn.get_bucket_lifecycle_configuration.return_value = {
             'Rules': []}
         ret = yield self.actor._get_lifecycle()
         self.assertEquals(ret, [])
@@ -390,7 +392,7 @@ class TestBucket(testing.AsyncTestCase):
     @testing.gen_test
     def test_get_lifecycle_empty(self):
         self.actor._bucket_exists = True
-        self.actor.s3_conn.get_bucket_lifecycle.side_effect = ClientError(
+        self.actor.s3_conn.get_bucket_lifecycle_configuration.side_effect = ClientError(
             {'Error': {'Code': ''}}, 'NoSuchLifecycleConfiguration')
         ret = yield self.actor._get_lifecycle()
         self.assertEquals(ret, [])
@@ -398,7 +400,7 @@ class TestBucket(testing.AsyncTestCase):
     @testing.gen_test
     def test_get_lifecycle_clienterror(self):
         self.actor._bucket_exists = True
-        self.actor.s3_conn.get_bucket_lifecycle.side_effect = ClientError(
+        self.actor.s3_conn.get_bucket_lifecycle_configuration.side_effect = ClientError(
             {'Error': {'Code': ''}}, 'SomeOtherError')
         with self.assertRaises(ClientError):
             yield self.actor._get_lifecycle()
@@ -407,7 +409,7 @@ class TestBucket(testing.AsyncTestCase):
     def test_compare_lifecycle(self):
         self.actor._bucket_exists = True
         self.actor.lifecycle = [{'test': 'test'}]
-        self.actor.s3_conn.get_bucket_lifecycle.return_value = {
+        self.actor.s3_conn.get_bucket_lifecycle_configuration.return_value = {
             'Rules': [{'test': 'test'}]}
         ret = yield self.actor._compare_lifecycle()
         self.assertTrue(ret)
@@ -421,7 +423,7 @@ class TestBucket(testing.AsyncTestCase):
     @testing.gen_test
     def test_compare_lifecycle_diff(self):
         self.actor.lifecycle = [{'test1': 'test'}]
-        self.actor.s3_conn.get_bucket_lifecycle.return_value = {
+        self.actor.s3_conn.get_bucket_lifecycle_configuration.return_value = {
             'Rules': [{'test': 'test'}]}
         ret = yield self.actor._compare_lifecycle()
         self.assertFalse(ret)
@@ -437,14 +439,14 @@ class TestBucket(testing.AsyncTestCase):
     def test_set_lifecycle(self):
         self.actor.lifecycle = [{'test': 'test'}]
         yield self.actor._set_lifecycle()
-        self.actor.s3_conn.put_bucket_lifecycle.assert_has_calls([
+        self.actor.s3_conn.put_bucket_lifecycle_configuration.assert_has_calls([
             mock.call(
                 Bucket='test',
                 LifecycleConfiguration={'Rules': [{'test': 'test'}]})])
 
     @testing.gen_test
     def test_set_lifecycle_client_error(self):
-        self.actor.s3_conn.put_bucket_lifecycle.side_effect = ClientError(
+        self.actor.s3_conn.put_bucket_lifecycle_configuration.side_effect = ClientError(
             {'Error': {'Code': ''}}, 'Error')
         with self.assertRaises(s3_actor.InvalidBucketConfig):
             yield self.actor._set_lifecycle()

--- a/kingpin/actors/aws/test/test_s3.py
+++ b/kingpin/actors/aws/test/test_s3.py
@@ -59,20 +59,6 @@ class TestBucket(testing.AsyncTestCase):
                         'invalid_data': 'bad_field'
                     }})
 
-    def test_generate_lifecycle_missing_prefix(self):
-        bad_config = [
-            {'id': 'test', 'state': 'Enabled'}
-        ]
-        with self.assertRaises(s3_actor.InvalidBucketConfig):
-            self.actor._generate_lifecycle(bad_config)
-
-    def test_generate_lifecycle_missing_expiration(self):
-        bad_config = [
-            {'id': 'test', 'prefix': '/', 'state': 'Enabled'}
-        ]
-        with self.assertRaises(s3_actor.InvalidBucketConfig):
-            self.actor._generate_lifecycle(bad_config)
-
     def test_generate_lifecycle_valid_config(self):
         # Validates that the generated config called by the __init__ class is
         # correct based on the actor configuration in the setUp() method above


### PR DESCRIPTION
AWS added a new API to change some of the functionality slightly. You can now use Filter>Prefix instead of just Prefix to add multiple lifecycle policy rules onto the same prefixes. Not quite sure how it determines which policy wins but I will leave that as an exercise for the reader.