### PR TITLE
fix(deps): resolve setuptools deprecation warnings in build

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,1 @@
 include README.rst
-include requirements*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "kingpin"
 description = "Deployment Automation Engine"
 requires-python = ">=3.9"
-license = {text = "Apache License, Version 2.0"}
+license = "Apache-2.0"
 authors = [{name = "Nextdoor Engineering"}]
 maintainers = [{name = "Nextdoor Engineering"},]
 keywords = [
@@ -16,7 +16,6 @@ keywords = [
 classifiers = [
   "Development Status :: 4 - Beta",
   "Intended Audience :: Developers",
-  "License :: OSI Approved :: Apache Software License",
   "Natural Language :: English",
   "Operating System :: POSIX",
   "Programming Language :: Python :: 3",


### PR DESCRIPTION
## Summary
- Migrate `project.license` from deprecated table format to SPDX string (`"Apache-2.0"`)
- Remove deprecated `License :: OSI Approved :: Apache Software License` classifier
- Remove stale `include requirements*` from `MANIFEST.in` (leftover from pip-to-uv migration in #643)

## Test plan
- [x] `make build 2>&1 | grep -iE 'warning|deprecated'` produces zero output
- [x] `make test` — 396 passed, 100% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)