### PR TITLE
chore(release): bump version to 5.0.2

### DIFF
--- a/kingpin/version.py
+++ b/kingpin/version.py
@@ -1,3 +1,3 @@
 """Kingpin version number. You must bump this when creating a new release."""
 
-__version__ = "5.0.1"
+__version__ = "5.0.2"


### PR DESCRIPTION
## Summary
- Bump kingpin version from 5.0.1 to 5.0.2

## Release Checklist
- [ ] Tests pass (CI will verify)
- [ ] Merge this PR, then publish a GitHub Release tagged `v5.0.2` to trigger PyPI publish