### PR TITLE
docs(docs): remove stale Tornado references from docs, tests, and examples

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@ Kingpin: Deployment Automation Engine
 Kingpin provides 3 main functions:
 
 -  **API Abstraction** - Job instructions are provided to Kingpin via a JSON based DSL (read below). The schema is strict and consistent from one action to another.
--  **Automation Engine** - Kingpin leverages python's `tornado <http://tornado.readthedocs.org/>`__ engine.
+-  **Automation Engine** - Kingpin leverages python's `asyncio <https://docs.python.org/3/library/asyncio.html>`__ library.
 -  **Parallel Execution** - Aside from non-blocking network IO, Kingpin can execute any action in parallel with another. (Read group.Async below)
 
 .. toctree::

--- a/examples/test/base/nested_sleep_timeouts.json
+++ b/examples/test/base/nested_sleep_timeouts.json
@@ -1,9 +1,8 @@
 /* This script is used to test a race condition where the outer-actor
 raises an ActorTimedOut exception moments before the inner-actor raises
-the same exception. Tornado, by default, raises an 'Exception in Future
-<...> after timeout' exception to let the user know that an exception
-was raised after the initial timeout happened. Our code works around this
-by explicitly defining ActorTimedOut as a 'quiet' exception in this case */
+the same exception. asyncio.shield() is used in BaseActor.timeout() to
+prevent cancellation of the inner task, allowing it to continue running
+even after the timeout fires. */
 { "desc": "Outer group",
   "actor": "group.Sync",
   "timeout": 1,

--- a/kingpin/test/test_utils.py
+++ b/kingpin/test/test_utils.py
@@ -297,8 +297,8 @@ class TestCoroutineHelpers(unittest.IsolatedAsyncioTestCase):
         logger = mock.Mock()  # used for tracking
 
         # Repeat this message 10 times per second
-        # seconds=0 instructs Tornado to invoke this log on every IO loop
-        # Below we yield gen.moment to allow IO loop iterations.
+        # seconds=0 schedules the log on every event loop iteration.
+        # Below we await asyncio.sleep(0) to allow event loop iterations.
         # We do N+1 loops and check N count.
         logid = utils.create_repeating_log(logger.info, "test", seconds=0)
         await asyncio.sleep(0)


### PR DESCRIPTION
## Summary
- Update `docs/index.rst`: tornado link → asyncio link
- Update `docs/development.rst`: modernize all code examples from `@gen.coroutine`/`yield`/`gen.Return` to `async`/`await`, fix `super()` calls, replace `%`-formatting with f-strings, fix `from=` keyword arg bug, fix `UnrecoverableActorException` → `UnrecoverableActorFailure`, fix Python 2 docs link
- Update `examples/test/base/nested_sleep_timeouts.json`: reference `asyncio.shield()` instead of Tornado
- Update `kingpin/test/test_utils.py`: reference asyncio event loop instead of Tornado in comment

All doc code examples verified: valid Python syntax and tested with stubs.

## Test plan
- [x] `make test` — 366 passed
- [x] `make ruff` — all checks passed
- [x] Doc code examples verified as valid Python (AST-parsed + stub-tested)
- [x] `grep -r ornado` on `*.{py,rst,yaml,json,html,txt,cfg,toml}` returns zero results
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)