### PR TITLE
Add support for !GetAtt, !Sub and datetime by using Amazon's cfn-flip to parse YAML

### DIFF
--- a/examples/test/aws.cloudformation/cf.integration.yaml
+++ b/examples/test/aws.cloudformation/cf.integration.yaml
@@ -1,0 +1,30 @@
+---
+AWSTemplateFormatVersion: 2010-09-09
+Description: Stupid-simple CloudFormation template for Kingpin Integration Testing.
+Parameters:
+  BucketName:
+    Type: String
+  BucketPassword:
+    Type: String
+    NoEcho: true
+  DefaultParam:
+    Type: String
+    Default: DefaultValue
+  Metadata:
+    Type: String
+Conditions: {}
+Resources:
+  IntegrationTestBucket:
+    Type: AWS::S3::Bucket
+    Metadata:
+      Test:
+        Ref: Metadata
+    Properties:
+      BucketName: !Ref BucketName
+      Tags:
+      - Key: DefaultParam
+        Value:
+          Ref: DefaultParam
+      - Key: Kingpin
+        Value:
+          Ref: BucketName

--- a/kingpin/actors/aws/cloudformation.py
+++ b/kingpin/actors/aws/cloudformation.py
@@ -18,6 +18,9 @@
 """
 
 import json
+from json import JSONEncoder
+
+import datetime
 import logging
 import re
 import uuid
@@ -40,6 +43,11 @@ log = logging.getLogger(__name__)
 
 __author__ = 'Matt Wise <matt@nextdoor.com>'
 
+class DateTimeEncoder(JSONEncoder):
+    #Override the default method
+    def default(self, obj):
+        if isinstance(obj, (datetime.date, datetime.datetime)):
+            return obj.isoformat()
 
 # This executor is used by the tornado.concurrent.run_on_executor()
 # decorator. We would like this to be a class variable so its shared
@@ -267,7 +275,7 @@ class CloudFormationBaseActor(base.AWSBaseActor):
         else:
             # The template is provided inline.
             try:
-                return json.dumps(self._parse_policy_json(template)), None
+                return json.dumps(self._parse_policy_json(template),cls=DateTimeEncoder), None
             except exceptions.UnrecoverableActorFailure as e:
                 raise InvalidTemplate(e)
 

--- a/kingpin/actors/aws/cloudformation.py
+++ b/kingpin/actors/aws/cloudformation.py
@@ -43,11 +43,12 @@ log = logging.getLogger(__name__)
 
 __author__ = 'Matt Wise <matt@nextdoor.com>'
 
-class DateTimeEncoder(JSONEncoder):
-    #Override the default method
+
+class DateEncoder(JSONEncoder):
     def default(self, obj):
-        if isinstance(obj, (datetime.date, datetime.datetime)):
+        if isinstance(obj, (datetime.date)):
             return obj.isoformat()
+
 
 # This executor is used by the tornado.concurrent.run_on_executor()
 # decorator. We would like this to be a class variable so its shared
@@ -275,7 +276,11 @@ class CloudFormationBaseActor(base.AWSBaseActor):
         else:
             # The template is provided inline.
             try:
-                return json.dumps(self._parse_policy_json(template),cls=DateTimeEncoder), None
+                return (
+                    json.dumps(self._parse_policy_json(
+                        template), cls=DateEncoder),
+                    None
+                )
             except exceptions.UnrecoverableActorFailure as e:
                 raise InvalidTemplate(e)
 

--- a/kingpin/test/test_utils.py
+++ b/kingpin/test/test_utils.py
@@ -126,7 +126,7 @@ class TestUtils(unittest.TestCase):
         examples = '%s/../../examples' % dirname
         simple = '%s/simple.json' % examples
         ret = utils.convert_script_to_dict(simple, {})
-        self.assertEqual(type(ret), dict)
+        self.assertIsInstance(ret, dict)
 
         # Should work with file instance also
         dirname, filename = os.path.split(os.path.abspath(__file__))
@@ -134,7 +134,7 @@ class TestUtils(unittest.TestCase):
         simple = '%s/simple.json' % examples
         instance = open(simple)
         ret = utils.convert_script_to_dict(instance, {})
-        self.assertEqual(type(ret), dict)
+        self.assertIsInstance(ret, dict)
 
         # Should definitly support YAML as well
         dirname, filename = os.path.split(os.path.abspath(__file__))
@@ -142,7 +142,7 @@ class TestUtils(unittest.TestCase):
         simple = '%s/simple.yaml' % examples
         instance = open(simple)
         ret = utils.convert_script_to_dict(instance, {})
-        self.assertEqual(type(ret), dict)
+        self.assertIsInstance(ret, dict)
 
     def test_convert_script_to_dict_bad_name(self):
         instance = io.StringIO()  # Empty buffer will fail demjson.

--- a/kingpin/utils.py
+++ b/kingpin/utils.py
@@ -58,6 +58,7 @@ STATIC_PATH_NAME = 'static'
 # THREADPOOL_SIZE = 10
 # THREADPOOL = futures.ThreadPoolExecutor(THREADPOOL_SIZE)
 
+
 def str_to_class(string):
     """Method that converts a string name into a usable Class name
 

--- a/kingpin/utils.py
+++ b/kingpin/utils.py
@@ -30,9 +30,9 @@ import os
 import pprint
 import re
 import sys
-import yaml
 import io
 from io import IOBase
+import cfn_tools
 
 from tornado import gen
 from tornado import ioloop
@@ -57,7 +57,6 @@ STATIC_PATH_NAME = 'static'
 # # want to prvent the app from going thread-crazy.
 # THREADPOOL_SIZE = 10
 # THREADPOOL = futures.ThreadPoolExecutor(THREADPOOL_SIZE)
-
 
 def str_to_class(string):
     """Method that converts a string name into a usable Class name
@@ -370,7 +369,7 @@ def convert_script_to_dict(script_file, tokens):
         if suffix == 'json':
             decoded = demjson.decode(parsed)
         elif suffix in ('yml', 'yaml'):
-            decoded = yaml.safe_load(parsed)
+            decoded = cfn_tools.load_yaml(parsed)
             if decoded is None:
                 raise exceptions.InvalidScript(
                     'Invalid YAML in `%s`' % filename)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,9 @@ simplejson
 jsonschema
 jsonpickle
 demjson
-PyYAML
+
+# Used to parse CFN yaml, which has a few edge cases PyYaml doesn't parse by default
+cfn-flip
 
 # Colorize the log output!
 rainbow_logging_handler


### PR DESCRIPTION
While trying to add Datadog's [MetricStream CFN stack](https://datadog-cloudformation-stream-template.s3.amazonaws.com/aws/streams_main.yaml), I hit two issues with KingPin.

1. It uses the shorthand functions `!GetAtt` and `!Sub` a lot. 
2. The `Version` in Policy documents was unquoted, so PyYaml natively parsed it as a date which then failed to JSON dump. 


This is currently failing tests due to coveragee, but I do not see many examples of YAML based CFN stacks that would be easy to build upon. 

@diranged @stlava Does this seem like a reasonable idea to you two? 