### PR TITLE
[AWSBaseActor] Respect boto3/AWS retry configurability

### DIFF
--- a/kingpin/actors/aws/base.py
+++ b/kingpin/actors/aws/base.py
@@ -119,7 +119,8 @@ class AWSBaseActor(base.BaseActor):
         boto_config = botocore_config.Config(
             region_name=self.region,
             retries={
-                "mode": "adaptive",
+                "max_attempts": aws_settings.AWS_MAX_ATTEMPTS,
+                "mode": aws_settings.AWS_RETRY_MODE
             },
         )
 

--- a/kingpin/actors/aws/base.py
+++ b/kingpin/actors/aws/base.py
@@ -120,7 +120,7 @@ class AWSBaseActor(base.BaseActor):
             region_name=self.region,
             retries={
                 "max_attempts": aws_settings.AWS_MAX_ATTEMPTS,
-                "mode": aws_settings.AWS_RETRY_MODE
+                "mode": aws_settings.AWS_RETRY_MODE,
             },
         )
 

--- a/kingpin/actors/aws/settings.py
+++ b/kingpin/actors/aws/settings.py
@@ -32,3 +32,12 @@ __author__ = "Mikhail Simin <mikhail@nextdoor.com>"
 AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID", None)
 AWS_SECRET_ACCESS_KEY = os.getenv("AWS_SECRET_ACCESS_KEY", None)
 AWS_SESSION_TOKEN = os.getenv("AWS_SESSION_TOKEN", None)
+
+# kingpin is pretty fast which can leads to API throttling. You can set you own
+# boto3 configuration by using the standard AWS env vars, but in the absence of
+# them, we try to set you some sane defaults based on the boto3 documentation
+# and our experience with running kingpin as scale.
+#
+# Docs: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/retries.html
+AWS_MAX_ATTEMPTS = os.getenv("AWS_MAX_ATTEMPTS", 10)
+AWS_RETRY_MODE = os.getenv("AWS_RETRY_MODE", "standard")


### PR DESCRIPTION
We simply forward the `AWS_*` env vars into the config if they are set. Otherwise we will just use some sane default parameters which we have found work well based on our understanding of the commented documentation and our experience in running kingpin at scale.