### PR TITLE
fix: Incorrect traceback parameter

### DIFF
--- a/kingpin/actors/aws/base.py
+++ b/kingpin/actors/aws/base.py
@@ -99,9 +99,9 @@ class AWSBaseActor(base.BaseActor):
         # found which will tell boto3 to fallback to default behavior.
         boto3_client_kwargs = {}
         boto3_client_kwargs["aws_access_key_id"] = aws_settings.AWS_ACCESS_KEY_ID
-        boto3_client_kwargs[
-            "aws_secret_access_key"
-        ] = aws_settings.AWS_SECRET_ACCESS_KEY
+        boto3_client_kwargs["aws_secret_access_key"] = (
+            aws_settings.AWS_SECRET_ACCESS_KEY
+        )
         boto3_client_kwargs["aws_session_token"] = aws_settings.AWS_SESSION_TOKEN
 
         # Establish connection objects that don't require a region
@@ -226,5 +226,4 @@ class AWSBaseActor(base.BaseActor):
 
 
 class EnsurableAWSBaseActor(AWSBaseActor, base.EnsurableBaseActor):
-
     """Ensurable version of the AWS Base Actor"""

--- a/kingpin/actors/aws/cloudformation.py
+++ b/kingpin/actors/aws/cloudformation.py
@@ -61,32 +61,26 @@ S3_REGEX = re.compile(r"s3://(?P<bucket>[a-z0-9.-]+)/(?P<key>.*)")
 
 
 class CloudFormationError(exceptions.RecoverableActorFailure):
-
     """Raised on any generic CloudFormation error."""
 
 
 class StackFailed(exceptions.RecoverableActorFailure):
-
     """Raised any time a Stack fails to be created or updated."""
 
 
 class InvalidTemplate(exceptions.UnrecoverableActorFailure):
-
     """An invalid CloudFormation template was supplied."""
 
 
 class StackAlreadyExists(exceptions.RecoverableActorFailure):
-
     """The requested CloudFormation stack already exists."""
 
 
 class StackNotFound(exceptions.RecoverableActorFailure):
-
     """The requested CloudFormation stack does not exist."""
 
 
 class ParametersConfig(SchemaCompareBase):
-
     """Validates the Parameters option.
 
     A valid `parameters` option is a dictionary with simple Key/Value pairs of
@@ -103,7 +97,6 @@ class ParametersConfig(SchemaCompareBase):
 
 
 class CapabilitiesConfig(SchemaCompareBase):
-
     """Validates the Capabilities option"""
 
     SCHEMA = {
@@ -122,7 +115,6 @@ class CapabilitiesConfig(SchemaCompareBase):
 
 
 class OnFailureConfig(StringCompareBase):
-
     """Validates the On Failure option.
 
     The `on_failure` option can take one of the following settings:
@@ -135,7 +127,6 @@ class OnFailureConfig(StringCompareBase):
 
 
 class TerminationProtectionConfig(StringCompareBase):
-
     """Validates the TerminationProtectionConfig option.
 
     The `enable_termination_protection` option can take one of the following
@@ -184,7 +175,6 @@ FAILED = (
 
 
 class CloudFormationBaseActor(base.AWSBaseActor):
-
     """Base Actor for CloudFormation tasks"""
 
     # Get references to existing objects that are used by the

--- a/kingpin/actors/aws/iam/base.py
+++ b/kingpin/actors/aws/iam/base.py
@@ -36,5 +36,4 @@ EXECUTOR = concurrent.futures.ThreadPoolExecutor(10)
 
 
 class IAMBaseActor(base.AWSBaseActor):
-
     """Base class for IAM actors."""

--- a/kingpin/actors/aws/iam/entities.py
+++ b/kingpin/actors/aws/iam/entities.py
@@ -49,7 +49,6 @@ MAX_ITEMS = 1000
 
 
 class EntityBaseActor(base.IAMBaseActor):
-
     """User/Group/Role Base Management Class
 
     Managing Users, Groups and Roles in Amazon IAM is nearly identical. This
@@ -507,7 +506,6 @@ class EntityBaseActor(base.IAMBaseActor):
 
 
 class User(EntityBaseActor):
-
     """Manages an IAM User.
 
     This actor manages the state of an Amazon IAM User.
@@ -651,7 +649,6 @@ class User(EntityBaseActor):
 
 
 class Group(EntityBaseActor):
-
     """Manages an IAM Group.
 
     This actor manages the state of an Amazon IAM Group.
@@ -807,7 +804,6 @@ class Group(EntityBaseActor):
 
 
 class Role(EntityBaseActor):
-
     """Manages an IAM Role.
 
     This actor manages the state of an Amazon IAM Role.
@@ -1000,7 +996,6 @@ class Role(EntityBaseActor):
 
 
 class InstanceProfile(EntityBaseActor):
-
     """Manages an IAM Instance Profile.
 
     This actor manages the state of an Amazon IAM Instance Profile.

