### PR TITLE
[iam.role] Fix IAM Role creation with Boto3

### DIFF
--- a/kingpin/actors/aws/iam/test/test_entities.py
+++ b/kingpin/actors/aws/iam/test/test_entities.py
@@ -1009,7 +1009,7 @@ class TestRole(testing.AsyncTestCase):
         self.actor._ensure_assume_role_doc.side_effect = [tornado_value(None)]
         yield self.actor._execute()
         self.assertTrue(self.actor._ensure_entity.called)
-        self.assertFalse(self.actor._ensure_assume_role_doc.called)
+        self.assertTrue(self.actor._ensure_assume_role_doc.called)
         self.iam_stubber.assert_no_pending_responses()
 
     @testing.gen_test
@@ -1024,6 +1024,30 @@ class TestRole(testing.AsyncTestCase):
         self.assertTrue(self.actor._ensure_entity.called)
         self.assertTrue(self.actor._ensure_inline_policies.called)
         self.assertTrue(self.actor._ensure_assume_role_doc.called)
+
+    @testing.gen_test
+    def test_create_entity(self):
+        self.actor.assume_role_policy_doc = "{}"
+        self.actor._dry = False
+        self.iam_stubber.add_response(
+            # API Call
+            "create_role",
+            # Response,
+            {
+                "Role": {
+                    "Arn": "arn:.................",
+                    "Path": "/",
+                    "RoleName": "test",
+                    "RoleId": "AQ..............C...",
+                    "CreateDate": datetime(2015, 1, 1),
+                }
+            },
+            # Call Params
+            {"RoleName": "test", "AssumeRolePolicyDocument": '"{}"'},
+        )
+        self.iam_stubber.activate()
+        yield self.actor._create_entity("test")
+        self.iam_stubber.assert_no_pending_responses()
 
 
 class TestInstanceProfile(testing.AsyncTestCase):

--- a/kingpin/version.py
+++ b/kingpin/version.py
@@ -13,4 +13,4 @@
 # Copyright 2018 Nextdoor.com, Inc
 
 
-__version__ = "2.0.1"
+__version__ = "2.0.2"


### PR DESCRIPTION
It turns out that in Boto3 you _must_ supply the
AssumeRolePolicyDocument - AWS will not create the default document for
you. For that reason, we change our default behavior here to set the
`assume_role_policy_document` setting to the default EC2 policy
document.