### PR TITLE
refactor(actors): replace IOLoop.add_timeout with asyncio call_later

### DIFF
--- a/kingpin/actors/test/test_base.py
+++ b/kingpin/actors/test/test_base.py
@@ -13,7 +13,6 @@ from tornado import testing
 # the urllib debugger works.
 os.environ["URLLIB_DEBUG"] = "1"
 
-from kingpin import utils
 from kingpin.actors import base
 
 reload(base)
@@ -80,11 +79,11 @@ class FakeEnsurableBaseActor(base.EnsurableBaseActor):
 
 class TestBaseActor(testing.AsyncTestCase):
     async def true(self):
-        await utils.tornado_sleep(0.01)
+        await asyncio.sleep(0.01)
         return True
 
     async def false(self):
-        await utils.tornado_sleep(0.01)
+        await asyncio.sleep(0.01)
         return False
 
     def setUp(self):

--- a/kingpin/test/test_utils.py
+++ b/kingpin/test/test_utils.py
@@ -290,9 +290,9 @@ class TestCoroutineHelpers(testing.AsyncTestCase):
         self.assertEqual(ret, True)
 
     @testing.gen_test
-    def testTornadoSleep(self):
+    def test_asyncio_sleep(self):
         start = time.time()
-        yield utils.tornado_sleep(0.1)
+        yield asyncio.sleep(0.1)
         stop = time.time()
         self.assertTrue(stop - start > 0.1)
 


### PR DESCRIPTION
## Summary

Replace Tornado's timer API with asyncio equivalents in the repeating log utility, and delete the legacy `tornado_sleep()` wrapper.

### What changed

- **`utils.py`**: `create_repeating_log()` now uses `asyncio.get_event_loop().call_later(delay, callback)` instead of `ioloop.IOLoop.current().add_timeout(timedelta, callback)`. `clear_repeating_log()` uses `handle.timer_handle.cancel()` instead of `ioloop.IOLoop.current().remove_timeout(handle.timeout_id)`. Deleted `tornado_sleep()` (it was just a wrapper around `asyncio.sleep()`). Removed `from tornado import ioloop` — this was the **last tornado import in utils.py**.
- **`actors/test/test_base.py`**: Replaced `await utils.tornado_sleep(0.01)` with `await asyncio.sleep(0.01)`.
- **`test/test_utils.py`**: Replaced `yield utils.tornado_sleep(0.1)` with `yield asyncio.sleep(0.1)`, renamed test to `test_asyncio_sleep`.

### Why this is safe

- `call_later(seconds, callback)` is the direct equivalent of `add_timeout(timedelta, callback)` — same semantics, just takes seconds (float) instead of timedelta
- `handle.cancel()` is the direct equivalent of `remove_timeout(handle)` 
- `tornado_sleep()` was already just `await asyncio.sleep()` internally — removing the wrapper is zero behavioral change

## Test plan

- [x] `make test` passes (360 tests, 0 failures)
- [x] `ruff check` clean
- [x] `test_repeating_log` test exercises the full create/clear lifecycle

Part 6 of 10 in the tornado removal migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)