--- a/kingpin/actors/aws/s3.py
+++ b/kingpin/actors/aws/s3.py
@@ -47,12 +47,10 @@ EXECUTOR = concurrent.futures.ThreadPoolExecutor(10)
 
 
 class InvalidBucketConfig(exceptions.RecoverableActorFailure):
-
     """Raised whenever an invalid option is passed to a Bucket"""
 
 
 class PublicAccessBlockConfig(SchemaCompareBase):
-
     """Provides JSON-Schema based validation of the supplied Public Access
     Block Configuration..
 
@@ -105,7 +103,6 @@ class PublicAccessBlockConfig(SchemaCompareBase):
 
 
 class LoggingConfig(SchemaCompareBase):
-
     """Provides JSON-Schema based validation of the supplied logging config.
 
     The S3 LoggingConfig format should look like this:
@@ -135,7 +132,6 @@ class LoggingConfig(SchemaCompareBase):
 
 
 class LifecycleConfig(SchemaCompareBase):
-
     """Provides JSON-Schema based validation of the supplied Lifecycle config.
 
     The S3 Lifecycle system allows for many unique configurations. Each
@@ -358,7 +354,6 @@ class LifecycleConfig(SchemaCompareBase):
 
 
 class NotificationConfiguration(SchemaCompareBase):
-
     """Provides JSON-Schema based validation of the supplied Notification Config.
 
     .. code-block:: json
@@ -394,7 +389,6 @@ class NotificationConfiguration(SchemaCompareBase):
 
 
 class TaggingConfig(SchemaCompareBase):
-
     """Provides JSON-Schema based validation of the supplied tagging config.
 
     The S3 TaggingConfig format should look like this:
@@ -427,7 +421,6 @@ class TaggingConfig(SchemaCompareBase):
 
 
 class Bucket(base.EnsurableAWSBaseActor):
-
     """Manage the state of a single S3 Bucket.
 
     The actor has the following functionality:

--- a/kingpin/actors/aws/test/integration_cloudformation.py
+++ b/kingpin/actors/aws/test/integration_cloudformation.py
@@ -17,7 +17,6 @@ UUID = uuid.uuid4().hex
 
 
 class IntegrationCreate(testing.AsyncTestCase):
-
     """High Level CloudFormation Testing.
 
     These tests will check two things:
@@ -97,7 +96,6 @@ class IntegrationCreate(testing.AsyncTestCase):
 
 
 class IntegrationStack(testing.AsyncTestCase):
-
     """High Level CloudFormation Stack Testing.
 
     These tests will check two things:

--- a/kingpin/actors/aws/test/integration_s3.py
+++ b/kingpin/actors/aws/test/integration_s3.py
@@ -16,7 +16,6 @@ logging.getLogger("boto").setLevel(logging.INFO)
 
 
 class IntegrationS3(testing.AsyncTestCase):
-
     """High level S3 Actor testing.
 
     These tests will check two things:

--- a/kingpin/actors/base.py
+++ b/kingpin/actors/base.py
@@ -65,7 +65,6 @@ DEFAULT_TIMEOUT = os.getenv("DEFAULT_TIMEOUT", 3600)
 
 
 class LogAdapter(logging.LoggerAdapter):
-
     """Simple Actor Logging Adapter.
 
     Provides a common logging format for actors that uses the actors
@@ -77,7 +76,6 @@ class LogAdapter(logging.LoggerAdapter):
 
 
 class BaseActor(object):
-
     """Abstract base class for Actor objects."""
 
     # {
@@ -560,7 +558,6 @@ class BaseActor(object):
 
 
 class EnsurableBaseActor(BaseActor):
-
     """Base Class for Actors that "ensure" the state of a resource.
 
     Many of our actors have a goal of ensuring that a particular resource is in
@@ -757,7 +754,6 @@ class EnsurableBaseActor(BaseActor):
 
 
 class HTTPBaseActor(BaseActor):
-
     """Abstract base class for an HTTP-client based Actor object.
 
     This class provides common methods for getting access to asynchronous

--- a/kingpin/actors/exceptions.py
+++ b/kingpin/actors/exceptions.py
@@ -22,12 +22,10 @@ from kingpin import exceptions
 
 
 class ActorException(exceptions.KingpinException):
-
     """Base Kingpin Actor Exception"""
 
 
 class RecoverableActorFailure(ActorException):
-
     """Base exception that allows script executions to continue on failure.
 
     This exception class is used to throw an error when an Actor fails, but
@@ -39,7 +37,6 @@ class RecoverableActorFailure(ActorException):
 
 
 class UnrecoverableActorFailure(ActorException):
-
     """Base exception for unrecoverable failures.
 
     This exception class should be used for critical failures that should
