### PR TITLE
fix(ci): Fix flaky tests related to stubber out of order expectations

### DIFF
--- a/kingpin/version.py
+++ b/kingpin/version.py
@@ -1,3 +1,3 @@
 """Kingpin version number. You must bump this when creating a new release."""
 
-__version__ = "4.0.0"
+__version__ = "4.0.1"


### PR DESCRIPTION
boto3 Stubber expects calls to come in order. However, our code (or the underlying libraries) can do calls in a random order. This PR helps eliviate the in order expectations.