### PR TITLE
fix(actors): replace deprecated IOLoop.instance() with IOLoop.current()

### DIFF
--- a/kingpin/bin/deploy.py
+++ b/kingpin/bin/deploy.py
@@ -222,7 +222,7 @@ def begin():
     utils.setup_root_logger(level=args.level, color=args.color)
 
     try:
-        ioloop.IOLoop.instance().run_sync(main)
+        ioloop.IOLoop.current().run_sync(main)
     except KeyboardInterrupt:
         log.info("CTRL-C Caught, shutting down")
         sys.exit(130)  # Standard KeyboardInterrupt exit code.

--- a/kingpin/bin/test/test_deploy.py
+++ b/kingpin/bin/test/test_deploy.py
@@ -231,8 +231,8 @@ class TestDeploy(unittest.TestCase):
     )
     def test_begin_keyboard_interrupt(self):
         self._import_kingpin_bin_deploy()
-        with mock.patch("tornado.ioloop.IOLoop.instance") as mock_ioloop_instance:
-            mock_ioloop_instance.side_effect = KeyboardInterrupt()
+        with mock.patch("tornado.ioloop.IOLoop.current") as mock_ioloop_current:
+            mock_ioloop_current.side_effect = KeyboardInterrupt()
             with self.assertRaises(SystemExit) as cm:
                 self.kingpin_bin_deploy.begin()
                 self.assertEqual(cm.exception.code, 130)


### PR DESCRIPTION
## Summary
- Replace `IOLoop.instance()` with `IOLoop.current()` in the CLI entry point (`kingpin/bin/deploy.py`)
- Update the corresponding mock target in `test_begin_keyboard_interrupt` (`kingpin/bin/test/test_deploy.py`)

`IOLoop.instance()` has been deprecated since Tornado 5.0 (2018) and is a pass-through alias for `IOLoop.current()`. This was the sole remaining `instance()` call in the codebase — all other IOLoop references already use `current()`.

On Python 3.13, the `instance()` → `current()` → `asyncio.get_event_loop()` chain emits a `DeprecationWarning`, and future Python versions may promote this to a `RuntimeError`.

## Test plan
- [x] `pytest kingpin/bin/test/test_deploy.py` — 18/18 passed
- [x] `make test` — 396/396 passed, 100% coverage
- [x] `make lint` — clean
- [x] Manual dry-run smoke tests against example scripts
- [x] Integration dry-run validation against real deployment scripts in engineering

🤖 Generated with [Claude Code](https://claude.com/claude-code)