### PR TITLE
Add support for CFN templates in S3

### DIFF
--- a/kingpin/actors/aws/cloudformation.py
+++ b/kingpin/actors/aws/cloudformation.py
@@ -48,6 +48,9 @@ __author__ = 'Matt Wise <matt@nextdoor.com>'
 EXECUTOR = concurrent.futures.ThreadPoolExecutor(10)
 
 
+S3_REGEX = re.compile(r's3://([a-z0-9.-]+)/(.*)')
+
+
 class CloudFormationError(exceptions.RecoverableActorFailure):
 
     """Raised on any generic CloudFormation error."""
@@ -235,7 +238,7 @@ class CloudFormationBaseActor(base.AWSBaseActor):
             return None, None
 
         if template.startswith('s3://'):
-            match = re.match(r's3://([a-z0-9.-]+)/(.*)', template)
+            match = S3_REGEX.match(template)
             if match:
                 bucket = match.group(1)
                 key = match.group(2)

--- a/kingpin/actors/aws/cloudformation.py
+++ b/kingpin/actors/aws/cloudformation.py
@@ -230,7 +230,7 @@ class CloudFormationBaseActor(base.AWSBaseActor):
         """
         # if the template is provided inline, return it and don't bother with
         # s3 buckets
-        if inline_template
+        if inline_template:
             try:
                 return json.dumps(self._parse_policy_json(inline_template)), None
             except exceptions.UnrecoverableActorFailure as e:
@@ -257,7 +257,6 @@ class CloudFormationBaseActor(base.AWSBaseActor):
             return remote_template, url
         except Exception as e:
             raise InvalidTemplate(e)
-
 
     @gen.coroutine
     def _validate_template(self, body=None, url=None):
@@ -286,7 +285,6 @@ class CloudFormationBaseActor(base.AWSBaseActor):
                 yield self.api_call(self.cf3_conn.validate_template, **cfg)
             except ClientError as e:
                 raise InvalidTemplate(e)
-
 
     def _create_parameters(self, parameters):
         """Converts a simple Key/Value dict into Amazon CF Parameters.

--- a/kingpin/actors/aws/cloudformation.py
+++ b/kingpin/actors/aws/cloudformation.py
@@ -48,7 +48,7 @@ __author__ = 'Matt Wise <matt@nextdoor.com>'
 EXECUTOR = concurrent.futures.ThreadPoolExecutor(10)
 
 
-S3_REGEX = re.compile(r's3://([a-z0-9.-]+)/(.*)')
+S3_REGEX = re.compile(r's3://(?P<bucket>[a-z0-9.-]+)/(?P<key>.*)')
 
 
 class CloudFormationError(exceptions.RecoverableActorFailure):
@@ -240,8 +240,8 @@ class CloudFormationBaseActor(base.AWSBaseActor):
         if template.startswith('s3://'):
             match = S3_REGEX.match(template)
             if match:
-                bucket = match.group(1)
-                key = match.group(2)
+                bucket = match.group('bucket')
+                key = match.group('key')
             else:
                 raise InvalidTemplate()
 

--- a/kingpin/actors/aws/cloudformation.py
+++ b/kingpin/actors/aws/cloudformation.py
@@ -247,6 +247,7 @@ class CloudFormationBaseActor(base.AWSBaseActor):
 
             # figure out the region the bucket is in
             if s3_region is None:
+                log.info(f'Getting region for bucket {bucket}')
                 resp = self.s3_conn.get_bucket_location(Bucket=bucket)
                 s3_region = resp['LocationConstraint']
                 if s3_region is None:
@@ -259,6 +260,7 @@ class CloudFormationBaseActor(base.AWSBaseActor):
 
             s3 = self.get_s3_client(s3_region)
             try:
+                log.info('Downloading template stored in s3')
                 resp = s3.get_object(Bucket=bucket, Key=key)
             except Exception as e:
                 raise InvalidTemplate(e)

--- a/kingpin/actors/aws/cloudformation.py
+++ b/kingpin/actors/aws/cloudformation.py
@@ -21,7 +21,7 @@ import json
 import logging
 import re
 import uuid
-from typing import Any, Dict, Optional
+from typing import Optional
 
 import boto3
 from botocore.exceptions import ClientError
