### PR TITLE
remove escaping in non strict mode and fix escaped_tokens

### DIFF
--- a/kingpin/actors/base.py
+++ b/kingpin/actors/base.py
@@ -113,7 +113,7 @@ class BaseActor(object):
     # second 'global runtime context object'.
     strict_init_context = True
 
-    # Controls whether to remove escape characters from tokens that has been
+    # Controls whether to remove escape characters from tokens that have been
     # escaped.
     remove_escape_sequence = True
 

--- a/kingpin/actors/base.py
+++ b/kingpin/actors/base.py
@@ -114,9 +114,8 @@ class BaseActor(object):
     strict_init_context = True
 
     # Controls whether to remove escape characters from tokens that has been
-    # escaped. Has no affect unless subclasses override strict_init_context to
-    # be false.
-    non_strict_remove_escape = True
+    # escaped.
+    remove_escape_sequence = True
 
     def __init__(self, desc=None, options={}, dry=False, warn_on_failure=False,
                  condition=True, init_context={}, init_tokens={},
@@ -157,7 +156,7 @@ class BaseActor(object):
         self._fill_in_contexts(
             context=self._init_context,
             strict=self.strict_init_context,
-            non_strict_remove_escape=self.non_strict_remove_escape)
+            remove_escape_sequence=self.remove_escape_sequence)
 
         self._setup_log()
         self._setup_defaults()
@@ -166,9 +165,9 @@ class BaseActor(object):
         # Fill in any options with the supplied initialization context. Be
         self.log.debug('Initialized (warn_on_failure=%s, '
                        'strict_init_context=%s,'
-                       'non_strict_remove_escape=%s)' %
+                       'remove_escape_sequence=%s)' %
                        (warn_on_failure, self.strict_init_context,
-                        self.non_strict_remove_escape))
+                        self.remove_escape_sequence))
 
     def __repr__(self):
         """Returns a nice name/description of the actor.
@@ -383,7 +382,7 @@ class BaseActor(object):
         return check
 
     def _fill_in_contexts(self, context={}, strict=True,
-                          non_strict_remove_escape=True):
+                          remove_escape_sequence=True):
         """Parses self._options and updates it with the supplied context.
 
         Parses the objects self._options dict (by converting it into a JSON
@@ -406,7 +405,7 @@ class BaseActor(object):
                 self.left_context_separator,
                 self.right_context_separator,
                 strict=strict,
-                non_strict_remove_escape=non_strict_remove_escape)
+                remove_escape_sequence=remove_escape_sequence)
         except LookupError as e:
             msg = 'Context for description failed: %s' % e
             raise exceptions.InvalidOptions(msg)
@@ -419,7 +418,7 @@ class BaseActor(object):
                 self.left_context_separator,
                 self.right_context_separator,
                 strict=strict,
-                non_strict_remove_escape=non_strict_remove_escape)
+                remove_escape_sequence=remove_escape_sequence)
         except LookupError as e:
             msg = 'Context for condition failed: %s' % e
             raise exceptions.InvalidOptions(msg)
@@ -439,7 +438,7 @@ class BaseActor(object):
                 self.right_context_separator,
                 strict=strict,
                 escape_sequence='\\\\',
-                non_strict_remove_escape=non_strict_remove_escape)
+                remove_escape_sequence=remove_escape_sequence)
         except LookupError as e:
             msg = 'Context for options failed: %s' % e
             raise exceptions.InvalidOptions(msg)

--- a/kingpin/actors/base.py
+++ b/kingpin/actors/base.py
@@ -113,6 +113,11 @@ class BaseActor(object):
     # second 'global runtime context object'.
     strict_init_context = True
 
+    # Controls whether to remove escape characters from tokens that has been
+    # escaped. Has no affect unless subclasses override strict_init_context to
+    # be false.
+    non_strict_remove_escape = True
+
     def __init__(self, desc=None, options={}, dry=False, warn_on_failure=False,
                  condition=True, init_context={}, init_tokens={},
                  timeout=None):
@@ -149,8 +154,10 @@ class BaseActor(object):
 
         # strict about this -- but in the future, when we have a
         # runtime_context object, we may loosen this restriction).
-        self._fill_in_contexts(context=self._init_context,
-                               strict=self.strict_init_context)
+        self._fill_in_contexts(
+            context=self._init_context,
+            strict=self.strict_init_context,
+            non_strict_remove_escape=self.non_strict_remove_escape)
 
         self._setup_log()
         self._setup_defaults()
@@ -158,8 +165,10 @@ class BaseActor(object):
 
         # Fill in any options with the supplied initialization context. Be
         self.log.debug('Initialized (warn_on_failure=%s, '
-                       'strict_init_context=%s)' %
-                       (warn_on_failure, self.strict_init_context))
+                       'strict_init_context=%s,'
+                       'non_strict_remove_escape=%s)' %
+                       (warn_on_failure, self.strict_init_context,
+                        self.non_strict_remove_escape))
 
     def __repr__(self):
         """Returns a nice name/description of the actor.
@@ -373,7 +382,8 @@ class BaseActor(object):
             self._condition, check))
         return check
 
-    def _fill_in_contexts(self, context={}, strict=True):
+    def _fill_in_contexts(self, context={}, strict=True,
+                          non_strict_remove_escape=True):
         """Parses self._options and updates it with the supplied context.
 
         Parses the objects self._options dict (by converting it into a JSON
@@ -395,7 +405,8 @@ class BaseActor(object):
                 context,
                 self.left_context_separator,
                 self.right_context_separator,
-                strict=strict)
+                strict=strict,
+                non_strict_remove_escape=non_strict_remove_escape)
         except LookupError as e:
             msg = 'Context for description failed: %s' % e
             raise exceptions.InvalidOptions(msg)