@@ -52,17 +49,14 @@ class UnrecoverableActorFailure(ActorException):
 
 
 class ActorTimedOut(RecoverableActorFailure):
-
     """Raised when an Actor takes too long to execute"""
 
 
 class InvalidActor(UnrecoverableActorFailure):
-
     """Raised when an invalid Actor name was supplied"""
 
 
 class InvalidOptions(UnrecoverableActorFailure):
-
     """Invalid option arguments passed into the Actor object.
 
     This can be used both for the actual options dict passed into the actor,
@@ -72,15 +66,12 @@ class InvalidOptions(UnrecoverableActorFailure):
 
 
 class InvalidCredentials(UnrecoverableActorFailure):
-
     """Invalid or missing credentials required for Actor object."""
 
 
 class UnparseableResponseFromEndpoint(UnrecoverableActorFailure):
-
     """Invalid response returned from a remote REST endpoint."""
 
 
 class BadRequest(RecoverableActorFailure):
-
     """An action failed due to a HTTP 400 error likely due to bad input."""

--- a/kingpin/actors/group.py
+++ b/kingpin/actors/group.py
@@ -37,7 +37,6 @@ __author__ = "Matt Wise <matt@nextdoor.com>"
 
 
 class BaseGroupActor(base.BaseActor):
-
     """Group together a series of other `kingpin.actors.base.BaseActor` objects
 
     :acts:
@@ -221,7 +220,6 @@ class BaseGroupActor(base.BaseActor):
 
 
 class Sync(BaseGroupActor):
-
     """Execute a series of `kingpin.actors.base.BaseActor` synchronously.
 
     Groups together a series of Actors and executes them synchronously
@@ -365,7 +363,6 @@ class Sync(BaseGroupActor):
 
 
 class Async(BaseGroupActor):
-
     """Execute several `kingpin.actors.base.BaseActor` objects asynchronously.
 
     Groups together a series of Actors and executes them asynchronously -

--- a/kingpin/actors/hipchat.py
+++ b/kingpin/actors/hipchat.py
@@ -57,7 +57,6 @@ NAME = os.getenv("HIPCHAT_NAME", "Kingpin")
 
 
 class HipchatBase(base.HTTPBaseActor):
-
     """Simple Hipchat Abstract Base Object"""
 
     def __init__(self, *args, **kwargs):
@@ -136,7 +135,6 @@ class HipchatBase(base.HTTPBaseActor):
 
 
 class Message(HipchatBase):
-
     """Sends a message to a room in HipChat.
 
     **Options**
@@ -237,7 +235,6 @@ class Message(HipchatBase):
 
 
 class Topic(HipchatBase):
-
     """Sets a HipChat room topic.
 
     **Options**

--- a/kingpin/actors/librato.py
+++ b/kingpin/actors/librato.py
@@ -58,7 +58,6 @@ EMAIL = os.getenv("LIBRATO_EMAIL", None)
 
 
 class Annotation(base.HTTPBaseActor):
-
     """Librato Annotation Actor
 
     Posts an Annotation to Librato.

--- a/kingpin/actors/misc.py
+++ b/kingpin/actors/misc.py
@@ -52,7 +52,6 @@ __author__ = "Matt Wise <matt@nextdoor.com>, " "Mikhail Simin <mikhail@nextdoor.
 
 
 class Note(base.BaseActor):
-
     """Print any message to log."""
 
     all_options = {"message": (str, REQUIRED, "Message to log.")}
@@ -65,7 +64,6 @@ class Note(base.BaseActor):
 
 
 class Macro(base.BaseActor):
-
     """Parses a kingpin script, instantiates and executes it.
 
     **Parse JSON/YAML**
@@ -274,7 +272,6 @@ class Macro(base.BaseActor):
 
 
 class Sleep(base.BaseActor):
-
     """Sleeps for an arbitrary number of seconds.
 
     **Options**
@@ -320,7 +317,6 @@ class Sleep(base.BaseActor):
 
 
 class GenericHTTP(base.HTTPBaseActor):
-
     """A very simple actor that allows GET/POST methods over HTTP.
 
     Does a GET or a POST to a specified URL.

--- a/kingpin/actors/packagecloud.py
+++ b/kingpin/actors/packagecloud.py
@@ -74,7 +74,6 @@ class PackagecloudAPI(api.RestConsumer):
 
 
 class PackagecloudBase(base.BaseActor):
-
     """Simple packagecloud Abstract Base Object"""
 
     def __init__(self, *args, **kwargs):
@@ -265,7 +264,6 @@ class PackagecloudBase(base.BaseActor):
 
 
 class Delete(PackagecloudBase):
-
     """Deletes packages from a PackageCloud repo.
 
     Searches for packages that match the `packages_to_delete` regex pattern and
@@ -334,7 +332,6 @@ class Delete(PackagecloudBase):
 
 
 class DeleteByDate(PackagecloudBase):
-
     """Deletes packages from a PackageCloud repo older than X.
 
     Adds additional functionality to the `Delete` class with a `older_than`
