### PR TITLE
feat(cfn): Append hash to outputs

### DIFF
--- a/kingpin/actors/aws/cloudformation.py
+++ b/kingpin/actors/aws/cloudformation.py
@@ -242,7 +242,9 @@ class CloudFormationBaseActor(base.AWSBaseActor):
         template_obj = json.loads(template_str)
 
         if len(KINGPIN_CFN_HASH_OUTPUT_KEY) > 0:
-            if "Outputs" not in template_obj.keys() or not isinstance(template_obj["Outputs"], dict):
+            if "Outputs" not in template_obj.keys() or not isinstance(
+                template_obj["Outputs"], dict
+            ):
                 return template_str
 
             template_outputs_keys = template_obj["Outputs"].keys()
@@ -308,7 +310,9 @@ class CloudFormationBaseActor(base.AWSBaseActor):
         else:
             # The template is provided inline.
             try:
-                ret_template = json.dumps(self._parse_policy_json(template), cls=DateEncoder)
+                ret_template = json.dumps(
+                    self._parse_policy_json(template), cls=DateEncoder
+                )
             except exceptions.UnrecoverableActorFailure as e:
                 raise InvalidTemplate(e)
 
@@ -1117,7 +1121,9 @@ class Stack(CloudFormationBaseActor):
             # overwrite the outputs with an empty dict
             template_obj["Outputs"] = {}
 
-        template_obj["Outputs"][KINGPIN_CFN_HASH_OUTPUT_KEY] = {"Value": md5(datetime.now())}
+        template_obj["Outputs"][KINGPIN_CFN_HASH_OUTPUT_KEY] = {
+            "Value": md5(datetime.now())
+        }
 
         return json.dumps(template_obj)
 

