### PR TITLE
fix(actors): replace deprecated Draft4Validator with Draft202012Validator

### DIFF
--- a/kingpin/constants.py
+++ b/kingpin/constants.py
@@ -41,7 +41,7 @@ class SchemaCompareBase:
     @classmethod
     def validate(self, option):
         try:
-            jsonschema.Draft4Validator(self.SCHEMA).validate(option)
+            jsonschema.Draft202012Validator(self.SCHEMA).validate(option)
         except jsonschema.exceptions.ValidationError as e:
             raise exceptions.InvalidOptions(
                 f"Supplied parameter does not match schema: {e}"

--- a/kingpin/test/test_constants.py
+++ b/kingpin/test/test_constants.py
@@ -1,0 +1,39 @@
+import unittest
+
+from kingpin.actors import exceptions
+from kingpin.constants import SchemaCompareBase
+
+
+class _TestSchema(SchemaCompareBase):
+    SCHEMA = {
+        "type": ["object", "null"],
+        "required": ["name"],
+        "additionalProperties": False,
+        "properties": {
+            "name": {"type": "string"},
+            "count": {"type": "integer"},
+        },
+    }
+
+
+class TestSchemaCompareBase(unittest.TestCase):
+    def test_valid_option_passes(self):
+        _TestSchema.validate({"name": "foo", "count": 1})
+
+    def test_valid_option_minimal(self):
+        _TestSchema.validate({"name": "bar"})
+
+    def test_null_passes_when_schema_allows(self):
+        _TestSchema.validate(None)
+
+    def test_invalid_option_raises(self):
+        with self.assertRaises(exceptions.InvalidOptions):
+            _TestSchema.validate({"wrong_key": "value"})
+
+    def test_missing_required_raises(self):
+        with self.assertRaises(exceptions.InvalidOptions):
+            _TestSchema.validate({"count": 1})
+
+    def test_wrong_type_raises(self):
+        with self.assertRaises(exceptions.InvalidOptions):
+            _TestSchema.validate({"name": 123})


### PR DESCRIPTION
## Summary
- Replace `jsonschema.Draft4Validator` with `Draft202012Validator` in `SchemaCompareBase.validate()` (`constants.py:44`)
- Add direct unit tests for `SchemaCompareBase.validate()` (previously had zero direct coverage)
- All 7 schema types verified compatible with Draft 2020-12: `ParametersConfig`, `CapabilitiesConfig`, `PublicAccessBlockConfig`, `LoggingConfig`, `LifecycleConfig`, `NotificationConfiguration`, `TaggingConfig`

Addresses plan item #4 — `Draft4Validator` is expected to be removed in jsonschema 5.0.

## Test plan
- [x] `make test` — 366 passed (360 existing + 6 new)
- [x] `make ruff` — all checks passed
- [x] Example dry runs pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)