@@ -399,7 +396,6 @@ class DeleteByDate(PackagecloudBase):
 
 
 class WaitForPackage(PackagecloudBase):
-
     """Searches for a package that matches `name` and `version` until found or
     a timeout occurs.
 

--- a/kingpin/actors/pingdom.py
+++ b/kingpin/actors/pingdom.py
@@ -78,7 +78,6 @@ class PingdomClient(api.RestClient):
 
 
 class PingdomBase(base.BaseActor):
-
     """Simple Pingdom Abstract Base Object"""
 
     all_options = {
@@ -114,7 +113,6 @@ class PingdomBase(base.BaseActor):
 
 
 class Pause(PingdomBase):
-
     """Start Pingdom Maintenance.
 
     Pause a particular "check" on Pingdom.
@@ -158,7 +156,6 @@ class Pause(PingdomBase):
 
 
 class Unpause(PingdomBase):
-
     """Stop Pingdom Maintenance.
 
     Unpause a particular "check" on Pingdom.

--- a/kingpin/actors/rollbar.py
+++ b/kingpin/actors/rollbar.py
@@ -53,7 +53,6 @@ TOKEN = os.getenv("ROLLBAR_TOKEN", None)
 
 
 class RollbarBase(base.HTTPBaseActor):
-
     """Simple Rollbar Base Abstract Actor"""
 
     def __init__(self, *args, **kwargs):
@@ -141,7 +140,6 @@ class RollbarBase(base.HTTPBaseActor):
 
 
 class Deploy(RollbarBase):
-
     """Posts a Deploy message to Rollbar.
 
     https://rollbar.com/docs/deploys_other/

--- a/kingpin/actors/slack.py
+++ b/kingpin/actors/slack.py
@@ -70,7 +70,6 @@ class SlackAPI(api.RestConsumer):
 
 
 class SlackBase(base.BaseActor):
-
     """Simple Slack Abstract Base Object"""
 
     def __init__(self, *args, **kwargs):
@@ -122,7 +121,6 @@ class SlackBase(base.BaseActor):
 
 
 class Message(SlackBase):
-
     """Sends a message to a channel in Slack.
 
     **Options**

--- a/kingpin/actors/spotinst.py
+++ b/kingpin/actors/spotinst.py
@@ -126,7 +126,6 @@ class SpotinstAPI(api.RestConsumer):
 
 
 class SpotinstException(exceptions.RecoverableActorFailure):
-
     """Base SpotInst exception handler.
 
     This exception handler parses the Spotinst returned messages when an error
@@ -182,7 +181,6 @@ class SpotinstException(exceptions.RecoverableActorFailure):
 
 
 class InvalidConfig(SpotinstException):
-
     """Thrown when an invalid request was supplied to Spotinst"""
 
 
@@ -209,7 +207,6 @@ class SpotinstRestClient(api.RestClient):
 
 
 class ElastiGroupSchema(SchemaCompareBase):
