### PR TITLE
chore(deps): replace standalone mock with unittest.mock

### DIFF
--- a/kingpin/.serena/memories/ruff_async_migration_rules.md
+++ b/kingpin/.serena/memories/ruff_async_migration_rules.md
@@ -1,0 +1,47 @@
+# Ruff Rules for Tornado-to-AsyncIO Migration
+
+## Key Finding: No Tornado-Specific Rules
+Ruff has NO rules that specifically detect Tornado patterns like `gen.coroutine`,
+`gen.Return`, `IOLoop.instance()`, etc. These must be caught via custom tooling
+or manual review. The flake8-async rules focus on asyncio/trio/anyio patterns.
+
+## ASYNC Rules — Full List (flake8-async)
+All detect blocking/problematic patterns in `async def` functions:
+
+- ASYNC100: cancel-scope-no-checkpoint — timeout context manager lacks await
+- ASYNC105: trio-sync-call — missing await on trio async call (auto-fix)
+- ASYNC109: async-function-with-timeout — timeout param instead of context manager
+- ASYNC110: async-busy-wait — sleep in while loop, use Event instead
+- ASYNC115: async-zero-sleep — sleep(0) should be checkpoint() (auto-fix)
+- ASYNC116: long-sleep-not-forever — sleep >24h should be sleep_forever (auto-fix)
+- ASYNC210: blocking-http-call-in-async-function — urllib/requests in async
+- ASYNC212: blocking-http-call-httpx-in-async-function — httpx.Client in async
+- ASYNC220: create-subprocess-in-async-function — os.popen in async
+- ASYNC221: run-process-in-async-function — subprocess.run in async
+- ASYNC222: wait-for-process-in-async-function — os.waitpid in async
+- ASYNC230: blocking-open-call-in-async-function — open() in async
+- ASYNC240: blocking-path-method-in-async-function — os.path/pathlib blocking
+- ASYNC250: blocking-input-in-async-function — input() in async
+- ASYNC251: blocking-sleep-in-async-function — time.sleep in async
+
+## Key UP Rules for Patterns We Already Fixed
+- UP004: useless-object-inheritance — `class Foo(object)` → `class Foo`
+- UP008: super-call-with-parameters — `super(Cls, self)` → `super()`
+- UP031: printf-string-formatting — `"%s" % x` → `.format()` or f-string
+- UP032: f-string — `.format()` → f-string
+- UP028: yield-in-for-loop — `for x in y: yield x` → `yield from y`
+
+## Key UP Rules for Async Migration
+- UP041: timeout-error-alias — `asyncio.TimeoutError` → `TimeoutError`
+- UP024: os-error-alias — `IOError` → `OSError`
+
+## Key UP Rules for Python 3.11+ Modernization
+- UP006: non-pep585-annotation — `typing.List[int]` → `list[int]`
+- UP007: non-pep604-annotation-union — `Union[X, Y]` → `X | Y`
+- UP035: deprecated-import — `from collections import Sequence` → `.abc`
+- UP036: outdated-version-block — dead `sys.version_info` checks
+- UP042: replace-str-enum — `(str, enum.Enum)` → `enum.StrEnum`
+
+## Key RUF Rules for Async
+- RUF006: asyncio-dangling-task — `create_task()` without saving reference
+- RUF029: unused-async (preview) — `async def` with no await inside

--- a/kingpin/actors/aws/test/test_base.py
+++ b/kingpin/actors/aws/test/test_base.py
@@ -4,7 +4,7 @@ from boto3 import exceptions as boto3_exceptions
 from botocore import stub
 from tornado import testing
 import botocore.exceptions
-import mock
+from unittest import mock
 
 from kingpin.actors import exceptions
 from kingpin.actors.aws import base

--- a/kingpin/actors/aws/test/test_cloudformation.py
+++ b/kingpin/actors/aws/test/test_cloudformation.py
@@ -5,7 +5,7 @@ import json
 import boto3
 from botocore.exceptions import ClientError
 from tornado import testing
-import mock
+from unittest import mock
 
 from kingpin.actors.aws import base
 from kingpin.actors.aws import settings