@@ -254,7 +254,7 @@ class CloudFormationBaseActor(base.AWSBaseActor):
             # AWS support assured me this format would work for all regions for
             # all buckets they also said
             # f'https://{bucket}.s3-{region}.amazonaws.com/{key} would also
-            # work but I'm hesitant to use buckets as components in a subdomain.
+            # work but I'm hesitant to use buckets as components in a subdomain
             url = f'https://s3-{s3_region}.amazonaws.com/{bucket}/{key}'
 
             s3 = self.get_s3_client(s3_region)
@@ -608,7 +608,7 @@ class Create(CloudFormationBaseActor):
     not exist. Does not create the stack.
     """
 
-    all_options: Dict[str, Any] = {
+    all_options = {
         'capabilities': (list, [],
                          'The list of capabilities that you want to allow '
                          'in the stack'),
@@ -623,7 +623,8 @@ class Create(CloudFormationBaseActor):
         'template': (str, REQUIRED,
                      'Path to the AWS CloudFormation File. s3://, '
                      'file:///, absolute or relative file paths.'),
-        'template_s3_region': (str, None, 'Region of the bucket containing template_s3_path'),
+        'template_s3_region': (str, None,
+                               'Region of the bucket containing template'),
         'timeout_in_minutes': (int, 60,
                                'The amount of time that can pass before the '
                                'stack status becomes CREATE_FAILED'),
@@ -817,7 +818,7 @@ class Stack(CloudFormationBaseActor):
     not exist. Does not create the stack.
     """
 
-    all_options: Dict[str, Any] = {
+    all_options = {
         'name': (str, REQUIRED, 'Name of the stack'),
         'state': (STATE, 'present',
                   'Desired state of the bucket: present/absent'),
@@ -837,7 +838,8 @@ class Stack(CloudFormationBaseActor):
         'template': (str, REQUIRED,
                      'Path to the AWS CloudFormation File. s3://, '
                      'file:///, absolute or relative file paths.'),
-        'template_s3_region': (str, None, 'Region of the bucket containing template_s3_path'),
+        'template_s3_region': (str, None,
+                               'Region of the bucket containing template'),
         'timeout_in_minutes': (int, 60,
                                'The amount of time that can pass before the '
                                'stack status becomes CREATE_FAILED'),

--- a/kingpin/actors/aws/cloudformation.py
+++ b/kingpin/actors/aws/cloudformation.py
@@ -252,11 +252,9 @@ class CloudFormationBaseActor(base.AWSBaseActor):
                 s3_region = resp['LocationConstraint']
                 if s3_region is None:
                     s3_region = 'us-east-1'
-            # AWS support assured me this format would work for all regions for
-            # all buckets they also said
-            # f'https://{bucket}.s3-{region}.amazonaws.com/{key} would also
-            # work but I'm hesitant to use buckets as components in a subdomain
-            url = f'https://s3-{s3_region}.amazonaws.com/{bucket}/{key}'
+            # AWS has a multitude of different s3 url formats, but not all are
+            # supported. Use this one.
+            url = f'https://{bucket}.s3.{s3_region}.amazonaws.com/{key}'
 
             s3 = self.get_s3_client(s3_region)
             log.debug('Downloading template stored in s3')

--- a/kingpin/actors/aws/cloudformation.py
+++ b/kingpin/actors/aws/cloudformation.py
@@ -824,8 +824,8 @@ class Stack(CloudFormationBaseActor):
         'template': (str, None,
                      'Path to the AWS CloudFormation File. (ie file:///), '
                      'absolute or relative file paths.'),
-        'template_bucket': (str, None, ''),
-        'template_key': (str, None, ''),
+        'template_bucket': (str, None, 'S3 bucket containing the CFN template'),
+        'template_key': (str, None, 'Key in S3 bucket containing the CFN template'),
         'timeout_in_minutes': (int, 60,
                                'The amount of time that can pass before the '
                                'stack status becomes CREATE_FAILED'),

--- a/kingpin/actors/aws/cloudformation.py
+++ b/kingpin/actors/aws/cloudformation.py
@@ -569,7 +569,7 @@ class Create(CloudFormationBaseActor):
     :template:
       String of path to CloudFormation template. Can either be in the form of a
       local file path (ie, `./my_template.json`) or a URI (ie
-      `https://my_site.com/cf.json`).
+      `s3://bucket-name/cf.json`).
 
     :timeout_in_minutes:
       The amount of time that can pass before the stack status becomes
@@ -776,7 +776,7 @@ class Stack(CloudFormationBaseActor):
     :template:
       String of path to CloudFormation template. Can either be in the form of a
       local file path (ie, `./my_template.json`) or a URI (ie
-      `https://my_site.com/cf.json`).
+      `s3://bucket-name/cf.json`).
 
     :timeout_in_minutes:
       The amount of time that can pass before the stack status becomes

