### PR TITLE
refactor(actors): modernize Python idioms and remove Python 2 remnants

### DIFF
--- a/kingpin/actors/aws/base.py
+++ b/kingpin/actors/aws/base.py
@@ -65,7 +65,7 @@ class AWSBaseActor(base.BaseActor):
     def __init__(self, *args, **kwargs):
         """Check for required settings."""
 
-        super(AWSBaseActor, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         # By default, we will try to let Boto handle discovering its
         # credentials at instantiation time. This _can_ result in synchronous
@@ -168,7 +168,7 @@ class AWSBaseActor(base.BaseActor):
 
     def _wrap_boto_exception(self, e):
         if isinstance(e, boto3_exceptions.Boto3Error):
-            return exceptions.RecoverableActorFailure("Boto3 had a failure: %s" % e)
+            return exceptions.RecoverableActorFailure(f"Boto3 had a failure: {e}")
         return e
 
     def _parse_json(self, file_path):
@@ -189,7 +189,7 @@ class AWSBaseActor(base.BaseActor):
 
         # Run through any supplied JSON files and verify that they're
         # not corrupt very early on.
-        self.log.debug("Parsing and validating %s" % file_path)
+        self.log.debug(f"Parsing and validating {file_path}")
 
         try:
             p_doc = utils.load_json_with_tokens(
@@ -198,7 +198,7 @@ class AWSBaseActor(base.BaseActor):
             assert isinstance(p_doc, dict), f"Expected dict but got {type(p_doc)}"
         except kingpin_exceptions.InvalidScript as e:
             raise exceptions.UnrecoverableActorFailure(
-                "Error parsing %s: %s" % (file_path, e)
+                f"Error parsing {file_path}: {e}"
             )
 
         return p_doc

--- a/kingpin/actors/aws/test/test_api_call_queue.py
+++ b/kingpin/actors/aws/test/test_api_call_queue.py
@@ -20,7 +20,7 @@ class TestApiCallQueue(testing.AsyncTestCase):
     )
 
     def setUp(self):
-        super(TestApiCallQueue, self).setUp()
+        super().setUp()
         self.api_call_queue = api_call_queue.ApiCallQueue()
         self.api_call_queue.delay_min = 0.05
         self.api_call_queue.delay_max = 0.2

--- a/kingpin/actors/aws/test/test_base.py
+++ b/kingpin/actors/aws/test/test_base.py
@@ -49,7 +49,7 @@ TARGET_GROUP_RESPONSE = {
 
 class TestBase(testing.AsyncTestCase):
     def setUp(self):
-        super(TestBase, self).setUp()
+        super().setUp()
         settings.AWS_ACCESS_KEY_ID = "unit-test"
         settings.AWS_SECRET_ACCESS_KEY = "unit-test"
         settings.AWS_SESSION_TOKEN = "unit-test"

--- a/kingpin/actors/aws/test/test_cloudformation.py
+++ b/kingpin/actors/aws/test/test_cloudformation.py
@@ -51,7 +51,7 @@ def create_fake_stack_event(name, resource, status, reason=None):
 
 class TestCloudFormationBaseActor(testing.AsyncTestCase):
     def setUp(self):
-        super(TestCloudFormationBaseActor, self).setUp()
+        super().setUp()
         settings.AWS_ACCESS_KEY_ID = "unit-test"
         settings.AWS_SECRET_ACCESS_KEY = "unit-test"
         settings.AWS_SESSION_TOKEN = "unit-test"
@@ -401,7 +401,7 @@ class TestCloudFormationBaseActor(testing.AsyncTestCase):
 
 class TestCreate(testing.AsyncTestCase):
     def setUp(self):
-        super(TestCreate, self).setUp()
+        super().setUp()
         settings.AWS_ACCESS_KEY_ID = "unit-test"
         settings.AWS_SECRET_ACCESS_KEY = "unit-test"
         settings.AWS_SESSION_TOKEN = "unit-test"
@@ -690,7 +690,7 @@ class TestCreate(testing.AsyncTestCase):
 
 class TestDelete(testing.AsyncTestCase):
     def setUp(self):
-        super(TestDelete, self).setUp()
+        super().setUp()
         settings.AWS_ACCESS_KEY_ID = "unit-test"
         settings.AWS_SECRET_ACCESS_KEY = "unit-test"
         settings.AWS_SESSION_TOKEN = "unit-test"
@@ -796,7 +796,7 @@ class TestDelete(testing.AsyncTestCase):
 
 class TestStack(testing.AsyncTestCase):
     def setUp(self):
-        super(TestStack, self).setUp()
+        super().setUp()
         settings.AWS_ACCESS_KEY_ID = "unit-test"
         settings.AWS_SECRET_ACCESS_KEY = "unit-test"
         settings.AWS_SESSION_TOKEN = "unit-test"

--- a/kingpin/actors/aws/test/test_iam.py
+++ b/kingpin/actors/aws/test/test_iam.py
@@ -23,7 +23,7 @@ def tornado_value(*args):
 
 class TestIAMBaseActor(testing.AsyncTestCase):
     def setUp(self):
-        super(TestIAMBaseActor, self).setUp()
+        super().setUp()
         settings.AWS_ACCESS_KEY_ID = "unit-test"
         settings.AWS_SECRET_ACCESS_KEY = "unit-test"
         settings.AWS_SESSION_TOKEN = "unit-test"
@@ -496,7 +496,7 @@ class TestIAMBaseActor(testing.AsyncTestCase):
 
 class TestUser(testing.AsyncTestCase):
     def setUp(self):
-        super(TestUser, self).setUp()
+        super().setUp()
         settings.AWS_ACCESS_KEY_ID = "unit-test"
         settings.AWS_SECRET_ACCESS_KEY = "unit-test"
         settings.AWS_SESSION_TOKEN = "unit-test"
@@ -686,7 +686,7 @@ class TestUser(testing.AsyncTestCase):
 
 class TestGroup(testing.AsyncTestCase):
     def setUp(self):
-        super(TestGroup, self).setUp()
+        super().setUp()
         settings.AWS_ACCESS_KEY_ID = "unit-test"
         settings.AWS_SECRET_ACCESS_KEY = "unit-test"
         settings.AWS_SESSION_TOKEN = "unit-test"
@@ -846,7 +846,7 @@ class TestGroup(testing.AsyncTestCase):
 
 class TestRole(testing.AsyncTestCase):
     def setUp(self):
-        super(TestRole, self).setUp()
+        super().setUp()
         settings.AWS_ACCESS_KEY_ID = "unit-test"
         settings.AWS_SECRET_ACCESS_KEY = "unit-test"
         settings.AWS_SESSION_TOKEN = "unit-test"
@@ -1057,7 +1057,7 @@ class TestRole(testing.AsyncTestCase):
 
 class TestInstanceProfile(testing.AsyncTestCase):
     def setUp(self):
-        super(TestInstanceProfile, self).setUp()
+        super().setUp()
         settings.AWS_ACCESS_KEY_ID = "unit-test"
         settings.AWS_SECRET_ACCESS_KEY = "unit-test"
         settings.AWS_SESSION_TOKEN = "unit-test"

--- a/kingpin/actors/aws/test/test_s3.py
+++ b/kingpin/actors/aws/test/test_s3.py
@@ -14,7 +14,7 @@ log = logging.getLogger(__name__)
 
 class TestBucket(testing.AsyncTestCase):
     def setUp(self):
-        super(TestBucket, self).setUp()
+        super().setUp()
         settings.AWS_ACCESS_KEY_ID = "unit-test"
         settings.AWS_SECRET_ACCESS_KEY = "unit-test"
         settings.AWS_SESSION_TOKEN = "unit-test"

--- a/kingpin/actors/misc.py
+++ b/kingpin/actors/misc.py
@@ -141,12 +141,12 @@ class Macro(base.BaseActor):
             We override the default ``init_tokens={}`` from the base class and
             default it to a *copy* of the ``os.environ`` dict.
         """
-        super(Macro, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         # Temporary check that macro is a local file.
         self._check_macro()
 
-        self.log.info("Preparing actors from %s" % self.option("macro"))
+        self.log.info(f"Preparing actors from {self.option('macro')}")
 
         # Take the "init tokens" that were supplied to this actor by its parent
         # and merge them with the explicitly defined tokens in the actor
@@ -166,7 +166,7 @@ class Macro(base.BaseActor):
         # Instantiate the first actor, but don't execute it.
         # Any errors raised by this actor should be attributed to it, and not
         # this Macro actor. No try/catch here
-        if type(config) == list:
+        if isinstance(config, list):
             # List is a Sync group actor
             self.initial_actor = group.Sync(options={"acts": config}, dry=self._dry)
         else:
@@ -203,7 +203,7 @@ class Macro(base.BaseActor):
                 client.close()
             buf = io.StringIO()
             # Set buffer representation for debug printing.
-            buf.__repr__ = lambda: ("In-memory file from: %s" % self.option("macro"))
+            buf.__repr__ = lambda: (f"In-memory file from: {self.option('macro')}")
             buf.write(R.body)
             buf.seek(0)
             client.close()
@@ -232,7 +232,7 @@ class Macro(base.BaseActor):
             UnrecoverableActorFailure -
                 if parsing script or inserting env vars fails.
         """
-        self.log.debug("Parsing %s" % script_file)
+        self.log.debug(f"Parsing {script_file}")
         try:
             config = utils.load_json_with_tokens(
                 file_path=script_file, tokens=self._init_tokens
@@ -247,7 +247,7 @@ class Macro(base.BaseActor):
 
     def _check_schema(self, config):
         # Run the dict through our schema validator quickly
-        self.log.debug("Validating schema for %s" % self.option("macro"))
+        self.log.debug(f"Validating schema for {self.option('macro')}")
         try:
             schema.validate(config)
         except kingpin_exceptions.InvalidScript as e:
@@ -256,7 +256,7 @@ class Macro(base.BaseActor):
 
     def get_orgchart(self, parent=""):
         """Return orgchart including the actor inside of the macro file."""
-        ret = super(Macro, self).get_orgchart(parent=parent)
+        ret = super().get_orgchart(parent=parent)
         macro = self.initial_actor.get_orgchart(parent=str(id(self)))
         return ret + macro
 
@@ -301,7 +301,7 @@ class Sleep(base.BaseActor):
     def _execute(self):
         """Executes an actor and yields the results when its finished."""
 
-        self.log.debug("Sleeping for %s seconds" % self.option("sleep"))
+        self.log.debug(f"Sleeping for {self.option('sleep')} seconds")
 
         sleep = self.option("sleep")
 
@@ -367,7 +367,7 @@ class GenericHTTP(base.HTTPBaseActor):
         is_post = bool(self.option("data"))
         method = ["GET", "POST"][is_post]
 
-        self.log.info("Would do a %s request to %s" % (method, self.option("url")))
+        self.log.info(f"Would do a {method} request to {self.option('url')}")
         raise gen.Return()
 
     @gen.coroutine

--- a/kingpin/actors/test/test_base.py
+++ b/kingpin/actors/test/test_base.py
@@ -25,7 +25,7 @@ from kingpin.actors.test.helper import mock_tornado
 from kingpin.constants import REQUIRED, STATE
 
 
-class FakeHTTPClientClass(object):
+class FakeHTTPClientClass:
     """Fake HTTPClient object for testing"""
 
     response_value = None
@@ -50,7 +50,7 @@ class FakeEnsurableBaseActor(base.EnsurableBaseActor):
     def _precache(self):
         # Call our parent class precache.. no real need here other than for
         # unit test coverage.
-        yield super(FakeEnsurableBaseActor, self)._precache()
+        yield super()._precache()
 
         # These do not match -- so we'll trigger the setters
         self.state = "absent"
@@ -112,7 +112,7 @@ class TestBaseActor(testing.AsyncTestCase):
         raise gen.Return(False)
 
     def setUp(self):
-        super(TestBaseActor, self).setUp()
+        super().setUp()
 
         # Create a BaseActor object
         self.actor = base.BaseActor("Unit Test Action", {})
@@ -290,7 +290,7 @@ class TestBaseActor(testing.AsyncTestCase):
             "False": False,
             "FALSE": False,
         }
-        for value, should_execute in list(conditions.items()):
+        for value, should_execute in conditions.items():
             self.actor._condition = value
             self.actor._execute = mock_tornado()
             yield self.actor.execute()
@@ -415,7 +415,7 @@ class TestBaseActor(testing.AsyncTestCase):
 
 class TestEnsurableBaseActor(testing.AsyncTestCase):
     def setUp(self):
-        super(TestEnsurableBaseActor, self).setUp()
+        super().setUp()
         self.actor = FakeEnsurableBaseActor(
             "Unit Test Actor",
             {
@@ -465,7 +465,7 @@ class TestEnsurableBaseActor(testing.AsyncTestCase):
 
 class TestHTTPBaseActor(testing.AsyncTestCase):
     def setUp(self):
-        super(TestHTTPBaseActor, self).setUp()
+        super().setUp()
         self.actor = base.HTTPBaseActor("Unit Test Action", {})
 
     @testing.gen_test
@@ -546,7 +546,7 @@ class TestHTTPBaseActor(testing.AsyncTestCase):
 class TestActualEnsurableBaseActor(testing.AsyncTestCase):
     def setUp(self):
 
-        super(TestActualEnsurableBaseActor, self).setUp()
+        super().setUp()
         self.actor = base.EnsurableBaseActor(
             "Unit Test Actor",
             {

--- a/kingpin/actors/test/test_group.py
+++ b/kingpin/actors/test/test_group.py
@@ -59,7 +59,7 @@ class FakeActorPopulate(base.BaseActor):
 
 class TestGroupActorBaseClass(testing.AsyncTestCase):
     def setUp(self, *args, **kwargs):
-        super(TestGroupActorBaseClass, self).setUp(*args, **kwargs)
+        super().setUp(*args, **kwargs)
         FakeActor.last_value = None
         self.actor_returns = {
             "desc": "returns",

--- a/kingpin/actors/test/test_misc.py
+++ b/kingpin/actors/test/test_misc.py
@@ -24,7 +24,7 @@ class TestNote(testing.AsyncTestCase):
 
 class TestMacro(testing.AsyncTestCase):
     def setUp(self):
-        super(TestMacro, self).setUp()
+        super().setUp()
         importlib.reload(misc)
 
     def test_init(self):

--- a/kingpin/actors/test/test_utils.py
+++ b/kingpin/actors/test/test_utils.py
@@ -17,7 +17,7 @@ class FakeActor(base.BaseActor):
     """Fake Actor use for Unit Tests"""
 
     def __init__(self, *args, **kwargs):
-        super(FakeActor, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.conn = mock.MagicMock()
         self.conn.call.return_value = helper.tornado_value(None)
         self.conn.call.__name__ = "test_call"

--- a/kingpin/actors/utils.py
+++ b/kingpin/actors/utils.py
@@ -94,10 +94,8 @@ def timer(f):
         ret = yield gen.coroutine(f)(self, *args, **kwargs)
 
         # Log the finished execution time
-        exec_time = "%.2f" % (time.time() - start_time)
-        self.log.debug(
-            "%s.%s() execution time: %ss" % (self._type, f.__name__, exec_time)
-        )
+        exec_time = f"{time.time() - start_time:.2f}"
+        self.log.debug(f"{self._type}.{f.__name__}() execution time: {exec_time}s")
 
         raise gen.Return(ret)
 
@@ -139,7 +137,7 @@ def get_actor(config, dry):
     clean_config = config.copy()
     clean_config["init_tokens"] = "<hidden>"
 
-    log.debug('Building Actor "%s" with args: %s' % (actor_string, clean_config))
+    log.debug(f'Building Actor "{actor_string}" with args: {clean_config}')
     ActorClass = get_actor_class(actor_string)
     return ActorClass(dry=dry, **config)
 
@@ -162,7 +160,7 @@ def get_actor_class(actor):
         try:
             return utils.str_to_class(full_actor)
         except expected_exceptions as e:
-            log.debug('Tried importing "%s" but failed: %s' % (full_actor, e))
+            log.debug(f'Tried importing "{full_actor}" but failed: {e}')
 
-    msg = 'Unable to import "%s" as a valid Actor.' % actor
+    msg = f'Unable to import "{actor}" as a valid Actor.'
     raise exceptions.InvalidActor(msg)

--- a/kingpin/bin/deploy.py
+++ b/kingpin/bin/deploy.py
@@ -25,7 +25,7 @@ logging.getLogger("boto").setLevel(logging.CRITICAL)
 logging.getLogger("botocore").setLevel(logging.CRITICAL)
 
 # Initial option handler to set up the basic application environment.
-parser = argparse.ArgumentParser(description="Kingpin v%s" % __version__)
+parser = argparse.ArgumentParser(description=f"Kingpin v{__version__}")
 parser.set_defaults(verbose=True)
 
 # Job Configuration
@@ -112,7 +112,7 @@ args = parser.parse_args()
 
 def kingpin_fail(message: str):
     parser.print_help()
-    sys.stderr.write("\nError: %s\n" % message)
+    sys.stderr.write(f"\nError: {message}\n")
     sys.exit(1)
 
 
@@ -136,9 +136,7 @@ def get_main_actor(dry: bool):
     try:
         script = args.script or sys.argv[1] if sys.argv else None
     except Exception as e:
-        kingpin_fail(
-            "%s You must specify --script or provide it as first argument." % e
-        )
+        kingpin_fail(f"{e} You must specify --script or provide it as first argument.")
 
     return Macro(
         desc="Kingpin", options={"macro": script, "tokens": env_tokens}, dry=dry
@@ -161,7 +159,7 @@ def main():
             sys.exit(1)
 
         if args.orgchart:
-            log.info("Creating organizational chart into %s" % args.orgchart)
+            log.info(f"Creating organizational chart into {args.orgchart}")
             try:
                 orgdata = actor.get_orgchart()
             except Exception as e:

--- a/kingpin/bin/test/test_deploy.py
+++ b/kingpin/bin/test/test_deploy.py
@@ -9,7 +9,7 @@ from kingpin.actors.misc import Macro, Sleep
 
 class TestDeploy(unittest.TestCase):
     def __init__(self, *args, **kwargs):
-        super(TestDeploy, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         self.kingpin_bin_deploy = None
 

--- a/kingpin/constants.py
+++ b/kingpin/constants.py
@@ -3,11 +3,11 @@ import jsonschema
 from kingpin.actors import exceptions
 
 
-class REQUIRED(object):
+class REQUIRED:
     """Meta class to identify required arguments for actors."""
 
 
-class StringCompareBase(object):
+class StringCompareBase:
     """Meta class to identify the desired state for a resource.
 
     This basic type of constant allows someone to easily define a set of valid
@@ -20,9 +20,7 @@ class StringCompareBase(object):
     @classmethod
     def validate(self, option):
         if option not in self.valid:
-            raise exceptions.InvalidOptions(
-                "%s not valid, use: %s" % (option, self.valid)
-            )
+            raise exceptions.InvalidOptions(f"{option} not valid, use: {self.valid}")
 
 
 class STATE(StringCompareBase):
@@ -35,7 +33,7 @@ class STATE(StringCompareBase):
     valid = ("present", "absent")
 
 
-class SchemaCompareBase(object):
+class SchemaCompareBase:
     """Meta class that compares the schema of a dict against rules."""
 
     SCHEMA = None
@@ -46,5 +44,5 @@ class SchemaCompareBase(object):
             jsonschema.Draft4Validator(self.SCHEMA).validate(option)
         except jsonschema.exceptions.ValidationError as e:
             raise exceptions.InvalidOptions(
-                "Supplied parameter does not match schema: %s" % e
+                f"Supplied parameter does not match schema: {e}"
             )

--- a/kingpin/test/test_schema.py
+++ b/kingpin/test/test_schema.py
@@ -9,7 +9,7 @@ from kingpin import schema
 
 class TestSchema(unittest.TestCase):
     def setUp(self, *args, **kwargs):
-        super(TestSchema, self).setUp(*args, **kwargs)
+        super().setUp(*args, **kwargs)
 
         dirname, filename = os.path.split(os.path.abspath(__file__))
         self.examples = "%s/../../examples" % dirname


### PR DESCRIPTION
## Summary
Mechanical modernization of legacy Python patterns across the codebase:

- 6 × `class Foo(object):` → `class Foo:` (Python 3 implicit `object` inheritance)
- 37 × `super(ClassName, self)` → `super()` (PEP 3135)
- 51+ × `"..." % (...)` → f-strings (PEP 498; only eager `%` operator patterns, not deferred logging)
- 3 × `type(x) == list` → `isinstance(x, list)` (Python docs recommendation)
- 11 × `list(dict.items())` → `dict.items()` (Python 3 dict views; kept 1 instance needed for mutation-during-iteration)
- 4 × Python 2 remnants removed: `basestring` comment, duplicate `str` in type tuple, dead `u'` prefix stripping, Python 2.7 Tornado docstring

22 files changed, +243 −300 (net −57 lines).

## Test plan
- [x] `make test` — 361/361 passed, 100% coverage
- [x] `make lint` — clean
- [x] Integration dry-run validation against real deployment scripts in engineering

🤖 Generated with [Claude Code](https://claude.com/claude-code)