-
     """Light validation against the Spotinst ElastiGroup schema.
 
     For full description of the JSON data format, please see:
@@ -277,7 +274,6 @@ class ElastiGroupSchema(SchemaCompareBase):
 
 
 class SpotinstBase(base.EnsurableBaseActor):
-
     """Simple Spotinst Abstract Base Object"""
 
     def __init__(self, *args, **kwargs):
@@ -313,7 +309,6 @@ class SpotinstBase(base.EnsurableBaseActor):
 
 
 class ElastiGroup(SpotinstBase):
-
     """Manages an ElastiGroup in Spotinst.
 
     `Spotinst ElastiGroups
@@ -762,10 +757,10 @@ class ElastiGroup(SpotinstBase):
         # Decode both of the userData fields so we can actually see the
         # userdata differences.
         for config in (new, existing):
-            config["group"]["compute"]["launchSpecification"][
-                "userData"
-            ] = base64.b64decode(
-                config["group"]["compute"]["launchSpecification"]["userData"]
+            config["group"]["compute"]["launchSpecification"]["userData"] = (
+                base64.b64decode(
+                    config["group"]["compute"]["launchSpecification"]["userData"]
+                )
             )
 
         # We only allow a user to supply a single subnetId for each AZ (this is

--- a/kingpin/actors/test/integration_hipchat.py
+++ b/kingpin/actors/test/integration_hipchat.py
@@ -13,7 +13,6 @@ __author__ = "Matt Wise <matt@nextdoor.com>"
 
 
 class IntegrationHipchatMessage(testing.AsyncTestCase):
-
     """Simple high level integration tests agains the HipChat API.
 
     These tests actually hit the HipChat API and test that the code
@@ -67,7 +66,6 @@ class IntegrationHipchatMessage(testing.AsyncTestCase):
 
 
 class IntegrationHipchatTopic(testing.AsyncTestCase):
-
     """Simple high level integration tests agains the HipChat API.
 
     These tests actually hit the HipChat API and test that the code

--- a/kingpin/actors/test/integration_librato.py
+++ b/kingpin/actors/test/integration_librato.py
@@ -12,7 +12,6 @@ __author__ = "Charles McLaughlin <charles@nextdoor.com>"
 
 
 class IntegrationLibratoAnnotation(testing.AsyncTestCase):
-
     """Integration tests against the Librato API.
 
     These tests actually hit the Librato API and test that the code

--- a/kingpin/actors/test/integration_rollbar.py
+++ b/kingpin/actors/test/integration_rollbar.py
@@ -14,7 +14,6 @@ __author__ = "Matt Wise <matt@nextdoor.com>"
 
 
 class IntegrationRollbarDeploy(testing.AsyncTestCase):
-
     """Simple high level integration tests agains the Rollbar API.
 
     These tests actually hit the Rollbar API and test that the code

--- a/kingpin/actors/test/integration_slack.py
+++ b/kingpin/actors/test/integration_slack.py
@@ -13,7 +13,6 @@ __author__ = "Matt Wise <matt@nextdoor.com>"
 
 
 class IntegrationSlackMessage(testing.AsyncTestCase):
-
     """Simple high level integration tests agains the Slack API.
 
     These tests actually hit the Slack API and test that the code

--- a/kingpin/actors/test/integration_spotinst.py
+++ b/kingpin/actors/test/integration_spotinst.py
@@ -15,7 +15,6 @@ __author__ = "Matt Wise <matt@nextdoor.com>"
 
 
 class IntegrationSpotinstElastiGroup(testing.AsyncTestCase):
-
     """Integration tests against the Spotinst API.
 
     These tests actually hit the Spotinst API and test that the code

--- a/kingpin/actors/test/test_base.py
+++ b/kingpin/actors/test/test_base.py
@@ -29,7 +29,6 @@ __author__ = "Matt Wise <matt@nextdoor.com>"
 
 
 class FakeHTTPClientClass(object):
-
     """Fake HTTPClient object for testing"""
 
     response_value = None

--- a/kingpin/actors/test/test_group.py
+++ b/kingpin/actors/test/test_group.py
@@ -15,7 +15,6 @@ log = logging.getLogger(__name__)
 
 
 class FakeActor(base.BaseActor):
-
     """Fake Actor for Tests"""
 
     all_options = {
@@ -31,7 +30,6 @@ class FakeActor(base.BaseActor):
 
 
 class FakeActorRaises(base.BaseActor):
-
     """Fake Actor for Tests"""
 
     all_options = {"exception": (object, True, "What this actor will return")}
@@ -43,7 +41,6 @@ class FakeActorRaises(base.BaseActor):
 
 
 class FakeActorPopulate(base.BaseActor):
-
     """Fake Actor for Tests"""
 
     all_options = {

--- a/kingpin/actors/test/test_hipchat.py
+++ b/kingpin/actors/test/test_hipchat.py
@@ -16,7 +16,6 @@ __author__ = "Matt Wise <matt@nextdoor.com>"
 
 
 class FakeHTTPClientClass(object):
-
     """Fake HTTPClient object for testing"""
 
     response_value = None
@@ -27,7 +26,6 @@ class FakeHTTPClientClass(object):
 
 
 class FakeExceptionRaisingHTTPClientClass(object):
-
     """Fake HTTPClient object for testing"""
 
     response_value = None
@@ -38,7 +36,6 @@ class FakeExceptionRaisingHTTPClientClass(object):
 
 
 class TestHipchatBase(testing.AsyncTestCase):
-
     """Unit tests for the Hipchat Message actor."""
 
     def setUp(self, *args, **kwargs):
@@ -93,7 +90,6 @@ class TestHipchatBase(testing.AsyncTestCase):
 
 
 class TestHipchatMessage(testing.AsyncTestCase):
-
     """Unit tests for the Hipchat Message actor."""
 
     def setUp(self, *args, **kwargs):
@@ -222,7 +218,6 @@ class TestHipchatMessage(testing.AsyncTestCase):
 
 
 class TestHipchatTopic(testing.AsyncTestCase):
-
     """Unit tests for the Hipchat Message actor."""
 
     def setUp(self, *args, **kwargs):

--- a/kingpin/actors/test/test_packagecloud.py
+++ b/kingpin/actors/test/test_packagecloud.py
@@ -72,7 +72,6 @@ def _get_older_than():
 
 
 class TestPackagecloudBase(testing.AsyncTestCase):
-
     """Unit tests for the packagecloud Base actor."""
 
     def setUp(self, *args, **kwargs):
@@ -259,7 +258,6 @@ class TestPackagecloudBase(testing.AsyncTestCase):
 
 
 class TestDelete(testing.AsyncTestCase):
-
     """Unit tests for the packagecloud Delete actor."""
 
     def setUp(self, *args, **kwargs):
@@ -292,7 +290,6 @@ class TestDelete(testing.AsyncTestCase):
 
 
 class TestDeleteByDate(testing.AsyncTestCase):
-
     """Unit tests for the packagecloud DeleteByDate actor."""
 
     def setUp(self, *args, **kwargs):
@@ -325,7 +322,6 @@ class TestDeleteByDate(testing.AsyncTestCase):
 
 
 class TestWaitForPackage(testing.AsyncTestCase):
-
     """Unit tests for the packagecloud WaitForPackage actor."""
 
     def setUp(self, *args, **kwargs):

--- a/kingpin/actors/test/test_rollbar.py
+++ b/kingpin/actors/test/test_rollbar.py
@@ -16,7 +16,6 @@ __author__ = "Matt Wise <matt@nextdoor.com>"
 
 
 class FakeHTTPClientClass(object):
-
     """Fake HTTPClient object for testing"""
 
     response_value = None
@@ -27,7 +26,6 @@ class FakeHTTPClientClass(object):
 
 
 class FakeExceptionRaisingHTTPClientClass(object):
-
     """Fake HTTPClient object for testing"""
 
     response_value = None
@@ -38,7 +36,6 @@ class FakeExceptionRaisingHTTPClientClass(object):
 
 
 class TestRollbarBase(testing.AsyncTestCase):
-
     """Unit tests for the Rollbar base actor."""
 
     def setUp(self, *args, **kwargs):
@@ -170,7 +167,6 @@ class TestRollbarBase(testing.AsyncTestCase):
 
 
 class TestDeploy(testing.AsyncTestCase):
-
     """Unit tests for the Rollbar Deploy actor."""
 
     def setUp(self, *args, **kwargs):

--- a/kingpin/actors/test/test_slack.py
+++ b/kingpin/actors/test/test_slack.py
@@ -14,7 +14,6 @@ __author__ = "Matt Wise <matt@nextdoor.com>"
 
 
 class TestSlackBase(testing.AsyncTestCase):
-
     """Unit tests for the Slack Base actor."""
 
     def setUp(self, *args, **kwargs):
@@ -68,7 +67,6 @@ class TestSlackBase(testing.AsyncTestCase):
 
 
 class TestMessage(testing.AsyncTestCase):
-
     """Unit tests for the Slack Message actor."""
 
     def setUp(self, *args, **kwargs):

--- a/kingpin/actors/test/test_spotinst.py
+++ b/kingpin/actors/test/test_spotinst.py
@@ -95,7 +95,6 @@ class TestSpotinstException(testing.AsyncTestCase):
 
 
 class TestSpotinstBase(testing.AsyncTestCase):
-
     """Unit tests for the packagecloud Base actor."""
 
     def setUp(self, *args, **kwargs):
@@ -121,7 +120,6 @@ class TestSpotinstBase(testing.AsyncTestCase):
 
 
 class TestElastiGroup(testing.AsyncTestCase):
-
     """Unit tests for the ElastiGroup actor."""
 
     def setUp(self, *args, **kwargs):

--- a/kingpin/actors/test/test_utils.py
+++ b/kingpin/actors/test/test_utils.py
@@ -15,7 +15,6 @@ log = logging.getLogger(__name__)
 
 
 class FakeActor(base.BaseActor):
-
     """Fake Actor use for Unit Tests"""
 
     def __init__(self, *args, **kwargs):

--- a/kingpin/bin/deploy.py
+++ b/kingpin/bin/deploy.py
@@ -236,7 +236,7 @@ def begin():
         # Skip traceback that involves tornado's libraries.
         import traceback
 
-        trace_lines = traceback.format_exc(e).splitlines()
+        trace_lines = traceback.format_exc().splitlines()
         skip_next = False
         for l in trace_lines:
             if "tornado" in l:

--- a/kingpin/constants.py
+++ b/kingpin/constants.py
@@ -21,12 +21,10 @@ __author__ = "Mikhail Simin <mikhail@nextdoor.com>"
 
 
 class REQUIRED(object):
-
     """Meta class to identify required arguments for actors."""
 
 
 class StringCompareBase(object):
-
     """Meta class to identify the desired state for a resource.
 
     This basic type of constant allows someone to easily define a set of valid
@@ -45,7 +43,6 @@ class StringCompareBase(object):
 
 
 class STATE(StringCompareBase):
-
     """Meta class to identify the desired state for a resource.
 
     Simple tester for 'present' or 'absent' on actors. Used for any actor thats
@@ -56,7 +53,6 @@ class STATE(StringCompareBase):
 
 
 class SchemaCompareBase(object):
-
     """Meta class that compares the schema of a dict against rules."""
 
     SCHEMA = None

--- a/kingpin/exceptions.py
+++ b/kingpin/exceptions.py
@@ -14,15 +14,12 @@
 
 
 class KingpinException(Exception):
-
     """Base Exception"""
 
 
 class InvalidScript(KingpinException):
-
     """Raised when an invalid script schema was detected"""
 
 
 class InvalidScriptName(KingpinException):
-
     """Raised when the script name does not end on .yaml or .json"""

--- a/kingpin/test/test_utils.py
+++ b/kingpin/test/test_utils.py
@@ -91,28 +91,28 @@ class TestUtils(unittest.TestCase):
 
     def test_populate_with_escape_strict_fail(self):
         tokens = {"UNIT_TEST": "FOOBAR"}
-        string = "Unit \%UNIT_TEST\% Test %TEST_TWO%"
+        string = "Unit \\%UNIT_TEST\\% Test %TEST_TWO%"
         with self.assertRaises(LookupError):
             utils.populate_with_tokens(string, tokens, strict=True)
 
     def test_populate_with_escape_strict(self):
         tokens = {"UNIT_TEST": "FOOBAR"}
-        string = "Unit \%UNIT_TEST\% Test"
+        string = "Unit \\%UNIT_TEST\\% Test"
         expect = "Unit %UNIT_TEST% Test"
         result = utils.populate_with_tokens(string, tokens, strict=True)
         self.assertEqual(result, expect)
 
     def test_populate_with_escape_non_strict(self):
         tokens = {"UNIT_TEST": "FOOBAR"}
-        string = "Unit \%UNIT_TEST\% Test"
+        string = "Unit \\%UNIT_TEST\\% Test"
         expect = "Unit %UNIT_TEST% Test"
         result = utils.populate_with_tokens(string, tokens, strict=False)
         self.assertEqual(result, expect)
 
     def test_populate_with_escape_non_strict_no_escape(self):
         tokens = {"UNIT_TEST": "FOOBAR"}
-        string = "Unit \%UNIT_TEST\% Test"
-        expect = "Unit \%UNIT_TEST\% Test"
+        string = "Unit \\%UNIT_TEST\\% Test"
+        expect = "Unit \\%UNIT_TEST\\% Test"
         result = utils.populate_with_tokens(
             string, tokens, strict=False, remove_escape_sequence=False
         )

--- a/kingpin/utils.py
+++ b/kingpin/utils.py
@@ -62,6 +62,7 @@ STATIC_PATH_NAME = "static"
 # THREADPOOL_SIZE = 10
 # THREADPOOL = futures.ThreadPoolExecutor(THREADPOOL_SIZE)
 
+
 # https://github.com/yaml/pyyaml/issues/64
 # https://github.com/zerwes/hiyapyco/issues/7
 #
@@ -465,7 +466,6 @@ def create_repeating_log(logger, message, handle=None, **kwargs):
     """
 
     class OpaqueHandle(object):
-
         """Tornado async io handler."""
 
         def __init__(self):


### PR DESCRIPTION
Docs: https://docs.python.org/3.11/library/traceback.html#traceback.format_exc

Fixes exception thrown during exception throwing:

```
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/circleci/project/.venv/bin/kingpin", line 8, in <module>
    sys.exit(begin())
             ^^^^^^^
  File "/home/circleci/project/.venv/lib/python3.11/site-packages/kingpin/bin/deploy.py", line 239, in begin
    trace_lines = traceback.format_exc(e).splitlines()
                  ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/circleci/.pyenv/versions/3.11.9/lib/python3.11/traceback.py", line 184, in format_exc
    return "".join(format_exception(*sys.exc_info(), limit=limit, chain=chain))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[...]
  File "/home/circleci/.pyenv/versions/3.11.9/lib/python3.11/traceback.py", line 406, in _extract_from_extended_frame_gen
    if limit >= 0:
       ^^^^^^^^^^
