### PR TITLE
S3 LCP: Fix Transitions API Key

### DIFF
--- a/kingpin/actors/aws/s3.py
+++ b/kingpin/actors/aws/s3.py
@@ -258,37 +258,43 @@ class LifecycleConfig(SchemaCompareBase):
                 },
 
                 # Action Properties
-                'transition': {
-                    'type': 'object',
-                    'required': ['storage_class'],
-                    'additionalProperties': False,
-                    'properties': {
-                        'days': {
-                            'type': ['string', 'integer'],
-                            'pattern': '^[0-9]+$',
-                        },
-                        'date': {
-                            'type': 'string',
-                            'format': 'date-time'
-                        },
-                        'storage_class': {
-                            'type': 'string',
-                            'enum': ['GLACIER', 'STANDARD_IA']
+                'transitions': {
+                    'type': 'array',
+                    'items': {
+                        'type': 'object',
+                        'required': ['storage_class'],
+                        'additionalProperties': False,
+                        'properties': {
+                            'days': {
+                                'type': ['string', 'integer'],
+                                'pattern': '^[0-9]+$',
+                            },
+                            'date': {
+                                'type': 'string',
+                                'format': 'date-time'
+                            },
+                            'storage_class': {
+                                'type': 'string',
+                                'enum': ['GLACIER', 'STANDARD_IA']
+                            }
                         }
                     }
                 },
-                'noncurrent_version_transition': {
-                    'type': 'object',
-                    'required': ['storage_class'],
-                    'additionalProperties': False,
-                    'properties': {
-                        'noncurrent_days': {
-                            'type': ['string', 'integer'],
-                            'pattern': '^[0-9]+$',
-                        },
-                        'storage_class': {
-                            'type': 'string',
-                            'enum': ['GLACIER', 'STANDARD_IA']
+                'noncurrent_version_transitions': {
+                    'type': 'array',
+                    'items': {
+                        'type': 'object',
+                        'required': ['storage_class'],
+                        'additionalProperties': False,
+                        'properties': {
+                            'noncurrent_days': {
+                                'type': ['string', 'integer'],
+                                'pattern': '^[0-9]+$',
+                            },
+                            'storage_class': {
+                                'type': 'string',
+                                'enum': ['GLACIER', 'STANDARD_IA']
+                            }
                         }
                     }
                 },

--- a/kingpin/actors/aws/test/test_s3.py
+++ b/kingpin/actors/aws/test/test_s3.py
@@ -30,10 +30,10 @@ class TestBucket(testing.AsyncTestCase):
                     'prefix': '/test',
                     'status': 'Enabled',
                     'expiration': '30',
-                    'transition': {
+                    'transitions': [{
                         'days': 45,
                         'storage_class': 'GLACIER',
-                    }
+                    }]
                 }],
                 'logging': {
                     'target': 'test_target',
@@ -74,7 +74,7 @@ class TestBucket(testing.AsyncTestCase):
         self.assertEquals(r['Expiration']['Days'], 30)
 
         # Validate that the transition config was built properly too
-        self.assertEquals(r['Transition']['Days'], 45)
+        self.assertEquals(r['Transitions'][0]['Days'], 45)
 
     def test_snake_to_camel(self):
         snake = {


### PR DESCRIPTION
Fixes:
```
19:58:23   CRITICAL  [S3 Bucket] Invalid Lifecycle Configuration: Parameter validation failed:
Unknown parameter in LifecycleConfiguration.Rules[0]: "Transition", must be one of: Expiration, ID, Prefix, Filter, Status, Transitions, NoncurrentVersionTransitions, NoncurrentVersionExpiration, AbortIncompleteMultipartUpload
```

Here are the API Changes when we switched to using `put_bucket_lifecycle_configuration `:
- https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.put_bucket_lifecycle
- https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.put_bucket_lifecycle_configuration