--- a/kingpin/actors/aws/test/test_cloudformation.py
+++ b/kingpin/actors/aws/test/test_cloudformation.py
@@ -105,7 +105,7 @@ class TestCloudFormationBaseActor(testing.AsyncTestCase):
             ret = self.actor._get_template_body(url, None)
             expected = (
                 expected_template,
-                'https://s3-us-east-1.amazonaws.com/bucket/foobar.json'
+                'https://bucket.s3.us-east-1.amazonaws.com/foobar.json'
             )
             self.assertEqual(ret, expected)
 
@@ -122,7 +122,7 @@ class TestCloudFormationBaseActor(testing.AsyncTestCase):
 
         with mock.patch.object(self.actor, 'get_s3_client') as mock_get:
             mock_s3 = mock.MagicMock()
-            mock_s3.get_object.side_effect = Exception()
+            mock_s3.get_object.side_effect = ClientError({}, 'FakeOperation')
             mock_get.return_value = mock_s3
 
             with self.assertRaises(cloudformation.InvalidTemplate):
@@ -1059,7 +1059,7 @@ class TestStack(testing.AsyncTestCase):
         template_body = json.dumps({})
         self.actor._template_body = template_body
         self.actor._template_url = (
-            'https://s3-us-east-1.amazonaws.com/foobar/bin'
+            'https://foobar.s3.us-east-1.amazonaws.com/bin'
         )
         fake_stack = create_fake_stack('fake', 'CREATE_COMPLETE')
         ret = yield self.actor._create_change_set(fake_stack, 'uuid')
