### PR TITLE
refactor(aws): migrate AWS actor tests to IsolatedAsyncioTestCase

### DIFF
--- a/kingpin/actors/aws/test/test_base.py
+++ b/kingpin/actors/aws/test/test_base.py
@@ -1,11 +1,11 @@
 import importlib
 import logging
+import unittest
 from unittest import mock
 
 import botocore.exceptions
 from boto3 import exceptions as boto3_exceptions
 from botocore import stub
-from tornado import testing
 
 from kingpin.actors import exceptions
 from kingpin.actors.aws import base, settings
@@ -46,7 +46,7 @@ TARGET_GROUP_RESPONSE = {
 }
 
 
-class TestBase(testing.AsyncTestCase):
+class TestBase(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         super().setUp()
         settings.AWS_ACCESS_KEY_ID = "unit-test"
@@ -54,25 +54,22 @@ class TestBase(testing.AsyncTestCase):
         settings.AWS_SESSION_TOKEN = "unit-test"
         importlib.reload(base)
 
-    @testing.gen_test
-    def test_api_call_raises_client_exception(self):
+    async def test_api_call_raises_client_exception(self):
         actor = base.AWSBaseActor("Unit Test Action", {})
         stubber = stub.Stubber(actor.iam_conn)
         stubber.add_client_error("list_roles", 400, "Error")
         stubber.activate()
         with self.assertRaises(botocore.exceptions.ClientError):
-            yield actor.api_call(actor.iam_conn.list_roles)
+            await actor.api_call(actor.iam_conn.list_roles)
         stubber.assert_no_pending_responses()
 
-    @testing.gen_test
-    def test_api_call_raises_boto3_core_exception(self):
+    async def test_api_call_raises_boto3_core_exception(self):
         actor = base.AWSBaseActor("Unit Test Action", {})
         actor.iam_conn = mock.MagicMock()
         actor.iam_conn.list_roles.side_effect = boto3_exceptions.Boto3Error
         with self.assertRaises(exceptions.RecoverableActorFailure):
-            yield actor.api_call(actor.iam_conn.list_roles)
+            await actor.api_call(actor.iam_conn.list_roles)
 
-    @testing.gen_test
     def test_parse_json(self):
         actor = base.AWSBaseActor("Unit Test Action", {})
 
@@ -84,7 +81,6 @@ class TestBase(testing.AsyncTestCase):
         with self.assertRaises(exceptions.UnrecoverableActorFailure):
             actor._parse_json("junk")
 
-    @testing.gen_test
     def test_parse_json_none(self):
         actor = base.AWSBaseActor("Unit Test Action", {})
         ret = actor._parse_json(None)

--- a/kingpin/actors/aws/test/test_s3.py
+++ b/kingpin/actors/aws/test/test_s3.py
@@ -1,9 +1,9 @@
 import importlib
 import logging
+import unittest
 from unittest import mock
 
 from botocore.exceptions import ClientError
-from tornado import testing
 
 from kingpin.actors import exceptions
 from kingpin.actors.aws import s3 as s3_actor
@@ -12,7 +12,7 @@ from kingpin.actors.aws import settings
 log = logging.getLogger(__name__)
 
 
-class TestBucket(testing.AsyncTestCase):
+class TestBucket(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         super().setUp()
         settings.AWS_ACCESS_KEY_ID = "unit-test"
@@ -89,180 +89,157 @@ class TestBucket(testing.AsyncTestCase):
             {"IShouldBeTaller": {"MeTooMan": ["not_me"]}},
         )
 
-    @testing.gen_test
-    def test_precache(self):
+    async def test_precache(self):
         self.actor.s3_conn.list_buckets.return_value = {
             "Buckets": [{"Name": "wrong_bucket"}, {"Name": "test"}]
         }
 
-        yield self.actor._precache()
+        await self.actor._precache()
         self.assertTrue(self.actor._bucket_exists)
 
-    @testing.gen_test
-    def test_get_state_absent(self):
-        ret = yield self.actor._get_state()
+    async def test_get_state_absent(self):
+        ret = await self.actor._get_state()
         self.assertEqual("absent", ret)
 
-    @testing.gen_test
-    def test_get_state_present(self):
+    async def test_get_state_present(self):
         self.actor._bucket_exists = True
-        ret = yield self.actor._get_state()
+        ret = await self.actor._get_state()
         self.assertEqual("present", ret)
 
-    @testing.gen_test
-    def test_set_state_absent(self):
+    async def test_set_state_absent(self):
         self.actor._options["state"] = "absent"
-        yield self.actor._set_state()
+        await self.actor._set_state()
         self.actor.s3_conn.delete_bucket.assert_has_calls([mock.call(Bucket="test")])
 
-    @testing.gen_test
-    def test_set_state_present(self):
+    async def test_set_state_present(self):
         self.actor._options["state"] = "present"
-        yield self.actor._set_state()
+        await self.actor._set_state()
         self.actor.s3_conn.create_bucket.assert_has_calls([mock.call(Bucket="test")])
 
-    @testing.gen_test
-    def test_create_bucket(self):
-        yield self.actor._create_bucket()
+    async def test_create_bucket(self):
+        await self.actor._create_bucket()
         self.actor.s3_conn.create_bucket.assert_called_with(Bucket="test")
 
-    @testing.gen_test
-    def test_create_bucket_new_region(self):
+    async def test_create_bucket_new_region(self):
         self.actor._options["region"] = "us-west-1"
-        yield self.actor._create_bucket()
+        await self.actor._create_bucket()
         self.actor.s3_conn.create_bucket.assert_called_with(
             Bucket="test", CreateBucketConfiguration={"LocationConstraint": "us-west-1"}
         )
 
-    @testing.gen_test
-    def test_verify_can_delete_bucket(self):
+    async def test_verify_can_delete_bucket(self):
         self.actor.s3_conn.list_objects.return_value = {"Contents": [1, 2, 3]}
         with self.assertRaises(exceptions.RecoverableActorFailure):
-            yield self.actor._verify_can_delete_bucket()
+            await self.actor._verify_can_delete_bucket()
 
-    @testing.gen_test
-    def test_verify_can_delete_bucket_true(self):
+    async def test_verify_can_delete_bucket_true(self):
         self.actor.s3_conn.list_objects.return_value = {}
-        yield self.actor._verify_can_delete_bucket()
+        await self.actor._verify_can_delete_bucket()
 
-    @testing.gen_test
-    def test_delete_bucket(self):
-        yield self.actor._delete_bucket()
+    async def test_delete_bucket(self):
+        await self.actor._delete_bucket()
         self.actor.s3_conn.delete_bucket.assert_has_calls([mock.call(Bucket="test")])
 
-    @testing.gen_test
-    def test_delete_bucket_409(self):
+    async def test_delete_bucket_409(self):
         self.actor.s3_conn.delete_bucket.side_effect = ClientError(
             {"Error": {"Code": ""}}, "Error"
         )
         with self.assertRaises(exceptions.RecoverableActorFailure):
-            yield self.actor._delete_bucket()
+            await self.actor._delete_bucket()
 
-    @testing.gen_test
-    def test_get_policy(self):
+    async def test_get_policy(self):
         self.actor._bucket_exists = True
         self.actor.s3_conn.get_bucket_policy.return_value = {"Policy": "{}"}
-        ret = yield self.actor._get_policy()
+        ret = await self.actor._get_policy()
         self.assertEqual({}, ret)
 
-    @testing.gen_test
-    def test_get_policy_no_bucket(self):
+    async def test_get_policy_no_bucket(self):
         self.actor._bucket_exists = False
-        ret = yield self.actor._get_policy()
+        ret = await self.actor._get_policy()
         self.assertEqual(ret, None)
 
-    @testing.gen_test
-    def test_get_policy_empty(self):
+    async def test_get_policy_empty(self):
         self.actor._bucket_exists = True
         self.actor.s3_conn.get_bucket_policy.side_effect = ClientError(
             {"Error": {"Code": ""}}, "NoSuchBucketPolicy"
         )
-        ret = yield self.actor._get_policy()
+        ret = await self.actor._get_policy()
         self.assertEqual("", ret)
 
-    @testing.gen_test
-    def test_get_policy_exc(self):
+    async def test_get_policy_exc(self):
         self.actor._bucket_exists = True
         self.actor.s3_conn.get_bucket_policy.side_effect = ClientError(
             {"Error": {"Code": ""}}, "SomeOtherError"
         )
         with self.assertRaises(ClientError):
-            yield self.actor._get_policy()
+            await self.actor._get_policy()
 
-    @testing.gen_test
-    def test_compare_policy(self):
+    async def test_compare_policy(self):
         self.actor._bucket_exists = True
         self.actor.policy = {"test": "policy"}
         self.actor.s3_conn.get_bucket_policy.return_value = {
             "Policy": '{"test": "policy"}'
         }
-        ret = yield self.actor._compare_policy()
+        ret = await self.actor._compare_policy()
         self.assertTrue(ret)
 
-    @testing.gen_test
-    def test_compare_policy_false(self):
+    async def test_compare_policy_false(self):
         self.actor._bucket_exists = True
         self.actor.policy = {"test": "bah"}
         self.actor.s3_conn.get_bucket_policy.return_value = {
             "Policy": '{"test": "policy"}'
         }
-        ret = yield self.actor._compare_policy()
+        ret = await self.actor._compare_policy()
         self.assertFalse(ret)
 
-    @testing.gen_test
-    def test_compare_policy_not_managing(self):
+    async def test_compare_policy_not_managing(self):
         self.actor._bucket_exists = True
         self.actor.policy = None
         self.actor.s3_conn.get_bucket_policy.return_value = {
             "Policy": '{"test": "policy"}'
         }
-        ret = yield self.actor._compare_policy()
+        ret = await self.actor._compare_policy()
         self.assertTrue(ret)
 
-    @testing.gen_test
-    def test_set_policy(self):
+    async def test_set_policy(self):
         self.actor.policy = {}
-        yield self.actor._set_policy()
+        await self.actor._set_policy()
         self.actor.s3_conn.put_bucket_policy.assert_has_calls(
             [mock.call(Bucket="test", Policy="{}")]
         )
 
-    @testing.gen_test
-    def test_set_policy_malformed_policy(self):
+    async def test_set_policy_malformed_policy(self):
         self.actor.policy = {}
         self.actor.s3_conn.put_bucket_policy.side_effect = ClientError(
             {"Error": {"Code": ""}}, "MalformedPolicy"
         )
         with self.assertRaises(exceptions.RecoverableActorFailure):
-            yield self.actor._set_policy()
+            await self.actor._set_policy()
 
         self.actor.s3_conn.put_bucket_policy.assert_has_calls(
             [mock.call(Bucket="test", Policy="{}")]
         )
 
-    @testing.gen_test
-    def test_set_policy_client_error(self):
+    async def test_set_policy_client_error(self):
         self.actor.policy = {}
         self.actor.s3_conn.put_bucket_policy.side_effect = ClientError(
             {"Error": {"Code": ""}}, "Some Other Error"
         )
         with self.assertRaises(exceptions.RecoverableActorFailure):
-            yield self.actor._set_policy()
+            await self.actor._set_policy()
 
         self.actor.s3_conn.put_bucket_policy.assert_has_calls(
             [mock.call(Bucket="test", Policy="{}")]
         )
 
-    @testing.gen_test
-    def test_set_policy_delete(self):
+    async def test_set_policy_delete(self):
         self.actor.policy = ""
-        yield self.actor._set_policy()
+        await self.actor._set_policy()
         self.actor.s3_conn.delete_bucket_policy.assert_has_calls(
             [mock.call(Bucket="test")]
         )
 
-    @testing.gen_test
-    def test_get_logging(self):
+    async def test_get_logging(self):
         self.actor._bucket_exists = True
         self.actor.s3_conn.get_bucket_logging.return_value = {
             "LoggingEnabled": {
@@ -271,40 +248,35 @@ class TestBucket(testing.AsyncTestCase):
             }
         }
 
-        ret = yield self.actor._get_logging()
+        ret = await self.actor._get_logging()
         self.assertEqual(ret, {"target": "Target-Bucket", "prefix": "Target-Prefix"})
 
-    @testing.gen_test
-    def test_get_logging_disabled(self):
+    async def test_get_logging_disabled(self):
         self.actor._bucket_exists = True
         self.actor.s3_conn.get_bucket_logging.return_value = {}
-        ret = yield self.actor._get_logging()
+        ret = await self.actor._get_logging()
         self.assertEqual(ret, {"target": "", "prefix": ""})
 
-    @testing.gen_test
-    def test_get_logging_no_bucket(self):
+    async def test_get_logging_no_bucket(self):
         self.actor._bucket_exists = False
-        ret = yield self.actor._get_logging()
+        ret = await self.actor._get_logging()
         self.assertEqual(ret, None)
 
-    @testing.gen_test
-    def test_set_logging_not_desired(self):
+    async def test_set_logging_not_desired(self):
         self.actor._options["logging"] = None
-        yield self.actor._set_logging()
+        await self.actor._set_logging()
         self.assertFalse(self.actor.s3_conn.put_bucket_logging.called)
 
-    @testing.gen_test
-    def test_set_logging_disabled(self):
+    async def test_set_logging_disabled(self):
         self.actor._options["logging"] = {"target": "", "prefix": ""}
-        yield self.actor._set_logging()
+        await self.actor._set_logging()
         self.actor.s3_conn.put_bucket_logging.assert_has_calls(
             [mock.call(Bucket="test", BucketLoggingStatus={})]
         )
 
-    @testing.gen_test
-    def test_set_logging(self):
+    async def test_set_logging(self):
         self.actor._options["logging"] = {"target": "tgt", "prefix": "pfx"}
-        yield self.actor._set_logging()
+        await self.actor._set_logging()
         self.actor.s3_conn.put_bucket_logging.assert_has_calls(
             [
                 mock.call(
@@ -316,126 +288,110 @@ class TestBucket(testing.AsyncTestCase):
             ]
         )
 
-    @testing.gen_test
-    def test_set_logging_client_error(self):
+    async def test_set_logging_client_error(self):
         self.actor.s3_conn.put_bucket_logging.side_effect = ClientError(
             {"Error": {"Code": ""}}, "Some error"
         )
         with self.assertRaises(s3_actor.InvalidBucketConfig):
-            yield self.actor._set_logging()
+            await self.actor._set_logging()
 
-    @testing.gen_test
-    def test_get_versioning(self):
+    async def test_get_versioning(self):
         self.actor._bucket_exists = True
         self.actor.s3_conn.get_bucket_versioning.return_value = {"Status": "Enabled"}
-        ret = yield self.actor._get_versioning()
+        ret = await self.actor._get_versioning()
         self.assertTrue(ret)
 
-    @testing.gen_test
-    def test_get_versioning_no_bucket(self):
+    async def test_get_versioning_no_bucket(self):
         self.actor._bucket_exists = False
-        ret = yield self.actor._get_versioning()
+        ret = await self.actor._get_versioning()
         self.assertEqual(None, ret)
 
-    @testing.gen_test
-    def test_get_versioning_suspended(self):
+    async def test_get_versioning_suspended(self):
         self.actor._bucket_exists = True
         self.actor.s3_conn.get_bucket_versioning.return_value = {"Status": "Suspended"}
-        ret = yield self.actor._get_versioning()
+        ret = await self.actor._get_versioning()
         self.assertFalse(ret)
 
-    @testing.gen_test
-    def test_set_versioning(self):
+    async def test_set_versioning(self):
         self.actor._options["versioning"] = True
-        yield self.actor._set_versioning()
+        await self.actor._set_versioning()
         self.actor.s3_conn.put_bucket_versioning.assert_has_calls(
             [mock.call(Bucket="test", VersioningConfiguration={"Status": "Enabled"})]
         )
 
-    @testing.gen_test
-    def test_set_versioning_suspended(self):
+    async def test_set_versioning_suspended(self):
         self.actor._options["versioning"] = False
-        yield self.actor._set_versioning()
+        await self.actor._set_versioning()
         self.actor.s3_conn.put_bucket_versioning.assert_has_calls(
             [mock.call(Bucket="test", VersioningConfiguration={"Status": "Suspended"})]
         )
 
-    @testing.gen_test
-    def test_set_versioning_none(self):
+    async def test_set_versioning_none(self):
         self.actor._options["versioning"] = None
-        yield self.actor._set_versioning()
+        await self.actor._set_versioning()
         self.assertFalse(self.actor.s3_conn.put_bucket_versioning.called)
 
-    @testing.gen_test
-    def test_get_lifecycle(self):
+    async def test_get_lifecycle(self):
         self.actor._bucket_exists = True
         self.actor.s3_conn.get_bucket_lifecycle_configuration.return_value = {
             "Rules": []
         }
-        ret = yield self.actor._get_lifecycle()
+        ret = await self.actor._get_lifecycle()
         self.assertEqual(ret, [])
 
-    @testing.gen_test
-    def test_get_lifecycle_no_bucket(self):
+    async def test_get_lifecycle_no_bucket(self):
         self.actor._bucket_exists = False
-        ret = yield self.actor._get_lifecycle()
+        ret = await self.actor._get_lifecycle()
         self.assertEqual(None, ret)
 
-    @testing.gen_test
-    def test_get_lifecycle_empty(self):
+    async def test_get_lifecycle_empty(self):
         self.actor._bucket_exists = True
         self.actor.s3_conn.get_bucket_lifecycle_configuration.side_effect = ClientError(
             {"Error": {"Code": ""}}, "NoSuchLifecycleConfiguration"
         )
-        ret = yield self.actor._get_lifecycle()
+        ret = await self.actor._get_lifecycle()
         self.assertEqual(ret, [])
 
-    @testing.gen_test
-    def test_get_lifecycle_clienterror(self):
+    async def test_get_lifecycle_clienterror(self):
         self.actor._bucket_exists = True
         self.actor.s3_conn.get_bucket_lifecycle_configuration.side_effect = ClientError(
             {"Error": {"Code": ""}}, "SomeOtherError"
         )
         with self.assertRaises(ClientError):
-            yield self.actor._get_lifecycle()
+            await self.actor._get_lifecycle()
 
-    @testing.gen_test
-    def test_compare_lifecycle(self):
+    async def test_compare_lifecycle(self):
         self.actor._bucket_exists = True
         self.actor.lifecycle = [{"test": "test"}]
         self.actor.s3_conn.get_bucket_lifecycle_configuration.return_value = {
             "Rules": [{"test": "test"}]
         }
-        ret = yield self.actor._compare_lifecycle()
+        ret = await self.actor._compare_lifecycle()
         self.assertTrue(ret)
 
-    @testing.gen_test
-    def test_compare_lifecycle_none(self):
+    async def test_compare_lifecycle_none(self):
         self.actor.lifecycle = None
-        ret = yield self.actor._compare_lifecycle()
+        ret = await self.actor._compare_lifecycle()
         self.assertTrue(ret)
 
-    @testing.gen_test
-    def test_compare_lifecycle_diff(self):
+    async def test_compare_lifecycle_diff(self):
         self.actor.lifecycle = [{"test1": "test"}]
         self.actor.s3_conn.get_bucket_lifecycle_configuration.return_value = {
             "Rules": [{"test": "test"}]
         }
-        ret = yield self.actor._compare_lifecycle()
+        ret = await self.actor._compare_lifecycle()
         self.assertFalse(ret)
 
-    @testing.gen_test
-    def test_set_lifecycle_delete(self):
+    async def test_set_lifecycle_delete(self):
         self.actor.lifecycle = []
-        yield self.actor._set_lifecycle()
+        await self.actor._set_lifecycle()
         self.actor.s3_conn.delete_bucket_lifecycle.assert_has_calls(
             [mock.call(Bucket="test")]
         )
 
-    @testing.gen_test
-    def test_set_lifecycle(self):
+    async def test_set_lifecycle(self):
         self.actor.lifecycle = [{"test": "test"}]
-        yield self.actor._set_lifecycle()
+        await self.actor._set_lifecycle()
         self.actor.s3_conn.put_bucket_lifecycle_configuration.assert_has_calls(
             [
                 mock.call(
@@ -444,16 +400,14 @@ class TestBucket(testing.AsyncTestCase):
             ]
         )
 
-    @testing.gen_test
-    def test_set_lifecycle_client_error(self):
+    async def test_set_lifecycle_client_error(self):
         self.actor.s3_conn.put_bucket_lifecycle_configuration.side_effect = ClientError(
             {"Error": {"Code": ""}}, "Error"
         )
         with self.assertRaises(s3_actor.InvalidBucketConfig):
-            yield self.actor._set_lifecycle()
+            await self.actor._set_lifecycle()
 
-    @testing.gen_test
-    def test_get_public_access_block_configuration(self):
+    async def test_get_public_access_block_configuration(self):
         test_cfg = {
             "BlockPublicAcls": True,
             "BlockPublicPolicy": True,
@@ -465,134 +419,118 @@ class TestBucket(testing.AsyncTestCase):
         self.actor.s3_conn.get_public_access_block.return_value = {
             "PublicAccessBlockConfiguration": test_cfg
         }
-        ret = yield self.actor._get_public_access_block_configuration()
+        ret = await self.actor._get_public_access_block_configuration()
         self.assertEqual(ret, test_cfg)
 
-    @testing.gen_test
-    def test_get_public_access_block_configuration_no_bucket(self):
+    async def test_get_public_access_block_configuration_no_bucket(self):
         self.actor._bucket_exists = False
-        ret = yield self.actor._get_public_access_block_configuration()
+        ret = await self.actor._get_public_access_block_configuration()
         self.assertEqual(None, ret)
 
-    @testing.gen_test
-    def test_get_public_access_block_configuration_empty(self):
+    async def test_get_public_access_block_configuration_empty(self):
         self.actor._bucket_exists = True
         self.actor.s3_conn.get_public_access_block.side_effect = ClientError(
             {"Error": {}}, "NoSuchPublicAccessBlockConfiguration"
         )
-        ret = yield self.actor._get_public_access_block_configuration()
+        ret = await self.actor._get_public_access_block_configuration()
         self.assertEqual(ret, [])
 
-    @testing.gen_test
-    def test_get_public_access_block_configuration_clienterror(self):
+    async def test_get_public_access_block_configuration_clienterror(self):
         self.actor._bucket_exists = True
         self.actor.s3_conn.get_public_access_block.side_effect = ClientError(
             {"Error": {}}, "SomeOtherError"
         )
         with self.assertRaises(ClientError):
-            yield self.actor._get_public_access_block_configuration()
+            await self.actor._get_public_access_block_configuration()
 
-    @testing.gen_test
-    def test_compare_public_access_block_configuration(self):
+    async def test_compare_public_access_block_configuration(self):
         self.actor._bucket_exists = True
         self.actor.access_block = [{"test": "test"}]
         self.actor.s3_conn.get_public_access_block.return_value = {
             "PublicAccessBlockConfiguration": [{"test": "test"}]
         }
-        ret = yield self.actor._compare_public_access_block_configuration()
+        ret = await self.actor._compare_public_access_block_configuration()
         self.assertTrue(ret)
 
-    @testing.gen_test
-    def test_compare_public_access_block_configuration_none(self):
+    async def test_compare_public_access_block_configuration_none(self):
         self.actor.access_block = None
-        ret = yield self.actor._compare_public_access_block_configuration()
+        ret = await self.actor._compare_public_access_block_configuration()
         self.assertTrue(ret)
 
-    @testing.gen_test
-    def test_compare_public_access_block_configuration_diff(self):
+    async def test_compare_public_access_block_configuration_diff(self):
         self.actor.access_block = [{"test1": "test"}]
         self.actor.s3_conn.get_public_access_block.return_value = {
             "Rules": [{"test": "test"}]
         }
-        ret = yield self.actor._compare_public_access_block_configuration()
+        ret = await self.actor._compare_public_access_block_configuration()
         self.assertFalse(ret)
 
-    @testing.gen_test
-    def test_set_public_access_block_configuration_delete(self):
+    async def test_set_public_access_block_configuration_delete(self):
         self.actor.access_block = {}
-        yield self.actor._set_public_access_block_configuration()
+        await self.actor._set_public_access_block_configuration()
         self.actor.s3_conn.delete_public_access_block.assert_has_calls(
             [mock.call(Bucket="test")]
         )
 
-    @testing.gen_test
-    def test_set_public_access_block_configuration(self):
+    async def test_set_public_access_block_configuration(self):
         self.actor.access_block = {"test": "test"}
-        yield self.actor._set_public_access_block_configuration()
+        await self.actor._set_public_access_block_configuration()
         self.actor.s3_conn.put_public_access_block.assert_has_calls(
             [mock.call(Bucket="test", PublicAccessBlockConfiguration={"test": "test"})]
         )
 
-    @testing.gen_test
-    def test_set_public_access_block_configuration_client_error(self):
+    async def test_set_public_access_block_configuration_client_error(self):
         self.actor.s3_conn.put_public_access_block.side_effect = ClientError(
             {"Error": {}}, "Error"
         )
         with self.assertRaises(s3_actor.InvalidBucketConfig):
-            yield self.actor._set_public_access_block_configuration()
+            await self.actor._set_public_access_block_configuration()
 
-    @testing.gen_test
-    def test_get_tags(self):
+    async def test_get_tags(self):
         self.actor._bucket_exists = True
         self.actor.s3_conn.get_bucket_tagging.return_value = {
             "TagSet": [{"Key": "k1", "Value": "v1"}]
         }
-        ret = yield self.actor._get_tags()
+        ret = await self.actor._get_tags()
         self.assertEqual(ret, [{"key": "k1", "value": "v1"}])
 
-    @testing.gen_test
-    def test_get_tags_multiple_tags(self):
+    async def test_get_tags_multiple_tags(self):
         self.actor._bucket_exists = True
         self.actor.s3_conn.get_bucket_tagging.return_value = {
             "TagSet": [{"Key": "k1", "Value": "v1"}, {"Key": "k2", "Value": "v2"}]
         }
-        ret = yield self.actor._get_tags()
+        ret = await self.actor._get_tags()
         self.assertEqual(
             ret, [{"key": "k1", "value": "v1"}, {"key": "k2", "value": "v2"}]
         )
 
-    @testing.gen_test
-    def test_get_tags_no_bucket(self):
+    async def test_get_tags_no_bucket(self):
         self.actor._bucket_exists = False
-        ret = yield self.actor._get_tags()
+        ret = await self.actor._get_tags()
         self.assertEqual(None, ret)
 
-    @testing.gen_test
-    def test_get_tags_not_managed(self):
+    async def test_get_tags_not_managed(self):
         self.actor._options["tags"] = None
-        ret = yield self.actor._get_tags()
+        ret = await self.actor._get_tags()
         self.assertEqual(None, ret)
 
-    @testing.gen_test
-    def test_get_tags_empty(self):
+    async def test_get_tags_empty(self):
         self.actor._bucket_exists = True
         self.actor.s3_conn.get_bucket_tagging.side_effect = ClientError(
             {"Error": {"Code": ""}}, "NoSuchTagSet"
         )
-        ret = yield self.actor._get_tags()
+        ret = await self.actor._get_tags()
         self.assertEqual(ret, [])
 
-    @testing.gen_test
-    def test_get_tags_exc(self):
+    async def test_get_tags_exc(self):
         self.actor._bucket_exists = True
         self.actor.s3_conn.get_bucket_tagging.side_effect = ClientError(
             {"Error": {"Code": ""}}, "SomeOtherError"
         )
         with self.assertRaises(ClientError):
-            yield self.actor._get_tags()
+            await self.actor._get_tags()
 
-    @testing.gen_test
-    def test_compare_tags(self):
+    async def test_compare_tags(self):
         self.actor._bucket_exists = True
         self.actor._options["tags"] = [{"key": "test_key", "value": "test_value"}]
         self.actor.s3_conn.get_bucket_tagging.return_value = {
@@ -600,36 +538,32 @@ class TestBucket(testing.AsyncTestCase):
                 {"Key": "test_key", "Value": "test_value"},
             ]
         }
-        ret = yield self.actor._compare_tags()
+        ret = await self.actor._compare_tags()
         self.assertTrue(ret)
 
-    @testing.gen_test
-    def test_compare_tags_false(self):
+    async def test_compare_tags_false(self):
         self.actor._bucket_exists = True
         self.actor._options["tags"] = [{"key": "test_key", "value": "test_value"}]
         self.actor.s3_conn.get_bucket_tagging.return_value = {
             "TagSet": [{"Key": "k1", "Value": "v1"}, {"Key": "k2", "Value": "v2"}]
         }
-        ret = yield self.actor._compare_tags()
+        ret = await self.actor._compare_tags()
         self.assertFalse(ret)
 
-    @testing.gen_test
-    def test_compare_tags_not_managing(self):
+    async def test_compare_tags_not_managing(self):
         self.actor._bucket_exists = True
         self.actor._options["tags"] = None
-        ret = yield self.actor._compare_tags()
+        ret = await self.actor._compare_tags()
         self.assertTrue(ret)
 
-    @testing.gen_test
-    def test_set_tags_none(self):
+    async def test_set_tags_none(self):
         self.actor._options["tags"] = None
-        yield self.actor._set_tags()
+        await self.actor._set_tags()
         self.assertFalse(self.actor.s3_conn.put_bucket_tagging.called)
 
-    @testing.gen_test
-    def test_set_tags(self):
+    async def test_set_tags(self):
         self.actor._options["tags"] = [{"key": "tag1", "value": "v1"}]
-        yield self.actor._set_tags()
+        await self.actor._set_tags()
         self.actor.s3_conn.put_bucket_tagging.assert_has_calls(
             [
                 mock.call(
@@ -638,7 +572,6 @@ class TestBucket(testing.AsyncTestCase):
             ]
         )
 
-    @testing.gen_test
     def test_snake_to_camelcase_for_notification_configuration(self):
         notification_configuration_snake_case = {
             "queue_configurations": [
@@ -665,16 +598,14 @@ class TestBucket(testing.AsyncTestCase):
             },
         )
 
-    @testing.gen_test
-    def test_set_notification_configurations_none(self):
+    async def test_set_notification_configurations_none(self):
         self.actor.notification_configuration = None
-        yield self.actor._set_notification_configuration()
+        await self.actor._set_notification_configuration()
         self.assertFalse(
             self.actor.s3_conn.put_bucket_notification_configuration.called
         )
 
-    @testing.gen_test
-    def test_set_notification_configurations_with_valid_configs(self):
+    async def test_set_notification_configurations_with_valid_configs(self):
         self.actor.notification_configuration = {
             "QueueConfigurations": [
                 {
@@ -683,7 +614,7 @@ class TestBucket(testing.AsyncTestCase):
                 }
             ]
         }
-        yield self.actor._set_notification_configuration()
+        await self.actor._set_notification_configuration()
         self.actor.s3_conn.put_bucket_notification_configuration.assert_has_calls(
             [
                 mock.call(
@@ -700,8 +631,7 @@ class TestBucket(testing.AsyncTestCase):
             ]
         )
 
-    @testing.gen_test
-    def test_set_notification_configurations_with_multiple_configs(self):
+    async def test_set_notification_configurations_with_multiple_configs(self):
         self.actor.notification_configuration = {
             "QueueConfigurations": [
                 {
@@ -714,7 +644,7 @@ class TestBucket(testing.AsyncTestCase):
                 },
             ]
         }
-        yield self.actor._set_notification_configuration()
+        await self.actor._set_notification_configuration()
         self.actor.s3_conn.put_bucket_notification_configuration.assert_has_calls(
             [
                 mock.call(
@@ -735,27 +665,24 @@ class TestBucket(testing.AsyncTestCase):
             ]
         )
 
-    @testing.gen_test
-    def test_set_notification_configurations_no_configs(self):
+    async def test_set_notification_configurations_no_configs(self):
         self.actor.notification_configuration = {"QueueConfigurations": []}
-        yield self.actor._set_notification_configuration()
+        await self.actor._set_notification_configuration()
         self.actor.s3_conn.put_bucket_notification_configuration.assert_has_calls([])
 
-    @testing.gen_test
-    def test_set_notification_configurations_empty_queue_configs(self):
+    async def test_set_notification_configurations_empty_queue_configs(self):
         self.actor.notification_configuration = {}
-        yield self.actor._set_notification_configuration()
+        await self.actor._set_notification_configuration()
         self.actor.s3_conn.put_bucket_notification_configuration.assert_has_calls([])
 
-    @testing.gen_test
-    def test_get_notification_configuration_with_existing_queueconfigs(self):
+    async def test_get_notification_configuration_with_existing_queueconfigs(self):
         self.actor._bucket_exists = True
         self.actor.s3_conn.get_bucket_notification_configuration.return_value = {
             "QueueConfigurations": [
                 {"QueueArn": "arn:aws:sqs", "Events": ["s3:ObjectCreated:*"]}
             ]
         }
-        ret = yield self.actor._get_notification_configuration()
+        ret = await self.actor._get_notification_configuration()
         self.assertEqual(type(ret), dict)
         self.assertEqual(
             ret,
@@ -766,21 +693,18 @@ class TestBucket(testing.AsyncTestCase):
             },
         )
 
-    @testing.gen_test
-    def test_get_notification_configuration_no_bucket(self):
+    async def test_get_notification_configuration_no_bucket(self):
         self.actor._bucket_exists = False
-        ret = yield self.actor._get_notification_configuration()
+        ret = await self.actor._get_notification_configuration()
         self.assertEqual(ret, None)
 
-    @testing.gen_test
-    def test_get_notification_configuration_with_no_config(self):
+    async def test_get_notification_configuration_with_no_config(self):
         self.actor._bucket_exists = True
         self.actor.notification_configuration = None
-        ret = yield self.actor._get_notification_configuration()
+        ret = await self.actor._get_notification_configuration()
         self.assertEqual(ret, None)
 
-    @testing.gen_test
-    def test_compare_notification_configuration_with_new_config(self):
+    async def test_compare_notification_configuration_with_new_config(self):
         self.actor.notification_configuration = {
             "QueueConfigurations": [
                 {
@@ -790,11 +714,10 @@ class TestBucket(testing.AsyncTestCase):
             ]
         }
         self.actor.s3_conn.get_bucket_notification_configuration.return_value = {}
-        ret = yield self.actor._compare_notification_configuration()
+        ret = await self.actor._compare_notification_configuration()
         self.assertFalse(ret)
 
-    @testing.gen_test
-    def test_compare_notification_configuration_with_no_updated_config(self):
+    async def test_compare_notification_configuration_with_no_updated_config(self):
         self.actor._bucket_exists = True
         self.actor.notification_configuration = {
             "QueueConfigurations": [
@@ -812,12 +735,11 @@ class TestBucket(testing.AsyncTestCase):
                 }
             ]
         }
-        ret = yield self.actor._compare_notification_configuration()
+        ret = await self.actor._compare_notification_configuration()
         self.assertTrue(ret)
 
-    @testing.gen_test
-    def test_compare_notification_configuration_with_no_config(self):
+    async def test_compare_notification_configuration_with_no_config(self):
         self.actor.notification_configuration = None
         self.actor.s3_conn.get_bucket_notification_configuration.return_value = {}
-        ret = yield self.actor._compare_notification_configuration()
+        ret = await self.actor._compare_notification_configuration()
         self.assertTrue(ret)


### PR DESCRIPTION
## Summary

Migrate 5 AWS test files (~200 test methods) from `tornado.testing.AsyncTestCase` to `unittest.IsolatedAsyncioTestCase`.

### Files changed

- `actors/aws/test/test_base.py` — 1 test class
- `actors/aws/test/test_iam.py` — 5 test classes (~60 methods)
- `actors/aws/test/test_s3.py` — 1 test class (~80 methods)
- `actors/aws/test/test_cloudformation.py` — 4 test classes (~50 methods)
- `actors/aws/test/test_api_call_queue.py` — 1 test class + rewrote `@concurrent.run_on_executor` test helper

### Special handling (Lesson 2 from retro)

`test_api_call_queue.py` had a `@concurrent.run_on_executor` decorator on `_mock_api_function_async()`. This was rewritten to `async def` + `loop.run_in_executor()`, matching the production code pattern from PR 3/4. Also replaced `concurrent.futures.ThreadPoolExecutor` with the directly imported `ThreadPoolExecutor`.

### Why this is safe

- Same mechanical transformation as PR 7, applied to more files
- `tornado_value()` helper from `actors/test/helper.py` works unchanged with `await` (pure Python, no tornado imports)
- `python -W error::RuntimeWarning` verification catches any missed `yield` → `await` conversions
- Net deletion: -217 lines (decorator removal + import cleanup)

## Test plan

- [x] `make test` passes (360 tests, 0 failures)
- [x] `python -W error::RuntimeWarning -m pytest` passes
- [x] `ruff check` clean

Part 8 of 10 in the tornado removal migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)