### PR TITLE
chore(ci): route Python package installs through AWS CodeArtifact

### DIFF
--- a/.github/workflows/main-release.yaml
+++ b/.github/workflows/main-release.yaml
@@ -6,8 +6,22 @@ on:
 jobs:
   main-release:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
     - uses: actions/checkout@v7
+    - name: AWS CodeArtifact login
+      id: aws-login
+      uses: Nextdoor/actions/aws-login@main
+      with:
+        ecr: false
+        codeartifactPip: true
+    - name: Configure uv CodeArtifact auth
+      shell: bash
+      run: |
+        echo "UV_INDEX_CODEARTIFACT_USERNAME=aws" >> "$GITHUB_ENV"
+        echo "UV_INDEX_CODEARTIFACT_PASSWORD=${{ steps.aws-login.outputs.codeartifactToken }}" >> "$GITHUB_ENV"
     - name: Install uv
       uses: astral-sh/setup-uv@v9.0.0
       with:

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -6,8 +6,22 @@ on:
 jobs:
   publish-release:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
     - uses: actions/checkout@v7
+    - name: AWS CodeArtifact login
+      id: aws-login
+      uses: Nextdoor/actions/aws-login@main
+      with:
+        ecr: false
+        codeartifactPip: true
+    - name: Configure uv CodeArtifact auth
+      shell: bash
+      run: |
+        echo "UV_INDEX_CODEARTIFACT_USERNAME=aws" >> "$GITHUB_ENV"
+        echo "UV_INDEX_CODEARTIFACT_PASSWORD=${{ steps.aws-login.outputs.codeartifactToken }}" >> "$GITHUB_ENV"
     - name: Install uv
       uses: astral-sh/setup-uv@v9.0.0
       with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,8 +4,22 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
     - uses: actions/checkout@v7
+    - name: AWS CodeArtifact login
+      id: aws-login
+      uses: Nextdoor/actions/aws-login@main
+      with:
+        ecr: false
+        codeartifactPip: true
+    - name: Configure uv CodeArtifact auth
+      shell: bash
+      run: |
+        echo "UV_INDEX_CODEARTIFACT_USERNAME=aws" >> "$GITHUB_ENV"
+        echo "UV_INDEX_CODEARTIFACT_PASSWORD=${{ steps.aws-login.outputs.codeartifactToken }}" >> "$GITHUB_ENV"
     - name: Install uv
       uses: astral-sh/setup-uv@v9.0.0
     - run: uv sync --frozen

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -25,6 +25,15 @@ Create your VirtualEnvironment
     $ make venv
     $ source .venv/bin/activate
 
+Package Registry (Nextdoor CodeArtifact)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Package installs route through Nextdoor's AWS CodeArtifact repository (see
+``[[tool.uv.index]]`` in ``pyproject.toml``), which requires authentication
+even for reads. ``uv`` picks up credentials from ``~/.netrc``; Nextdoor
+engineers can populate it with the ``aws_codeartifact_token`` helper from
+dotfiles.
+
 Testing
 ~~~~~~~
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,3 +157,11 @@ ignore_missing_imports = true
 
 [tool.uv]
 python-preference = "only-managed"
+
+# All package installs route through Nextdoor's AWS CodeArtifact (go/migrate-to-ca).
+# Auth is required even for reads: ~/.netrc locally (populated by dotfiles'
+# aws_codeartifact_token) or UV_INDEX_CODEARTIFACT_USERNAME/PASSWORD in CI.
+[[tool.uv.index]]
+name = "codeartifact"
+url = "https://nextdoor-364942603424.d.codeartifact.us-west-2.amazonaws.com/pypi/kingpin.git/simple/"
+default = true


### PR DESCRIPTION
## Summary

Migrates this repo's Python installs to AWS CodeArtifact per go/migrate-to-ca:

- **`pyproject.toml`** — adds a `[[tool.uv.index]]` entry (`default = true`) pointing uv at `https://nextdoor-364942603424.d.codeartifact.us-west-2.amazonaws.com/pypi/kingpin.git/simple/`. Auth comes from `~/.netrc` locally and `UV_INDEX_CODEARTIFACT_*` env vars in CI — no tokens in committed config.
- **`test.yaml` / `main-release.yaml` / `publish-release.yaml`** — adds OIDC permissions, a `Nextdoor/actions/aws-login` step (`codeartifactPip: true` for any stray pip usage), and exports the CodeArtifact token as `UV_INDEX_CODEARTIFACT_USERNAME/PASSWORD` for all uv steps. `codeartifactPip` alone is insufficient here because **uv does not read pip.conf**.
- **`docs/development.rst`** — contributor note on registry auth.

## ⚠️ Merge blockers (in order)

- [ ] **Create the CodeArtifact repository** — `kingpin.git` does not exist in the `nextdoor` domain (verified via `describe-repository` / `list-repositories-in-domain`). Someone with access (or via `nextdoor/codeartifact-subsys` if repos are provisioned there) must run:
  ```sh
  aws --region us-west-2 codeartifact create-repository \
    --domain nextdoor --domain-owner 364942603424 \
    --repository kingpin.git \
    --upstreams repositoryName=upstream-pypi
  ```
- [ ] **Regenerate `uv.lock` against CodeArtifact** (`uv lock` with fresh CA auth) and push to this branch. This is not optional: verified empirically that `uv sync --frozen` downloads from the URLs baked into `uv.lock` (currently `files.pythonhosted.org`) and ignores the configured index for locked packages — without a re-lock, CI would silently keep hitting PyPI and break the day it's blocked. uv has no index-mirroring mechanism (astral-sh/uv#6349).
- [ ] **Verify with PyPI black-holed**: `uv sync --frozen --no-cache` with `pypi.org`/`files.pythonhosted.org` unreachable must succeed using only the CA URL.

## Things to be aware of

- **This repo is public OSS.** After the re-lock, `uv.lock` will contain CodeArtifact URLs that require Nextdoor AWS credentials even for reads — external contributors will not be able to `uv sync`, and fork PRs cannot assume the OIDC role, so `test.yaml` will fail for them. If external contribution matters, that's a decision to make before merging.
- **Renovate** updates `pyproject.toml`/`uv.lock` natively; after migration it needs CodeArtifact credentials (`hostRules`) or its lock-file updates will fail.
- **ReadTheDocs is unaffected** — it installs via pip (`.readthedocs.yaml`), which ignores `[tool.uv]` config and keeps using public PyPI.
- **PyPI publishing is unaffected** — `pypa/gh-action-pypi-publish` still publishes to public PyPI.
- CI on this branch is expected red until the first two checkboxes are done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)