--- a/kingpin/actors/aws/test/test_iam.py
+++ b/kingpin/actors/aws/test/test_iam.py
@@ -4,7 +4,7 @@ import json
 
 from datetime import datetime
 
-import mock
+from unittest import mock
 
 from botocore.stub import Stubber
 from tornado import gen, testing

--- a/kingpin/actors/aws/test/test_s3.py
+++ b/kingpin/actors/aws/test/test_s3.py
@@ -2,7 +2,7 @@ import logging
 
 from botocore.exceptions import ClientError
 from tornado import testing
-import mock
+from unittest import mock
 
 from kingpin.actors import exceptions
 from kingpin.actors.aws import s3 as s3_actor

--- a/kingpin/actors/test/test_base.py
+++ b/kingpin/actors/test/test_base.py
@@ -10,7 +10,7 @@ from tornado import gen
 from tornado import httpclient
 from tornado import simple_httpclient
 from tornado import testing
-import mock
+from unittest import mock
 
 # Unusual placement -- but we override the environment so that we can test that
 # the urllib debugger works.

--- a/kingpin/actors/test/test_group.py
+++ b/kingpin/actors/test/test_group.py
@@ -1,6 +1,6 @@
 import logging
 import time
-import mock
+from unittest import mock
 
 from tornado import gen
 from tornado import testing

--- a/kingpin/actors/test/test_misc.py
+++ b/kingpin/actors/test/test_misc.py
@@ -2,7 +2,7 @@ import logging
 
 from tornado import httpclient
 from tornado import testing
-import mock
+from unittest import mock
 
 from kingpin import exceptions as kingpin_exceptions
 from kingpin.actors import exceptions

--- a/kingpin/actors/test/test_utils.py
+++ b/kingpin/actors/test/test_utils.py
@@ -1,5 +1,5 @@
 import logging
-import mock
+from unittest import mock
 
 from tornado import gen
 from tornado import testing

--- a/kingpin/test/test_utils.py
+++ b/kingpin/test/test_utils.py
@@ -6,7 +6,7 @@ import time
 from tornado import gen
 from tornado import testing
 from tornado.testing import unittest
-import mock
+from unittest import mock
 import rainbow_logging_handler
 import requests
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,6 @@ dev = [
     # testing
     "pytest",
     "pytest-cov",
-    "mock",
     "pyflakes",
     "requests",
     # building

--- a/uv.lock
+++ b/uv.lock
@@ -459,7 +459,6 @@ docs = [
 dev = [
     { name = "black" },
     { name = "build" },
-    { name = "mock" },
     { name = "pyflakes" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -490,7 +489,6 @@ provides-extras = ["docs"]
 dev = [
     { name = "black" },
     { name = "build" },
-    { name = "mock" },
     { name = "pyflakes" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -580,15 +578,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
-]
-
-[[package]]
-name = "mock"
-version = "5.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/07/8c/14c2ae915e5f9dca5a22edd68b35be94400719ccfa068a03e0fb63d0f6f6/mock-5.2.0.tar.gz", hash = "sha256:4e460e818629b4b173f32d08bf30d3af8123afbb8e04bb5707a1fd4799e503f0", size = 92796, upload-time = "2025-03-03T12:31:42.911Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/d9/617e6af809bf3a1d468e0d58c3997b1dc219a9a9202e650d30c2fc85d481/mock-5.2.0-py3-none-any.whl", hash = "sha256:7ba87f72ca0e915175596069dbbcc7c75af7b5e9b9bc107ad6349ede0819982f", size = 31617, upload-time = "2025-03-03T12:31:41.518Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- The `mock` package (v5.2.0) is a Python 2 backport of `unittest.mock` — unnecessary since kingpin requires Python 3.11+
- 9 test files updated: `import mock` → `from unittest import mock` (via `uvx ruff check --select UP026 --fix`)
- `mock` removed from `[dependency-groups] dev`
- All 361 tests pass, 100% coverage
- 2 files (`test_deploy.py`, `test_api_call_queue.py`) were already migrated in #651

## Test plan
- [x] `make lint` passes
- [x] `make test` — 361 passed, 100% coverage
- [ ] CI validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)