--- a/kingpin/actors/aws/cloudformation.py
+++ b/kingpin/actors/aws/cloudformation.py
@@ -240,7 +240,7 @@ class CloudFormationBaseActor(base.AWSBaseActor):
         """
 
         # Bail if the user has disabled this feature.
-        if len(KINGPIN_CFN_HASH_OUTPUT_KEY) == 0:
+        if not KINGPIN_CFN_HASH_OUTPUT_KEY:
             return template
 
         # Bail if the "Outputs" section is missing or a type we do not expect.
@@ -1118,7 +1118,7 @@ class Stack(CloudFormationBaseActor):
         """Add a hash to the template to force a change in the stack."""
 
         # Bail if the user has disabled this feature.
-        if len(KINGPIN_CFN_HASH_OUTPUT_KEY) == 0:
+        if not KINGPIN_CFN_HASH_OUTPUT_KEY:
             return self._template_body
 
         template_obj = json.loads(self._template_body)

--- a/kingpin/actors/aws/cloudformation.py
+++ b/kingpin/actors/aws/cloudformation.py
@@ -1122,7 +1122,9 @@ class Stack(CloudFormationBaseActor):
             template_obj["Outputs"] = {}
 
         template_obj["Outputs"][KINGPIN_CFN_HASH_OUTPUT_KEY] = {
-            "Value": md5(datetime.datetime.now(datetime.timezone.utc))
+            "Value": md5(
+                datetime.datetime.now(datetime.timezone.utc).isoformat().encode()
+            ).hexdigest()
         }
 
         return json.dumps(template_obj)

--- a/kingpin/actors/aws/cloudformation.py
+++ b/kingpin/actors/aws/cloudformation.py
@@ -1117,6 +1117,10 @@ class Stack(CloudFormationBaseActor):
     def _template_body_with_hash(self) -> str:
         """Add a hash to the template to force a change in the stack."""
 
+        # Bail if the user has disabled this feature.
+        if len(KINGPIN_CFN_HASH_OUTPUT_KEY) == 0:
+            return self._template_body
+
         template_obj = json.loads(self._template_body)
 
         if not isinstance(template_obj.get("Outputs", None), dict):
@@ -1161,12 +1165,7 @@ class Stack(CloudFormationBaseActor):
         if self._template_url:
             change_opts["TemplateURL"] = self._template_url
         else:
-            if len(KINGPIN_CFN_HASH_OUTPUT_KEY) > 0:
-                # Hack in a "CFN change" so we can avoid the "No changes" error (for instance, when
-                # only conditional resources get changed in the source template)
-                change_opts["TemplateBody"] = self._template_body_with_hash()
-            else:
-                change_opts["TemplateBody"] = self._template_body
+            change_opts["TemplateBody"] = self._template_body_with_hash()
 
         self.log.info("Generating a stack Change Set...")
         try:

--- a/kingpin/actors/aws/cloudformation.py
+++ b/kingpin/actors/aws/cloudformation.py
@@ -1122,7 +1122,7 @@ class Stack(CloudFormationBaseActor):
             template_obj["Outputs"] = {}
 
         template_obj["Outputs"][KINGPIN_CFN_HASH_OUTPUT_KEY] = {
-            "Value": md5(datetime.now())
+            "Value": md5(datetime.datetime.now(datetime.timezone.utc))
         }
 
         return json.dumps(template_obj)

--- a/kingpin/actors/aws/settings.py
+++ b/kingpin/actors/aws/settings.py
@@ -41,3 +41,6 @@ AWS_SESSION_TOKEN = os.getenv("AWS_SESSION_TOKEN", None)
 # Docs: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/retries.html
 AWS_MAX_ATTEMPTS = int(os.getenv("AWS_MAX_ATTEMPTS", 10))
 AWS_RETRY_MODE = os.getenv("AWS_RETRY_MODE", "standard")
+
+# Set to "" (an empty string) to disable.
+KINGPIN_CFN_HASH_OUTPUT_KEY = os.getenv("KINGPIN_CFN_HASH_OUTPUT_KEY", "KingpinCfnHash")

--- a/kingpin/actors/aws/test/test_cloudformation.py
+++ b/kingpin/actors/aws/test/test_cloudformation.py
@@ -519,7 +519,14 @@ class TestCreate(testing.AsyncTestCase):
     @testing.gen_test
     def test_create_stack_url(self):
         with mock.patch.object(boto3, "client"):
-            with mock.patch.object(cloudformation.CloudFormationBaseActor, "_get_template_body", return_value=('{"fake": "template"}', "https://bucket.s3.us-west-2.amazonaws.com/key")):
+            with mock.patch.object(
+                cloudformation.CloudFormationBaseActor,
+                "_get_template_body",
+                return_value=(
+                    '{"fake": "template"}',
+                    "https://bucket.s3.us-west-2.amazonaws.com/key",
+                ),
+            ):
                 actor = cloudformation.Create(
                     "Unit Test Action",
                     {

--- a/kingpin/actors/aws/test/test_cloudformation.py
+++ b/kingpin/actors/aws/test/test_cloudformation.py
@@ -92,7 +92,7 @@ class TestCloudFormationBaseActor(testing.AsyncTestCase):
             "LocationConstraint": None
         }
 
-        expected_template = "i am a cfn template"
+        expected_template = '{"fake": "template"}'
         with mock.patch.object(self.actor, "get_s3_client") as mock_get:
             mock_s3 = mock.MagicMock()
             mock_body = mock.MagicMock()
@@ -248,11 +248,14 @@ class TestCloudFormationBaseActor(testing.AsyncTestCase):
             "TemplateBody": {"Fake": "Stack"},
         }
         self.actor.cf3_conn.get_template.return_value = fake_stack_template
+
         ret = yield self.actor._get_stack_template("test")
+
         self.actor.cf3_conn.get_template.assert_has_calls(
             [mock.call(StackName="test", TemplateStage="Original")]
         )
-        self.assertEqual(ret, {"Fake": "Stack"})
+        # self.assertEqual(dict(ret), {"Fake": "Stack"})
+        self.assertEqual(type(ret), type({"Fake": "Stack"}))
 
     @testing.gen_test
     def test_get_stack_template_exc(self):
@@ -516,14 +519,15 @@ class TestCreate(testing.AsyncTestCase):
     @testing.gen_test
     def test_create_stack_url(self):
         with mock.patch.object(boto3, "client"):
-            actor = cloudformation.Create(
-                "Unit Test Action",
-                {
-                    "name": "unit-test-cf",
-                    "region": "us-west-2",
-                    "template": "s3://bucket/key",
-                },
-            )
+            with mock.patch.object(cloudformation.CloudFormationBaseActor, "_get_template_body", return_value=('{"fake": "template"}', "https://bucket.s3.us-west-2.amazonaws.com/key")):
+                actor = cloudformation.Create(
+                    "Unit Test Action",
+                    {
+                        "name": "unit-test-cf",
+                        "region": "us-west-2",
+                        "template": "s3://bucket/key",
+                    },
+                )
         actor._wait_until_state = mock.MagicMock(name="_wait_until_state")
         actor._wait_until_state.side_effect = [tornado_value(None)]
         actor.cf3_conn.create_stack = mock.MagicMock(name="create_stack_mock")
@@ -1077,7 +1081,7 @@ class TestStack(testing.AsyncTestCase):
             [
                 mock.call(
                     StackName="arn:aws:cloudformation:us-east-1:xxxx:stack/fake/x",
-                    TemplateBody='{"blank": "json"}',
+                    TemplateBody='{"blank": "json", "Outputs": {"KingpinCfnHash": {"Value": "251693d288f81514f8f49b594fc83e47"}}}',
                     Capabilities=[],
                     ChangeSetName="kingpin-uuid",
                     Parameters=[{"ParameterValue": "value1", "ParameterKey": "key1"}],
@@ -1097,7 +1101,7 @@ class TestStack(testing.AsyncTestCase):
             [
                 mock.call(
                     StackName="arn:aws:cloudformation:us-east-1:xxxx:stack/fake/x",
-                    TemplateBody='{"blank": "json"}',
+                    TemplateBody='{"blank": "json", "Outputs": {"KingpinCfnHash": {"Value": "251693d288f81514f8f49b594fc83e47"}}}',
                     RoleARN="test_role_arn",
                     Capabilities=[],
                     ChangeSetName="kingpin-uuid",

--- a/kingpin/actors/aws/test/test_cloudformation.py
+++ b/kingpin/actors/aws/test/test_cloudformation.py
@@ -254,8 +254,7 @@ class TestCloudFormationBaseActor(testing.AsyncTestCase):
         self.actor.cf3_conn.get_template.assert_has_calls(
             [mock.call(StackName="test", TemplateStage="Original")]
         )
-        # self.assertEqual(dict(ret), {"Fake": "Stack"})
-        self.assertEqual(type(ret), type({"Fake": "Stack"}))
+        self.assertEqual(ret, {"Fake": "Stack"})
 
     @testing.gen_test
     def test_get_stack_template_exc(self):

--- a/kingpin/version.py
+++ b/kingpin/version.py
@@ -13,4 +13,4 @@
 # Copyright 2018 Nextdoor.com, Inc
 
 
-__version__ = "3.0.4"
+__version__ = "3.1.0"


### PR DESCRIPTION
This error appears sometimes when editing a cfn template:

> 00:39:22 CRITICAL [DRY: S3-LOGGING-BUCKET (us-east-2)] Unexpected Change Set state (Status) received (FAILED): No updates are to be performed.

This is a bit of an oddity between `kingpin` and CFN.

`kingpin` is pushing an update to CFN because the template has changed, but CFN is denying that there are any changes because physical resources in CFN template have not actually changes. This is likely because the PR is only making changes to conditional resources in the CFN template yet there are CFN stacks using this template that do not deploy that conditional resource - therefore leading to CFN believing there was "no update".

~~To resolve this, they need to bump the metadata in the CFN template on a non-conditional resource.~~

^ This action is no longer required of the engineer.

Through testing, we have figured out that modifying an `Outputs` map entry counts as a CFN change. Therefore we have added some code to automatically append a special output entry that `kingpin` will manage internally. If there is a diff in the live stack template vs the template we input into the `kingpin` script, our new code will ensure we add an extra output value hash when creating a changeset. We also take care to strip this managed output when re-downloading the stack from the live state.

You can disable all of this functionality by setting the `KINGPIN_CFN_HASH_OUTPUT_KEY` env var to an empty string.