### PR TITLE
[ci/cd] Update CircleCI Image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,27 +1,23 @@
 version: 2
 jobs:
-
   build:
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.11
     environment:
       DRY: true
       USER: bogus-string
     steps:
       - checkout
       - save_cache:
-          key: pip-{{ checksum "requirements.test.txt" }}
+          key: pip-{{ checksum "requirements.test.txt" }}-2023-01-03
           paths:
             - .venv
       - run: make venv
       - restore_cache:
           keys:
-            - pip-{{ checksum "requirements.test.txt" }}
-            -
+            - pip-{{ checksum "requirements.test.txt" }}-2023-01-03
       - run: make test
       - run: make pyblack
-
-
 workflows:
   version: 2
   default:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.10
     environment:
       DRY: true
       USER: bogus-string

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: cimg/python:3.10
+      - image: cimg/python:3.9
     environment:
       DRY: true
       USER: bogus-string


### PR DESCRIPTION
Example deprecation warning we are seeing with the old CircleCI image:

> You’re using a deprecated Docker convenience image. Upgrade to a next-gen Docker convenience image.