### PR TITLE
refactor(actors): replace IOLoop.run_sync with asyncio.run in deploy.py

### DIFF
--- a/kingpin/bin/deploy.py
+++ b/kingpin/bin/deploy.py
@@ -2,12 +2,11 @@
 """CLI Script Runner for Kingpin."""
 
 import argparse
+import asyncio
 import json
 import logging
 import os
 import sys
-
-from tornado import ioloop
 
 from kingpin import utils
 from kingpin.actors import exceptions as actor_exceptions
@@ -222,23 +221,14 @@ def begin():
     utils.setup_root_logger(level=args.level, color=args.color)
 
     try:
-        ioloop.IOLoop.current().run_sync(main)
+        asyncio.run(main())
     except KeyboardInterrupt:
         log.info("CTRL-C Caught, shutting down")
         sys.exit(130)  # Standard KeyboardInterrupt exit code.
     except Exception:
-        # Skip traceback that involves tornado's libraries.
         import traceback
 
-        trace_lines = traceback.format_exc().splitlines()
-        skip_next = False
-        for l in trace_lines:
-            if "tornado" in l:
-                skip_next = True
-                continue
-            if not skip_next:
-                print(l)
-            skip_next = False
+        traceback.print_exc()
         sys.exit(3)
 
 

--- a/kingpin/bin/test/test_deploy.py
+++ b/kingpin/bin/test/test_deploy.py
@@ -228,8 +228,7 @@ class TestDeploy(unittest.TestCase):
     )
     def test_begin_keyboard_interrupt(self):
         self._import_kingpin_bin_deploy()
-        with mock.patch("tornado.ioloop.IOLoop.current") as mock_ioloop_current:
-            mock_ioloop_current.side_effect = KeyboardInterrupt()
+        with mock.patch("asyncio.run", side_effect=KeyboardInterrupt()):
             with self.assertRaises(SystemExit) as cm:
                 self.kingpin_bin_deploy.begin()
                 self.assertEqual(cm.exception.code, 130)


### PR DESCRIPTION
## Summary

- Replace `ioloop.IOLoop.current().run_sync(main)` with `asyncio.run(main())` in `bin/deploy.py`
- Remove the tornado traceback filter (no longer needed)
- Update test mock target from `tornado.ioloop.IOLoop.current` to `asyncio.run`

## Test plan

- [x] `make test` passes (361 tests, 0 failures)
- [x] `kingpin --dry --script examples/test/sleep.json` works

Part 2 of 10 in the tornado removal migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)