### PR TITLE
[actors.aws.entities] Bugfix the IAM Role Creation actor

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -82,7 +82,7 @@ version = release = kingpin_version.__version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = en
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -82,7 +82,7 @@ version = release = kingpin_version.__version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = en
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/kingpin/actors/aws/iam/entities.py
+++ b/kingpin/actors/aws/iam/entities.py
@@ -886,7 +886,7 @@ class Role(EntityBaseActor):
         ),
         "assume_role_policy_document": (
             str,
-            '{"Version": "2012-10-17", "Statement": [{"Effect": "Allow", "Principal": {"Service": "ec2.amazonaws.com"}, "Action": "sts:AssumeRole" }]}',
+            None,
             ("The policy that grants an entity" "permission to assume the role"),
         ),
     }
@@ -909,9 +909,20 @@ class Role(EntityBaseActor):
         self._parse_inline_policies(self.option("inline_policies"))
 
         # Pre-parse the Assume Role Policy Document if it was supplied
-        self.assume_role_policy_doc = self._parse_policy_json(
-            self.option("assume_role_policy_document")
-        )
+        self.assume_role_policy_doc = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {"Service": "ec2.amazonaws.com"},
+                    "Action": "sts:AssumeRole",
+                }
+            ],
+        }
+        if self.option("assume_role_policy_document") is not None:
+            self.assume_role_policy_doc = self._parse_policy_json(
+                self.option("assume_role_policy_document")
+            )
 
     @gen.coroutine
     def _ensure_assume_role_doc(self, name):

--- a/kingpin/version.py
+++ b/kingpin/version.py
@@ -13,4 +13,4 @@
 # Copyright 2018 Nextdoor.com, Inc
 
 
-__version__ = "2.0.2"
+__version__ = "2.0.3"


### PR DESCRIPTION
I was passing in a string rather than a string-pointer to a file, and
that's not what the input was expecting. This is a simpler fix.