@@ -407,7 +418,8 @@ class BaseActor(object):
                 context,
                 self.left_context_separator,
                 self.right_context_separator,
-                strict=strict)
+                strict=strict,
+                non_strict_remove_escape=non_strict_remove_escape)
         except LookupError as e:
             msg = 'Context for condition failed: %s' % e
             raise exceptions.InvalidOptions(msg)
@@ -426,7 +438,8 @@ class BaseActor(object):
                 self.left_context_separator,
                 self.right_context_separator,
                 strict=strict,
-                escape_sequence='\\\\')
+                escape_sequence='\\\\',
+                non_strict_remove_escape=non_strict_remove_escape)
         except LookupError as e:
             msg = 'Context for options failed: %s' % e
             raise exceptions.InvalidOptions(msg)

--- a/kingpin/actors/group.py
+++ b/kingpin/actors/group.py
@@ -64,7 +64,7 @@ class BaseGroupActor(base.BaseActor):
     # Do not remove remove escape sequence from escaped tokens. This will be
     # done later by another actor. Otherwise we risk remove the escapes and
     # failing because the token isn't found by a sub actor.
-    non_strict_remove_escape = False
+    remove_escape_sequence = False
 
     def __init__(self, *args, **kwargs):
         """Initializes all of the sub actors.

--- a/kingpin/actors/group.py
+++ b/kingpin/actors/group.py
@@ -61,6 +61,11 @@ class BaseGroupActor(base.BaseActor):
     # the moment that this actor is instantiated.
     strict_init_context = False
 
+    # Do not remove remove escape sequence from escaped tokens. This will be
+    # done later by another actor. Otherwise we risk remove the escapes and
+    # failing because the token isn't found by a sub actor.
+    non_strict_remove_escape = False
+
     def __init__(self, *args, **kwargs):
         """Initializes all of the sub actors.
 

--- a/kingpin/test/test_utils.py
+++ b/kingpin/test/test_utils.py
@@ -110,6 +110,15 @@ class TestUtils(unittest.TestCase):
         result = utils.populate_with_tokens(string, tokens, strict=False)
         self.assertEquals(result, expect)
 
+    def test_populate_with_escape_non_strict_no_escape(self):
+        tokens = {'UNIT_TEST': 'FOOBAR'}
+        string = 'Unit \%UNIT_TEST\% Test'
+        expect = 'Unit \%UNIT_TEST\% Test'
+        result = utils.populate_with_tokens(string, tokens,
+                                            strict=False,
+                                            non_strict_remove_escape=False)
+        self.assertEquals(result, expect)
+
     def test_convert_script_to_dict(self):
         # Should work with string path to a file
         dirname, filename = os.path.split(os.path.abspath(__file__))

--- a/kingpin/test/test_utils.py
+++ b/kingpin/test/test_utils.py
@@ -116,7 +116,7 @@ class TestUtils(unittest.TestCase):
         expect = 'Unit \%UNIT_TEST\% Test'
         result = utils.populate_with_tokens(string, tokens,
                                             strict=False,
-                                            non_strict_remove_escape=False)
+                                            remove_escape_sequence=False)
         self.assertEquals(result, expect)
 
     def test_convert_script_to_dict(self):


### PR DESCRIPTION
There's an interesting usage issue when it comes to `populate_with_tokens`. This function is actually called multiple times over subsets of an input.

Consider:
```
---
- actor: aws.cloudformation.Stack
  options:
    name: FOBAR
    region: 'us-east-1'
    template: mystack.yaml
    parameters:
      Param1: foo
      Param2: \{bar\}
```

Because the above is actually wrapped by a `kingpin.actors.group.Sync` actor `populate_with_tokens` is called over the entire input.

The input is:
```
{
  "acts": [{
    "actor": "aws.cloudformation.Stack",
    "options": {
      "name": "FOBAR",
      "region": "us-east-1",
      "template": "mystack.yaml",
      "parameters": {
        "Param1": "foo",
        "Param2": "\\{bar\\}"
      }
    }
  }]
}
```

The output is:
```
{
  "acts": [{
    "actor": "aws.cloudformation.Stack",
    "options": {
      "name": "FOBAR",
      "region": "us-east-1",
      "template": "mystack.yaml",
      "parameters": {
        "Param1": "foo",
        "Param2": "{bar}"
      }
    }
  }]
}
```

At this point `Param2` `{bar}"` has been escaped.

Then as kingpin iterates `populate_with_tokens` is called on options of the `aws.cloudformation.Stack` act.

The input is:
```
{
  "name": "FOBAR",
  "region": "us-east-1",
  "template": "mystack.yaml",
  "parameters": {
    "Param1": "foo",
    "Param2": "{bar}"
  }
}
```

At this point `{bar}` is seen as an unmatched token.

A way around this problem is by not removing the escape sequence when in non strict mode. Why does this work? The group actor runs in non strict mode by default which means it doesn't error out if a token isn't found. However, the terminal actors (ones doing work eg `aws.cloudformation.Stack`) run in strict mode because at this point all tokens must be resolved.

Because tying the two functionalities in the same variable is a little confusing from the perspective of `populate_with_tokens`, I've added a new variable to control when the escape removal happens.

