### PR TITLE
chore(release): bump version to 6.0.0

### DIFF
--- a/kingpin/version.py
+++ b/kingpin/version.py
@@ -1,3 +1,3 @@
 """Kingpin version number. You must bump this when creating a new release."""
 
-__version__ = "5.0.2"
+__version__ = "6.0.0"


### PR DESCRIPTION
## Summary
- Bump kingpin version from 5.0.2 to 6.0.0

## Release Checklist
- [ ] Tests pass (CI will verify)
- [ ] Merge this PR, then publish a GitHub Release tagged `v6.0.0` to trigger PyPI publish