### PR TITLE
chore(deps): limit boto3 patch updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,8 +16,16 @@
   ],
   "packageRules": [
     {
-      "matchUpdateTypes": [ "patch", "minor" ],
+      "matchUpdateTypes": ["patch", "minor"],
       "automerge": true
+    },
+    {
+      "matchPackageNames": ["boto3"],
+      "matchUpdateTypes": ["patch"],
+      "groupName": "boto3 patch updates",
+      "schedule": ["before 5am on monday"],
+      "prConcurrentLimit": 1,
+      "automerge": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Configures renovate to group boto3 patch updates together
- Limits boto3 patch PRs to once per week (Mondays before 5am)
- Restricts to 1 concurrent PR for boto3 patches
- Disables automerge for boto3 patch updates to allow manual review

## Test plan
- [ ] Verify renovate configuration is valid
- [ ] Confirm boto3 patch updates only create PRs on Mondays
- [ ] Confirm only 1 boto3 patch PR can be open at a time

🤖 Generated with [Claude Code](https://claude.com/claude-code)