TypeError: '>=' not supported between instances of 'LookupError' and 'int'
```

Full traceback:

```
Traceback (most recent call last):
  File "/home/circleci/project/.venv/lib/python3.11/site-packages/kingpin/bin/deploy.py", line 231, in begin
    ioloop.IOLoop.instance().run_sync(main)
  File "/home/circleci/project/.venv/lib/python3.11/site-packages/tornado/ioloop.py", line 532, in run_sync
    return future_cell[0].result()
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/circleci/project/.venv/lib/python3.11/site-packages/tornado/gen.py", line 209, in wrapper
    yielded = next(result)
              ^^^^^^^^^^^^
  File "/home/circleci/project/.venv/lib/python3.11/site-packages/kingpin/bin/deploy.py", line 212, in main
    runner = get_main_actor(dry=args.dry)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/circleci/project/.venv/lib/python3.11/site-packages/kingpin/bin/deploy.py", line 159, in get_main_actor
    return Macro(
           ^^^^^^
  File "/home/circleci/project/.venv/lib/python3.11/site-packages/kingpin/actors/misc.py", line 182, in __init__
    self.initial_actor = group.Sync(options={"acts": config}, dry=self._dry)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/circleci/project/.venv/lib/python3.11/site-packages/kingpin/actors/group.py", line 105, in __init__
    self._actions = self._build_actions()
                    ^^^^^^^^^^^^^^^^^^^^^
  File "/home/circleci/project/.venv/lib/python3.11/site-packages/kingpin/actors/group.py", line 134, in _build_actions
    return self._build_action_group(self._init_context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/circleci/project/.venv/lib/python3.11/site-packages/kingpin/actors/group.py", line 184, in _build_action_group
    actor = utils.get_actor(act, dry=self._dry)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/circleci/project/.venv/lib/python3.11/site-packages/kingpin/actors/utils.py", line 151, in get_actor
    return ActorClass(dry=dry, **config)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/circleci/project/.venv/lib/python3.11/site-packages/kingpin/actors/group.py", line 105, in __init__
    self._actions = self._build_actions()
                    ^^^^^^^^^^^^^^^^^^^^^
  File "/home/circleci/project/.venv/lib/python3.11/site-packages/kingpin/actors/group.py", line 164, in _build_actions
    for action in self._build_action_group(context=combined_context):
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/circleci/project/.venv/lib/python3.11/site-packages/kingpin/actors/group.py", line 184, in _build_action_group
    actor = utils.get_actor(act, dry=self._dry)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/circleci/project/.venv/lib/python3.11/site-packages/kingpin/actors/utils.py", line 151, in get_actor
    return ActorClass(dry=dry, **config)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/circleci/project/.venv/lib/python3.11/site-packages/kingpin/actors/misc.py", line 182, in __init__
    self.initial_actor = group.Sync(options={"acts": config}, dry=self._dry)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/circleci/project/.venv/lib/python3.11/site-packages/kingpin/actors/group.py", line 105, in __init__
    self._actions = self._build_actions()
                    ^^^^^^^^^^^^^^^^^^^^^
  File "/home/circleci/project/.venv/lib/python3.11/site-packages/kingpin/actors/group.py", line 134, in _build_actions
    return self._build_action_group(self._init_context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/circleci/project/.venv/lib/python3.11/site-packages/kingpin/actors/group.py", line 184, in _build_action_group
    actor = utils.get_actor(act, dry=self._dry)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/circleci/project/.venv/lib/python3.11/site-packages/kingpin/actors/utils.py", line 151, in get_actor
    return ActorClass(dry=dry, **config)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/circleci/project/.venv/lib/python3.11/site-packages/kingpin/actors/aws/cloudformation.py", line 922, in __init__
    self._template_body, self._template_url = self._get_template_body(
                                              ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/circleci/project/.venv/lib/python3.11/site-packages/kingpin/actors/aws/cloudformation.py", line 293, in _get_template_body
    json.dumps(self._parse_policy_json(template), cls=DateEncoder),
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/circleci/project/.venv/lib/python3.11/site-packages/kingpin/actors/aws/base.py", line 216, in _parse_policy_json
    p_doc = utils.convert_script_to_dict(
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/circleci/project/.venv/lib/python3.11/site-packages/kingpin/utils.py", line 397, in convert_script_to_dict
    parsed = populate_with_tokens(raw, tokens)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/circleci/project/.venv/lib/python3.11/site-packages/kingpin/utils.py", line 354, in populate_with_tokens
    raise LookupError(
LookupError: Found un-matched tokens in JSON string: ['%2Forganization%']

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/circleci/project/.venv/bin/kingpin", line 8, in <module>
    sys.exit(begin())
             ^^^^^^^
  File "/home/circleci/project/.venv/lib/python3.11/site-packages/kingpin/bin/deploy.py", line 239, in begin
    trace_lines = traceback.format_exc(e).splitlines()
                  ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/circleci/.pyenv/versions/3.11.9/lib/python3.11/traceback.py", line 184, in format_exc
    return "".join(format_exception(*sys.exc_info(), limit=limit, chain=chain))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/circleci/.pyenv/versions/3.11.9/lib/python3.11/traceback.py", line 139, in format_exception
    te = TracebackException(type(value), value, tb, limit=limit, compact=True)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/circleci/.pyenv/versions/3.11.9/lib/python3.11/traceback.py", line 728, in __init__
    self.stack = StackSummary._extract_from_extended_frame_gen(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/circleci/.pyenv/versions/3.11.9/lib/python3.11/traceback.py", line 406, in _extract_from_extended_frame_gen
    if limit >= 0:
       ^^^^^^^^^^
TypeError: '>=' not supported between instances of 'LookupError' and 'int'
make: *** [Makefile:206: test] Error 1

Exited with code exit status 2
```