### PR TITLE
chore(deps): remove tornado dependency and clean up references

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ Kingpin: Deployment Automation Engine
 Kingpin provides 3 main functions:
 
 -  **API Abstraction** - Job instructions are provided to Kingpin via a JSON based DSL (read below). The schema is strict and consistent from one action to another.
--  **Automation Engine** - Kingpin leverages python's `tornado <http://tornado.readthedocs.org>`_ engine.
+-  **Automation Engine** - Kingpin leverages python's `asyncio <https://docs.python.org/3/library/asyncio.html>`_ library.
 -  **Parallel Execution** - Aside from non-blocking network IO, Kingpin can execute any action in parallel with another. (Read group.Async below)
 
 Documentation

--- a/kingpin/actors/group.py
+++ b/kingpin/actors/group.py
@@ -413,10 +413,6 @@ class Async(BaseGroupActor):
         failed (False).
         """
 
-        # This is an interesting tornado-ism. Here we generate and fire off
-        # each of the acts asynchronously into the IOLoop, and we record
-        # references to those tasks. However, we don't yield (wait) on them to
-        # finish.
         tasks = []
 
         if self.option("concurrency"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,9 +25,6 @@ classifiers = [
   "Topic :: Software Development",
 ]
 dependencies = [
-    # Async I/O engine, coroutines, HTTP client
-    # https://tornado.readthedocs.org/en/latest/gen.html#tornado.gen.with_timeout
-    "tornado==6.5.4",
     # JSON schema validation for the deployment DSL
     "jsonschema>=3.0.0,<5.0.0",
     "jsonpickle==4.1.1",

--- a/uv.lock
+++ b/uv.lock
@@ -445,7 +445,6 @@ dependencies = [
     { name = "jsonpickle" },
     { name = "jsonschema" },
     { name = "rainbow-logging-handler" },
-    { name = "tornado" },
 ]
 
 [package.optional-dependencies]
@@ -482,7 +481,6 @@ requires-dist = [
     { name = "rainbow-logging-handler", specifier = "==2.2.2" },
     { name = "sphinx", marker = "extra == 'docs'" },
     { name = "sphinx-rtd-theme", marker = "extra == 'docs'" },
-    { name = "tornado", specifier = "==6.5.4" },
 ]
 provides-extras = ["docs"]
 
@@ -1201,25 +1199,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/de/69/9aa0c6a505c2f80e519b43764f8b4ba93b5a0bbd2d9a9de6e2b24271b9a5/tomli-2.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2add28aacc7425117ff6364fe9e06a183bb0251b03f986df0e78e974047571fd", size = 120504, upload-time = "2026-01-11T11:22:35.764Z" },
     { url = "https://files.pythonhosted.org/packages/b3/9f/f1668c281c58cfae01482f7114a4b88d345e4c140386241a1a24dcc9e7bc/tomli-2.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2b1e3b80e1d5e52e40e9b924ec43d81570f0e7d09d11081b797bc4692765a3d4", size = 99561, upload-time = "2026-01-11T11:22:36.624Z" },
     { url = "https://files.pythonhosted.org/packages/23/d1/136eb2cb77520a31e1f64cbae9d33ec6df0d78bdf4160398e86eec8a8754/tomli-2.4.0-py3-none-any.whl", hash = "sha256:1f776e7d669ebceb01dee46484485f43a4048746235e683bcdffacdf1fb4785a", size = 14477, upload-time = "2026-01-11T11:22:37.446Z" },
-]
-
-[[package]]
-name = "tornado"
-version = "6.5.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/37/1d/0a336abf618272d53f62ebe274f712e213f5a03c0b2339575430b8362ef2/tornado-6.5.4.tar.gz", hash = "sha256:a22fa9047405d03260b483980635f0b041989d8bcc9a313f8fe18b411d84b1d7", size = 513632, upload-time = "2025-12-15T19:21:03.836Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ab/a9/e94a9d5224107d7ce3cc1fab8d5dc97f5ea351ccc6322ee4fb661da94e35/tornado-6.5.4-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:d6241c1a16b1c9e4cc28148b1cda97dd1c6cb4fb7068ac1bedc610768dff0ba9", size = 443909, upload-time = "2025-12-15T19:20:48.382Z" },
-    { url = "https://files.pythonhosted.org/packages/db/7e/f7b8d8c4453f305a51f80dbb49014257bb7d28ccb4bbb8dd328ea995ecad/tornado-6.5.4-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2d50f63dda1d2cac3ae1fa23d254e16b5e38153758470e9956cbc3d813d40843", size = 442163, upload-time = "2025-12-15T19:20:49.791Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/b5/206f82d51e1bfa940ba366a8d2f83904b15942c45a78dd978b599870ab44/tornado-6.5.4-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d1cf66105dc6acb5af613c054955b8137e34a03698aa53272dbda4afe252be17", size = 445746, upload-time = "2025-12-15T19:20:51.491Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/9d/1a3338e0bd30ada6ad4356c13a0a6c35fbc859063fa7eddb309183364ac1/tornado-6.5.4-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:50ff0a58b0dc97939d29da29cd624da010e7f804746621c78d14b80238669335", size = 445083, upload-time = "2025-12-15T19:20:52.778Z" },
-    { url = "https://files.pythonhosted.org/packages/50/d4/e51d52047e7eb9a582da59f32125d17c0482d065afd5d3bc435ff2120dc5/tornado-6.5.4-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e5fb5e04efa54cf0baabdd10061eb4148e0be137166146fff835745f59ab9f7f", size = 445315, upload-time = "2025-12-15T19:20:53.996Z" },
-    { url = "https://files.pythonhosted.org/packages/27/07/2273972f69ca63dbc139694a3fc4684edec3ea3f9efabf77ed32483b875c/tornado-6.5.4-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9c86b1643b33a4cd415f8d0fe53045f913bf07b4a3ef646b735a6a86047dda84", size = 446003, upload-time = "2025-12-15T19:20:56.101Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/83/41c52e47502bf7260044413b6770d1a48dda2f0246f95ee1384a3cd9c44a/tornado-6.5.4-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:6eb82872335a53dd063a4f10917b3efd28270b56a33db69009606a0312660a6f", size = 445412, upload-time = "2025-12-15T19:20:57.398Z" },
-    { url = "https://files.pythonhosted.org/packages/10/c7/bc96917f06cbee182d44735d4ecde9c432e25b84f4c2086143013e7b9e52/tornado-6.5.4-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6076d5dda368c9328ff41ab5d9dd3608e695e8225d1cd0fd1e006f05da3635a8", size = 445392, upload-time = "2025-12-15T19:20:58.692Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/1a/d7592328d037d36f2d2462f4bc1fbb383eec9278bc786c1b111cbbd44cfa/tornado-6.5.4-cp39-abi3-win32.whl", hash = "sha256:1768110f2411d5cd281bac0a090f707223ce77fd110424361092859e089b38d1", size = 446481, upload-time = "2025-12-15T19:21:00.008Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/6d/c69be695a0a64fd37a97db12355a035a6d90f79067a3cf936ec2b1dc38cd/tornado-6.5.4-cp39-abi3-win_amd64.whl", hash = "sha256:fa07d31e0cd85c60713f2b995da613588aa03e1303d75705dca6af8babc18ddc", size = 446886, upload-time = "2025-12-15T19:21:01.287Z" },
-    { url = "https://files.pythonhosted.org/packages/50/49/8dc3fd90902f70084bd2cd059d576ddb4f8bb44c2c7c0e33a11422acb17e/tornado-6.5.4-cp39-abi3-win_arm64.whl", hash = "sha256:053e6e16701eb6cbe641f308f4c1a9541f91b6261991160391bfc342e8a551a1", size = 445910, upload-time = "2025-12-15T19:21:02.571Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Final PR in the tornado removal migration. Remove the `tornado==6.5.4` dependency and clean up remaining references.

### What changed

- **`pyproject.toml`**: Removed `tornado==6.5.4` and its comments from `[project] dependencies`
- **`uv.lock`**: Regenerated without tornado (confirmed: `Removed tornado v6.5.4`)
- **`README.rst`**: Changed "Kingpin leverages python's tornado engine" to "Kingpin leverages python's asyncio library"
- **`actors/group.py`**: Removed stale comment referencing "tornado-ism"

### What was NOT changed (intentional)

- `mock_tornado()` and `tornado_value()` in `actors/test/helper.py` — pure-Python helpers with no tornado imports. Renaming would touch ~100 call sites for zero behavioral benefit (documented in retro.md).

### Migration summary (PRs 1-10)

| Metric | Value |
|--------|-------|
| PRs merged | 10 |
| Files changed | ~25 |
| Runtime deps removed | 1 (`tornado==6.5.4`) |
| Runtime deps added | 0 |
| Tests before | 361 |
| Tests after | 360 (1 deleted: tested tornado-specific return type) |

### Why this is safe

- All tornado imports were removed in PRs 1-9 — this PR only removes the dependency declaration
- If any code still imported tornado, `make test` would fail with `ModuleNotFoundError`
- `kingpin --help` verified working without tornado installed

## Test plan

- [x] `make test` passes (360 tests, 0 failures)
- [x] `kingpin --help` works without tornado
- [x] `grep -rn "tornado" kingpin/ --include="*.py"` returns zero results (excluding helper function names)
- [x] `ruff check` clean

Part 10 of 10 — tornado removal complete! 🎉

🤖 Generated with [Claude Code](https://claude.com/claude-code)