@@ -1067,7 +1067,7 @@ class TestStack(testing.AsyncTestCase):
         self.actor.cf3_conn.create_change_set.assert_has_calls(
             [mock.call(
                 StackName='arn:aws:cloudformation:us-east-1:xxxx:stack/fake/x',
-                TemplateURL='https://s3-us-east-1.amazonaws.com/foobar/bin',
+                TemplateURL='https://foobar.s3.us-east-1.amazonaws.com/bin',
                 Capabilities=[],
                 ChangeSetName='kingpin-uuid',
                 Parameters=[

--- a/kingpin/actors/aws/test/test_cloudformation.py
+++ b/kingpin/actors/aws/test/test_cloudformation.py
@@ -90,7 +90,9 @@ class TestCloudFormationBaseActor(testing.AsyncTestCase):
     def test_get_template_body_s3(self):
         url = 's3://bucket/foobar.json'
         self.actor.s3_conn = mock.MagicMock(name="s3_conn")
-        self.actor.s3_conn.get_bucket_location.return_value = {'LocationConstraint': None}
+        self.actor.s3_conn.get_bucket_location.return_value = (
+            {'LocationConstraint': None}
+        )
 
         expected_template = 'i am a cfn template'
         with mock.patch.object(self.actor, 'get_s3_client') as mock_get:
@@ -101,7 +103,10 @@ class TestCloudFormationBaseActor(testing.AsyncTestCase):
             mock_get.return_value = mock_s3
 
             ret = self.actor._get_template_body(url, None)
-            expected = (expected_template, 'https://s3-us-east-1.amazonaws.com/bucket/foobar.json')
+            expected = (
+                expected_template,
+                'https://s3-us-east-1.amazonaws.com/bucket/foobar.json'
+            )
             self.assertEqual(ret, expected)
 
         # Should raise exception
@@ -111,7 +116,9 @@ class TestCloudFormationBaseActor(testing.AsyncTestCase):
     def test_get_template_body_s3_read_failure(self):
         url = 's3://bucket/foobar.json'
         self.actor.s3_conn = mock.MagicMock(name="s3_conn")
-        self.actor.s3_conn.get_bucket_location.return_value = {'LocationConstraint': None}
+        self.actor.s3_conn.get_bucket_location.return_value = (
+            {'LocationConstraint': None}
+        )
 
         with mock.patch.object(self.actor, 'get_s3_client') as mock_get:
             mock_s3 = mock.MagicMock()
@@ -1051,7 +1058,9 @@ class TestStack(testing.AsyncTestCase):
         self.actor.cf3_conn.create_change_set.return_value = {'Id': 'abcd'}
         template_body = json.dumps({})
         self.actor._template_body = template_body
-        self.actor._template_url = 'https://s3-us-east-1.amazonaws.com/foobar/bin'
+        self.actor._template_url = (
+            'https://s3-us-east-1.amazonaws.com/foobar/bin'
+        )
         fake_stack = create_fake_stack('fake', 'CREATE_COMPLETE')
         ret = yield self.actor._create_change_set(fake_stack, 'uuid')
         self.assertEqual(ret, {'Id': 'abcd'})

--- a/kingpin/actors/aws/test/test_cloudformation.py
+++ b/kingpin/actors/aws/test/test_cloudformation.py
@@ -69,32 +69,64 @@ class TestCloudFormationBaseActor(testing.AsyncTestCase):
 
     def test_discover_noecho_params(self):
         file = 'examples/test/aws.cloudformation/cf.integration.json'
-        (body, url) = self.actor._get_template_body(file)
+        (body, url) = self.actor._get_template_body(file, None)
         ret = self.actor._discover_noecho_params(body)
         self.assertEqual(ret, ['BucketPassword'])
 
     def test_get_template_body(self):
         file = 'examples/test/aws.cloudformation/cf.unittest.json'
-        url = 'http://foobar.json'
 
         # Should work...
-        ret = self.actor._get_template_body(file)
+        ret = self.actor._get_template_body(file, None)
         expected = ('{"blank": "json"}', None)
         self.assertEqual(ret, expected)
 
         # Should return None
-        ret = self.actor._get_template_body(None)
+        ret = self.actor._get_template_body(None, None)
         expected = (None, None)
         self.assertEqual(ret, expected)
 
-        # Should return None
-        ret = self.actor._get_template_body(url)
-        expected = (None, 'http://foobar.json')
-        self.assertEqual(ret, expected)
+    def test_get_template_body_s3(self):
+        url = 's3://bucket/foobar.json'
+        self.actor.s3_conn = mock.MagicMock(name="s3_conn")
+        self.actor.s3_conn.get_bucket_location.return_value = {'LocationConstraint': None}
+
+        expected_template = 'i am a cfn template'
+        with mock.patch.object(self.actor, 'get_s3_client') as mock_get:
+            mock_s3 = mock.MagicMock()
+            mock_body = mock.MagicMock()
+            mock_body.read.return_value = expected_template
+            mock_s3.get_object.return_value = {'Body': mock_body}
+            mock_get.return_value = mock_s3
+
+            ret = self.actor._get_template_body(url, None)
+            expected = (expected_template, 'https://s3-us-east-1.amazonaws.com/bucket/foobar.json')
+            self.assertEqual(ret, expected)
 
         # Should raise exception
         with self.assertRaises(cloudformation.InvalidTemplate):
-            self.actor._get_template_body('missing')
+            self.actor._get_template_body('missing', None)
+
+    def test_get_template_body_s3_read_failure(self):
+        url = 's3://bucket/foobar.json'
+        self.actor.s3_conn = mock.MagicMock(name="s3_conn")
+        self.actor.s3_conn.get_bucket_location.return_value = {'LocationConstraint': None}
+
+        with mock.patch.object(self.actor, 'get_s3_client') as mock_get:
+            mock_s3 = mock.MagicMock()
+            mock_s3.get_object.side_effect = Exception()
+            mock_get.return_value = mock_s3
+
+            with self.assertRaises(cloudformation.InvalidTemplate):
+                self.actor._get_template_body(url, None)
+
+    def test_get_template_body_bad_s3_path(self):
+        url = 's3://bucket-foobar.json'
+        with self.assertRaises(cloudformation.InvalidTemplate):
+            self.actor._get_template_body(url, None)
+
+    def test_get_s3_client(self):
+        self.actor.get_s3_client('us-east-1')
 
     @testing.gen_test
     def test_validate_template_body(self):
@@ -625,6 +657,7 @@ class TestStack(testing.AsyncTestCase):
                 }
             })
         self.actor.cf3_conn = mock.MagicMock(name='cf3_conn')
+        self.actor.s3_conn = mock.MagicMock(name='s3_conn')
 
     def test_diff_params_safely(self):
         self.actor = cloudformation.Stack(
@@ -820,11 +853,57 @@ class TestStack(testing.AsyncTestCase):
             yield self.actor._update_stack(fake_stack)
 
     @testing.gen_test
-    def test_ensure_template_with_url_quietly_exits(self):
-        self.actor._template_url = 'http://fakeurl.com'
+    def test_ensure_template_with_url_works(self):
+        self.actor._template_body = json.dumps({})
+        self.actor._template_url = 's3://some.bucket.name/template.json'
+        expected_body = (
+            '{"AWSTemplateFormatVersion": "2010-09-09", "Resources": '
+            '{"ImageRepository": {"Type": "AWS::ECR::Repository"}}}')
+        body_io = mock.MagicMock()
+        body_io.read.return_value = expected_body
+        self.actor.s3_conn.get_object.return_value = {'Body': body_io}
+
+        self.actor._create_change_set = mock.MagicMock(name='_create_change')
+        self.actor._create_change_set.return_value = tornado_value(
+            {'Id': 'abcd'})
+        self.actor._wait_until_change_set_ready = mock.MagicMock(name='_wait')
+        self.actor._wait_until_change_set_ready.return_value = tornado_value(
+            {'Changes': []})
+        self.actor._execute_change_set = mock.MagicMock(name='_execute_change')
+        self.actor._execute_change_set.return_value = tornado_value(None)
+        self.actor.cf3_conn.delete_change_set.return_value = tornado_value(
+            None)
+
+        # Change the actors parameters from the first time it was run -- this
+        # ensures all the lines on the ensure_template method are called
+        self.actor._parameters = self.actor._create_parameters({})
+
         fake_stack = create_fake_stack('fake', 'CREATE_COMPLETE')
+
+        # Grab the raw stack body from the test actor -- this is what it should
+        # compare against, so this test should cause the method to bail out and
+        # not make any changes.
+        template = {'Fake': 'Stack'}
+        get_temp_mock = mock.MagicMock(name='_get_stack_template')
+        self.actor._get_stack_template = get_temp_mock
+        self.actor._get_stack_template.return_value = tornado_value(template)
+
+        # We run three tests in here because the setup takes so many lines
+        # (above). First test is a normal execution with changes detected.
         ret = yield self.actor._ensure_template(fake_stack)
         self.assertEqual(None, ret)
+        self.actor._create_change_set.assert_has_calls(
+            [mock.call(fake_stack)])
+        self.actor._wait_until_change_set_ready.assert_has_calls(
+            [mock.call('abcd', 'Status', 'CREATE_COMPLETE')])
+        self.assertFalse(self.actor.cf3_conn.delete_change_set.called)
+
+        # Quick second execution with _dry set. In this case, we SHOULD call
+        # the delete changset function.
+        self.actor._dry = True
+        yield self.actor._ensure_template(fake_stack)
+        self.actor.cf3_conn.delete_change_set.assert_has_calls(
+            [mock.call(ChangeSetName='abcd')])
 
     @testing.gen_test
     def test_ensure_template_no_diff(self):
@@ -968,8 +1047,9 @@ class TestStack(testing.AsyncTestCase):
     @testing.gen_test
     def test_create_change_set_url(self):
         self.actor.cf3_conn.create_change_set.return_value = {'Id': 'abcd'}
-        self.actor._template_body = None
-        self.actor._template_url = 'http://foobar.bin'
+        template_body = json.dumps({})
+        self.actor._template_body = template_body
+        self.actor._template_url = 's3://foobar.bin'
         fake_stack = create_fake_stack('fake', 'CREATE_COMPLETE')
         ret = yield self.actor._create_change_set(fake_stack, 'uuid')
         self.assertEqual(ret, {'Id': 'abcd'})


### PR DESCRIPTION
This implementation requires the user to explicitly provide a S3 bucket and key to their template.