### PR TITLE
chore(aws): remove dead EXECUTOR code from iam.py and s3.py

### DIFF
--- a/kingpin/actors/aws/iam.py
+++ b/kingpin/actors/aws/iam.py
@@ -9,7 +9,6 @@ import logging
 import os
 
 from botocore.exceptions import ClientError
-from tornado import concurrent
 
 from kingpin import utils
 from kingpin.actors import exceptions
@@ -20,12 +19,6 @@ log = logging.getLogger(__name__)
 
 __author__ = "Matt Wise <matt@nextdoor.com>"
 
-
-# This executor is used by the tornado.concurrent.run_on_executor()
-# decorator. We would like this to be a class variable so its shared
-# across RightScale objects, but we see testing IO errors when we
-# do this.
-EXECUTOR = concurrent.futures.ThreadPoolExecutor(10)
 
 # The maximum number of items returned to us in a get_all_*/list_* api call.
 # Defaults to 100, but setting to 1000 to reduce the number of API calls we

--- a/kingpin/actors/aws/s3.py
+++ b/kingpin/actors/aws/s3.py
@@ -9,7 +9,6 @@ import logging
 import jsonpickle
 from botocore.exceptions import ClientError, ParamValidationError
 from inflection import camelize
-from tornado import concurrent
 
 from kingpin import utils
 from kingpin.actors import exceptions
@@ -20,12 +19,6 @@ from kingpin.constants import REQUIRED, STATE, SchemaCompareBase
 log = logging.getLogger(__name__)
 
 __author__ = "Matt Wise <matt@nextdoor.com"
-
-
-# This executor is used by the tornado.concurrent.run_on_executor()
-# decorator. We would like this to be a class variable so its shared
-# across objects, but we see testing IO errors when we do this.
-EXECUTOR = concurrent.futures.ThreadPoolExecutor(10)
 
 
 class InvalidBucketConfig(exceptions.RecoverableActorFailure):


### PR DESCRIPTION
## Summary

- Remove unused `EXECUTOR = concurrent.futures.ThreadPoolExecutor(10)` and `from tornado import concurrent` from `actors/aws/iam.py` and `actors/aws/s3.py`
- These constants were defined for `@run_on_executor` but no method in either file uses that decorator — all IAM/S3 actors inherit `api_call()` from `AWSBaseActor` which has its own executor

## Test plan

- [x] `make test` passes (361 tests, 0 failures)

Part 1 of 10 in the tornado removal migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)