### PR TITLE
refactor(aws): replace @run_on_executor with run_in_executor in AWS actors

### DIFF
--- a/kingpin/actors/aws/cloudformation.py
+++ b/kingpin/actors/aws/cloudformation.py
@@ -9,12 +9,12 @@ import json
 import logging
 import re
 import uuid
+from concurrent.futures import ThreadPoolExecutor
 from hashlib import md5
 from json import JSONEncoder
 
 import boto3
 from botocore.exceptions import ClientError
-from tornado import concurrent, ioloop
 
 from kingpin import utils
 from kingpin.actors import exceptions
@@ -37,10 +37,7 @@ class DateEncoder(JSONEncoder):
             return obj.isoformat()
 
 
-# This executor is used by the tornado.concurrent.run_on_executor() decorator.
-# We would like this to be a class variable so its shared across objects, but we
-# see testing IO errors when we do this.
-EXECUTOR = concurrent.futures.ThreadPoolExecutor(10)
+EXECUTOR = ThreadPoolExecutor(10)
 
 
 S3_REGEX = re.compile(r"s3://(?P<bucket>[a-z0-9.-]+)/(?P<key>.*)")
@@ -158,10 +155,6 @@ FAILED = (
 
 class CloudFormationBaseActor(base.AWSBaseActor):
     """Base Actor for CloudFormation tasks"""
-
-    # Get references to existing objects that are used by the
-    # tornado.concurrent.run_on_executor() decorator.
-    ioloop = ioloop.IOLoop.current()
 
     executor = EXECUTOR
 


### PR DESCRIPTION
## Summary

Replace Tornado's `@concurrent.run_on_executor` decorator with stdlib `asyncio.get_event_loop().run_in_executor()` in the core AWS actor calling path.

### What changed

- **`actors/aws/base.py`**: `api_call()` is now `async def` using `loop.run_in_executor(self.executor, _call)` instead of `@concurrent.run_on_executor`. An inner `_call()` closure captures args/kwargs and is wrapped with `@utils.exception_logger` to preserve exception logging behavior. Removed `ioloop` class attribute (was only needed by the decorator). Replaced `from tornado import concurrent, ioloop` with `import asyncio` and `from concurrent.futures import ThreadPoolExecutor`.
- **`actors/aws/cloudformation.py`**: Removed `ioloop` class attribute and tornado imports. The `CloudFormationBaseActor` inherits `api_call()` from `AWSBaseActor` — no method changes needed here, only the executor class attribute and imports.

### Why this is safe

- `run_in_executor` is the stdlib equivalent of `@run_on_executor` — same semantics (submit sync function to thread pool, return awaitable)
- The `executor` class attribute is preserved — `CloudFormationBaseActor` still overrides it with its own 10-thread pool
- All existing callers already `await api_call(...)` — no call-site changes needed

## Test plan

- [x] `make test` passes (361 tests, 0 failures)
- [x] `ruff check` clean

Part 3 of 10 in the tornado removal migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)